### PR TITLE
Query

### DIFF
--- a/include/ozo/binary_query.h
+++ b/include/ozo/binary_query.h
@@ -1,0 +1,247 @@
+#include <ozo/binary_serialization.h>
+#include <ozo/concept.h>
+#include <ozo/query.h>
+#include <ozo/type_traits.h>
+
+#include <boost/hana/for_each.hpp>
+#include <boost/hana/tuple.hpp>
+
+#include <libpq-fe.h>
+
+#include <array>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+namespace ozo {
+
+template <class T>
+constexpr auto Nullable = is_nullable<std::decay_t<T>>::value;
+
+template <class BufferAllocatorT, class OidMapImplT, class ... ParamsT>
+class binary_query {
+public:
+    static constexpr std::size_t params_count = sizeof ... (ParamsT);
+
+    using buffer_allocator_type = BufferAllocatorT;
+    using oid_map_type = oid_map_t<OidMapImplT>;
+
+    binary_query(std::string_view text)
+        : impl(make_impl(buffer_allocator_type(), text, oid_map_type())) {}
+
+    binary_query(std::string_view text, const oid_map_type& oid_map, const ParamsT& ... params)
+        : impl(make_impl(buffer_allocator_type(), text, oid_map, params ...)) {}
+
+    binary_query(const buffer_allocator_type& buffer_allocator, std::string_view text, const oid_map_type& oid_map, const ParamsT& ... params)
+        : impl(make_impl(buffer_allocator, text, oid_map, params ...)) {}
+
+    constexpr const char* text() const noexcept {
+        return std::data(impl->text);
+    }
+
+    constexpr const ::Oid* types() const noexcept {
+        return std::data(impl->types);
+    }
+
+    constexpr const int* formats() const noexcept {
+        return std::data(impl->formats);
+    }
+
+    constexpr const int* lengths() const noexcept {
+        return std::data(impl->lengths);
+    }
+
+    constexpr const char* const* values() const noexcept {
+        return std::data(impl->values);
+    }
+
+private:
+    static constexpr auto binary_format = 1;
+
+    using buffer_type = std::vector<char, buffer_allocator_type>;
+
+    struct impl_type {
+        std::string_view text;
+        buffer_type buffer;
+        std::array<::Oid, params_count> types;
+        std::array<int, params_count> formats;
+        std::array<int, params_count> lengths;
+        std::array<const char*, params_count> values;
+
+        impl_type(std::string_view text, const buffer_allocator_type& buffer_allocator)
+            : text(text), buffer(buffer_allocator) {}
+
+        impl_type(const impl_type&) = delete;
+        impl_type(impl_type&&) = delete;
+    };
+
+    template <std::size_t field>
+    class field_proxy {
+    public:
+        field_proxy(impl_type& result) : result(result) {}
+
+        constexpr void set_type(::Oid value) noexcept {
+            result.types[field] = value;
+        }
+
+        constexpr void set_format(int value) noexcept {
+            result.formats[field] = value;
+        }
+
+        constexpr void set_length(int value) noexcept {
+            result.lengths[field] = value;
+        }
+
+        constexpr void set_value(const char* value) noexcept {
+            result.values[field] = value;
+        }
+
+        constexpr auto& buffer() noexcept {
+            return result.buffer;
+        }
+
+    private:
+        impl_type& result;
+    };
+
+    std::shared_ptr<impl_type> impl;
+
+    static constexpr auto make_impl(const buffer_allocator_type& buffer_allocator, std::string_view text, const oid_map_type& oid_map, const ParamsT& ... params) {
+        const auto tuple = hana::tuple<const ParamsT& ...>(params ...);
+        auto result = std::make_shared<impl_type>(text, buffer_allocator);
+        hana::for_each(
+            hana::to<hana::tuple_tag>(hana::make_range(hana::size_c<0>, hana::size_c<params_count>)),
+            [&] (auto field) {
+                field_proxy<field> proxy(*result);
+                write_meta(oid_map, tuple[field], proxy);
+            }
+        );
+        std::size_t offset = 0;
+        hana::for_each(
+            hana::to<hana::tuple_tag>(hana::make_range(hana::size_c<0>, hana::size_c<params_count>)),
+            [&] (auto field) {
+                if (const auto size = result->lengths[field]) {
+                    field_proxy<field>(*result).set_value(std::data(result->buffer) + offset);
+                    offset += size;
+                } else {
+                    field_proxy<field>(*result).set_value(nullptr);
+                }
+            }
+        );
+        return result;
+    }
+
+    template <class T, std::size_t field>
+    static constexpr Require<Nullable<T>> write_meta(const oid_map_type& oid_map, const T& value, field_proxy<field>& result) {
+        if (is_null(value)) {
+            write_null_meta(type_oid<std::decay_t<decltype(*value)>>(oid_map), result);
+        } else {
+            write_meta(oid_map, *value, result);
+        }
+    }
+
+    template <class T, std::size_t field>
+    static constexpr Require<!Nullable<T>> write_meta(const oid_map_type& oid_map, const T& value, field_proxy<field>& result) {
+        using ozo::send;
+        result.set_type(type_oid(oid_map, value));
+        result.set_format(binary_format);
+        const auto current_size = std::size(result.buffer());
+        send(value, oid_map, std::back_inserter(result.buffer()));
+        result.set_length(int(std::size(result.buffer()) - current_size));
+    }
+
+    template <class T, std::size_t field>
+    static constexpr Require<!Nullable<T>> write_meta(const oid_map_type& oid_map, const std::reference_wrapper<T>& value, field_proxy<field>& result) {
+        write_meta(oid_map, value.get(), result);
+    }
+
+    template <class T, std::size_t field>
+    static constexpr void write_meta(const oid_map_type& oid_map, const std::weak_ptr<T>& value, field_proxy<field>& result) {
+        write_meta(oid_map, value.lock(), result);
+    }
+
+    template <std::size_t field>
+    static constexpr void write_meta(const oid_map_type&, std::nullptr_t, field_proxy<field>& result) noexcept {
+        write_null_meta(null_oid_t::value, result);
+    }
+
+    template <std::size_t field>
+    static constexpr void write_meta(const oid_map_type&, std::nullopt_t, field_proxy<field>& result) noexcept {
+        write_null_meta(null_oid_t::value, result);
+    }
+
+    template <std::size_t field>
+    static constexpr void write_null_meta(::Oid oid, field_proxy<field>& result) noexcept {
+        result.set_type(oid);
+        result.set_format(binary_format);
+        result.set_length(0);
+    }
+};
+
+template <class ... ParamsT>
+auto make_binary_query(std::string_view text, const ParamsT& ... params) {
+    using binary_query_type = binary_query<std::allocator<char>, empty_oid_map::impl_type, const ParamsT& ...>;
+    return binary_query_type(text, register_types<>(), params ...);
+}
+
+template <class OidMapImplT, class ... ParamsT>
+auto make_binary_query(std::string_view text, const oid_map_t<OidMapImplT>& oid_map, const ParamsT& ... params) {
+    using binary_query_type = binary_query<std::allocator<char>, OidMapImplT, const ParamsT& ...>;
+    return binary_query_type(text, oid_map, params ...);
+}
+
+template <class BufferAllocatorT, class OidMapImplT, class ... ParamsT>
+auto make_binary_query(std::string_view text, const oid_map_t<OidMapImplT>& oid_map, const ParamsT& ... params) {
+    using binary_query_type = binary_query<BufferAllocatorT, OidMapImplT, const ParamsT& ...>;
+    return binary_query_type(text, oid_map, params ...);
+}
+
+template <class BufferAllocatorT, class OidMapImplT, class ... ParamsT>
+auto make_binary_query(const BufferAllocatorT& buffer_allocator, std::string_view text, const oid_map_t<OidMapImplT>& oid_map, const ParamsT& ... params) {
+    using binary_query_type = binary_query<BufferAllocatorT, OidMapImplT, const ParamsT& ...>;
+    return binary_query_type(buffer_allocator, text, oid_map, params ...);
+}
+
+template <class T, class = Require<Query<T>>>
+auto make_binary_query(const T& query) {
+    return hana::unpack(
+        get_params(query),
+        [&] (const auto& ... params) {
+            return make_binary_query(get_text(query), empty_oid_map(), params ...);
+        }
+    );
+}
+
+template <class OidMapImplT, class T, class = Require<Query<T>>>
+auto make_binary_query(const oid_map_t<OidMapImplT>& oid_map, const T& query) {
+    return hana::unpack(
+        get_params(query),
+        [&] (const auto& ... params) {
+            return make_binary_query(get_text(query), oid_map, params ...);
+        }
+    );
+}
+
+template <class BufferAllocatorT, class OidMapImplT, class T, class = Require<Query<T>>>
+auto make_binary_query(const oid_map_t<OidMapImplT>& oid_map, const T& query) {
+    return hana::unpack(
+        get_params(query),
+        [&] (const auto& ... params) {
+            return make_binary_query<BufferAllocatorT>(get_text(query), oid_map, params ...);
+        }
+    );
+}
+
+template <class BufferAllocatorT, class OidMapImplT, class T, class = Require<Query<T>>>
+auto make_binary_query(const BufferAllocatorT& buffer_allocator, const oid_map_t<OidMapImplT>& oid_map, const T& query) {
+    return hana::unpack(
+        get_params(query),
+        [&] (const auto& ... params) {
+            return make_binary_query(buffer_allocator, get_text(query), oid_map, params ...);
+        }
+    );
+}
+
+} // namespace ozo

--- a/include/ozo/binary_serialization.h
+++ b/include/ozo/binary_serialization.h
@@ -1,0 +1,174 @@
+#pragma once
+
+#include <ozo/concept.h>
+#include <ozo/type_traits.h>
+
+#include <libpq-fe.h>
+
+#include <boost/hana/adapt_struct.hpp>
+#include <boost/hana/for_each.hpp>
+#include <boost/hana/members.hpp>
+#include <boost/hana/tuple.hpp>
+#include <boost/range/algorithm/for_each.hpp>
+
+#include <type_traits>
+
+#include <limits.h>
+
+namespace ozo {
+namespace detail {
+
+struct pg_array {
+    BOOST_HANA_DEFINE_STRUCT(pg_array,
+        (std::int32_t, dimensions_count),
+        (std::int32_t, dataoffset),
+        (::Oid, elemtype)
+    );
+};
+
+struct pg_array_dimension {
+    BOOST_HANA_DEFINE_STRUCT(pg_array_dimension,
+        (std::int32_t, size),
+        (std::int32_t, index),
+        (std::int32_t, begin)
+    );
+};
+
+template <class T, std::size_t ... N>
+constexpr T byte_order_swap(T value, std::index_sequence<N ...>) {
+    return (((value >> N * CHAR_BIT & std::numeric_limits<std::uint8_t>::max()) << (sizeof(T) - 1 - N) * CHAR_BIT) | ...);
+}
+
+template <class T, class U = std::make_unsigned_t<T>>
+constexpr Require<endian::native == endian::little, U> convert_to_big_endian(T value) {
+    return byte_order_swap<U>(value, std::make_index_sequence<sizeof(T)> {});
+}
+
+template <class T>
+constexpr Require<endian::native == endian::big, T> convert_to_big_endian(T value) {
+    return value;
+}
+
+template <class T, class OutIteratorT>
+constexpr Require<std::is_integral_v<T>, OutIteratorT> write(T value, OutIteratorT out) {
+    hana::for_each(
+        hana::to<hana::tuple_tag>(hana::make_range(hana::size_c<0>, hana::size_c<sizeof(T)>)),
+        [&] (auto i) { *out++ = value >> decltype(i)::value * CHAR_BIT & std::numeric_limits<std::uint8_t>::max(); }
+    );
+    return out;
+}
+
+template <class T>
+struct floating_point_integral {};
+
+template <>
+struct floating_point_integral<float> {
+    using type = std::uint32_t;
+};
+
+template <>
+struct floating_point_integral<double> {
+    using type = std::uint64_t;
+};
+
+template <class T>
+using floating_point_integral_t = typename floating_point_integral<T>::type;
+
+template <class T, class OutIteratorT>
+constexpr Require<std::is_floating_point_v<T>, OutIteratorT> write(T value, OutIteratorT out) {
+    union {
+        T input;
+        floating_point_integral_t<T> output;
+    } data {value};
+    return write(data.output, out);
+}
+
+template <class T>
+constexpr Require<std::is_arithmetic_v<T>, std::size_t> get_size(const T&) noexcept {
+    return sizeof(T);
+}
+
+template <class T>
+constexpr Require<!std::is_arithmetic_v<T>, std::size_t> get_size(const T& value) noexcept {
+    return std::size(value);
+}
+
+template <class OutIteratorT>
+auto make_writer(OutIteratorT& out) {
+    return [&] (auto v) { out = write(v, out); };
+}
+
+template <class OidMapT, class OutIteratorT>
+auto make_sender(const OidMapT& oid_map, OutIteratorT& out) {
+    return [&] (const auto& v) { out = send(v, oid_map, out); };
+}
+
+} // namespace detail
+
+template <typename T>
+constexpr auto SingleByteIntegral = std::is_integral_v<T> && sizeof(T) == 1;
+
+template <class T, class OidMapT, class OutIteratorT>
+constexpr Require<SingleByteIntegral<T>, OutIteratorT> send(T value, const OidMapT&, OutIteratorT out) {
+    return detail::write(value, out);
+}
+
+template <typename T>
+constexpr auto MultiByteIntegral = std::is_integral_v<T> && (sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8);
+
+template <class T, class OidMapT, class OutIteratorT>
+constexpr Require<MultiByteIntegral<T>, OutIteratorT> send(T value, const OidMapT&, OutIteratorT out) {
+    return detail::write(detail::convert_to_big_endian(value), out);
+}
+
+template <typename T>
+constexpr auto FloatingPoint = std::is_floating_point_v<T> && (sizeof(T) == 4 || sizeof(T) == 8);
+
+template <class T, class OidMapT, class OutIteratorT>
+constexpr Require<FloatingPoint<T>, OutIteratorT> send(T value, const OidMapT&, OutIteratorT out) {
+    return detail::write(value, out);
+}
+
+template <class OidMapT, class OutIteratorT, class CharT, class TraitsT, class AllocatorT>
+constexpr OutIteratorT send(const std::basic_string<CharT, TraitsT, AllocatorT>& value, const OidMapT&, OutIteratorT out) {
+    boost::for_each(value, detail::make_writer(out));
+    return out;
+}
+
+template <class OidMapT, class OutIteratorT, class T, class AllocatorT>
+constexpr Require<std::is_arithmetic_v<T>, OutIteratorT> send(const std::vector<T, AllocatorT>& value, const OidMapT& oid_map, OutIteratorT out) {
+    out = send(detail::pg_array {1, 0, ::Oid(type_oid<std::decay_t<T>>(oid_map))}, oid_map, out);
+    out = send(detail::pg_array_dimension {std::int32_t(std::size(value)), 0, 1}, oid_map, out);
+    boost::for_each(value,
+        [&] (const auto& v) {
+            out = send(std::int32_t(detail::get_size(v)), oid_map, out);
+            out = send(v, oid_map, out);
+        });
+    return out;
+}
+
+template <class OidMapT, class OutIteratorT, class AllocatorT>
+constexpr OutIteratorT send(const std::vector<char, AllocatorT>& value, const OidMapT&, OutIteratorT out) {
+    boost::for_each(value, detail::make_writer(out));
+    return out;
+}
+
+template <class OidMapT, class OutIteratorT>
+constexpr OutIteratorT send(const boost::uuids::uuid& value, const OidMapT&, OutIteratorT out) {
+    hana::for_each(value, detail::make_writer(out));
+    return out;
+}
+
+template <class OidMapT, class OutIteratorT>
+constexpr OutIteratorT send(const detail::pg_array& value, const OidMapT& oid_map, OutIteratorT out) {
+    hana::for_each(hana::members(value), detail::make_sender(oid_map, out));
+    return out;
+}
+
+template <class OidMapT, class OutIteratorT>
+constexpr OutIteratorT send(const detail::pg_array_dimension& value, const OidMapT& oid_map, OutIteratorT out) {
+    hana::for_each(hana::members(value), detail::make_sender(oid_map, out));
+    return out;
+}
+
+} // namespace ozo

--- a/include/ozo/impl/query.h
+++ b/include/ozo/impl/query.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <ozo/type_traits.h>
+
+#include <boost/hana/tuple.hpp>
+
+#include <string_view>
+
+namespace ozo::impl {
+
+template <class ... ParamsT>
+struct query {
+    std::string_view text;
+    hana::tuple<ParamsT ...> params;
+};
+
+template <class ... ParamsT>
+const auto& get_query_text(const query<ParamsT ...>& value) {
+    return value.text;
+}
+
+template <class ... ParamsT>
+const auto& get_query_params(const query<ParamsT ...>& value) {
+    return value.params;
+}
+
+} // namespace ozo::impl

--- a/include/ozo/query.h
+++ b/include/ozo/query.h
@@ -1,12 +1,38 @@
 #pragma once
 
-#include <boost/hana.hpp>
+#include <ozo/impl/query.h>
+#include <ozo/concept.h>
 
 namespace ozo {
 
-template <const char* text, class ... Args>
-auto make_query(Args&& ... args) {
-    return boost::hana::make_tuple(std::forward<Args&&>(args) ...);
+template <class, class = std::void_t<>>
+struct is_query : std::false_type {};
+
+template <class T>
+struct is_query<T, std::void_t<
+    decltype(get_query_text(std::declval<const T&>())),
+    decltype(get_query_params(std::declval<const T&>()))
+>> : std::true_type {};
+
+template <typename T>
+constexpr auto Query = is_query<std::decay_t<T>>::value;
+
+template <class ... ParamsT>
+auto make_query(std::string_view text, ParamsT&& ... params) {
+    using result = impl::query<std::decay_t<ParamsT> ...>;
+    return result {text, hana::make_tuple(std::forward<ParamsT>(params) ...)};
+}
+
+template <class T, class = Require<Query<T>>>
+decltype(auto) get_text(const T& query) {
+    using impl::get_query_text;
+    return get_query_text(query);
+}
+
+template <class T, class = Require<Query<T>>>
+decltype(auto) get_params(const T& query) {
+    using impl::get_query_params;
+    return get_query_params(query);
 }
 
 } // namespace ozo

--- a/include/ozo/query_builder.h
+++ b/include/ozo/query_builder.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include <ozo/query.h>
+#include <ozo/type_traits.h>
+
+#include <boost/hana/fold.hpp>
+#include <boost/hana/for_each.hpp>
+#include <boost/hana/string.hpp>
+#include <boost/hana/tuple.hpp>
+
+namespace ozo {
+namespace detail {
+
+template <std::size_t, char ... c>
+struct concat_query_element_result {
+    using string_type = boost::hana::string<c ...>;
+
+    constexpr string_type string() noexcept {
+        return string_type();
+    }
+};
+
+template <std::size_t n, char ... c>
+auto make_concat_query_element_result(boost::hana::string<c ...>) noexcept {
+    return concat_query_element_result<n, c ...>();
+}
+
+template <std::size_t value>
+constexpr auto digit_to_string(std::integral_constant<std::size_t, value>) noexcept {
+    return boost::hana::string_c<'0' + value>;
+}
+
+template <std::size_t value>
+constexpr auto to_string() noexcept;
+
+template <std::size_t value>
+constexpr auto to_string_head(std::integral_constant<std::size_t, value>) noexcept {
+    return to_string<value>();
+}
+
+constexpr auto to_string_head(std::integral_constant<std::size_t, 0>) noexcept {
+    return boost::hana::string_c<>;
+}
+
+template <std::size_t value>
+constexpr auto to_string() noexcept {
+    constexpr auto divident = value % 10;
+    return to_string_head(std::integral_constant<std::size_t, (value - divident) / 10>())
+        + digit_to_string(std::integral_constant<std::size_t, divident>());
+}
+
+struct query_text_tag {};
+
+struct query_param_tag {};
+
+template <class ValueT, class TagT>
+struct query_element {
+    using value_type = ValueT;
+    using tag_type = TagT;
+
+    value_type value;
+};
+
+template <class T, std::size_t next_param_number, char ... c>
+constexpr auto concat_query_text(concat_query_element_result<next_param_number, c ...>, const query_element<T, query_text_tag>&) noexcept {
+    using s_type = concat_query_element_result<next_param_number, c ...>;
+    return make_concat_query_element_result<next_param_number>(typename s_type::string_type() + T());
+}
+
+template <class T, std::size_t next_param_number, char ... c>
+constexpr auto concat_query_text(concat_query_element_result<next_param_number, c ...>, const query_element<T, query_param_tag>&) noexcept {
+    using namespace boost::hana::literals;
+    using s_type = concat_query_element_result<next_param_number, c ...>;
+    return make_concat_query_element_result<next_param_number + 1>(
+        typename s_type::string_type() + "$"_s + to_string<next_param_number>()
+    );
+}
+
+template <class T, class ... ValuesT>
+constexpr auto concat_query_params(boost::hana::tuple<ValuesT ...>&& result, const query_element<T, query_text_tag>&) noexcept {
+    return result;
+}
+
+template <class T, class ... ValuesT>
+constexpr auto concat_query_params(boost::hana::tuple<ValuesT ...>&& result, const query_element<T, query_param_tag>& element) {
+    return hana::concat(std::move(result), hana::make_tuple(element.value));
+}
+
+} // namespace detail
+
+template <class ElementsT>
+struct query_builder {
+    using elements_type = ElementsT;
+
+    elements_type elements;
+
+    constexpr auto text() const noexcept {
+        using namespace detail;
+        return hana::fold(elements, make_concat_query_element_result<1>(hana::string_c<>),
+            [] (auto s, const auto& v) { return concat_query_text(s, v); }).string();
+    }
+
+    constexpr auto params() const noexcept {
+        using namespace detail;
+        return hana::fold(elements, hana::tuple<>(),
+            [] (auto&& s, const auto& v) { return concat_query_params(std::move(s), v); });
+    }
+
+    constexpr auto build() const {
+        return hana::unpack(
+            params(),
+            [&] (auto&& ... params) {
+                return make_query(hana::to<const char*>(text()), std::move(params) ...);
+            }
+        );
+    }
+};
+
+template <char ... c>
+constexpr auto make_query_builder(boost::hana::string<c ...>) {
+    using namespace detail;
+    using elements_tuple = hana::tuple<query_element<hana::string<c ...>, query_text_tag>>;
+    return query_builder<elements_tuple> {elements_tuple()};
+}
+
+template <class ... ElementsT>
+constexpr auto make_query_builder(boost::hana::tuple<ElementsT ...>&& elements) {
+    using namespace detail;
+    return query_builder<boost::hana::tuple<ElementsT ...>> {std::move(elements)};
+}
+
+template <class ElementsT, class OtherElementsT>
+constexpr auto operator +(query_builder<ElementsT>&& builder, query_builder<OtherElementsT>&& other) {
+    return make_query_builder(hana::concat(std::move(builder.elements), std::move(other.elements)));
+}
+
+template <class ValueT, class ElementsT>
+constexpr auto operator +(query_builder<ElementsT>&& builder, ValueT&& value) {
+    using namespace detail;
+    using query_element_param = query_element<std::decay_t<ValueT>, query_param_tag>;
+    using tail_tuple = hana::tuple<query_element_param>;
+    return make_query_builder(hana::concat(std::move(builder.elements), tail_tuple(query_element_param {std::forward<ValueT>(value)})));
+}
+
+template <class ValueT, class ElementsT>
+constexpr auto operator +(query_builder<ElementsT>&& builder, const ValueT& value) {
+    using namespace detail;
+    using query_element_param = query_element<std::reference_wrapper<const ValueT>, query_param_tag>;
+    using tail_tuple = hana::tuple<query_element_param>;
+    return make_query_builder(hana::concat(std::move(builder.elements), tail_tuple(query_element_param {value})));
+}
+
+namespace literals {
+
+template <class CharT, CharT ... c>
+constexpr auto operator "" _SQL() {
+    return make_query_builder(hana::string<c ...>());
+}
+
+} // namespace literals
+} // namespace ozo

--- a/include/ozo/type_traits.h
+++ b/include/ozo/type_traits.h
@@ -335,4 +335,16 @@ inline bool accepts_oid(const oid_map_t<MapImplT>& map, const T& v, oid_t oid) n
     return type_oid(map, v) == oid;
 }
 
+enum class endian {
+#ifdef _WIN32
+    little = 0,
+    big    = 1,
+    native = little
+#else
+    little = __ORDER_LITTLE_ENDIAN__,
+    big    = __ORDER_BIG_ENDIAN__,
+    native = __BYTE_ORDER__
+#endif
+};
+
 } // namespace ozo

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,8 @@
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Werror -Wno-ignored-optimization-argument -fno-devirtualize")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic -Werror -fno-devirtualize")
+
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-ignored-optimization-argument")
+endif()
 
 find_package(Boost COMPONENTS system thread REQUIRED)
 include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
@@ -27,12 +31,15 @@ include_directories(SYSTEM "${source_dir}/libs/json/src")
 link_directories("${source_dir}/libs/gherkin-cpp")
 
 set(SOURCES
-    bind.cpp
     async_connect.cpp
-    connection_pool.cpp
-    type_traits.cpp
+    binary_query.cpp
+    binary_serialization.cpp
+    bind.cpp
     connection.cpp
     connection_info.cpp
+    connection_pool.cpp
+    query_builder.cpp
+    type_traits.cpp
 )
 
 set(LIBRARIES

--- a/tests/binary_query.cpp
+++ b/tests/binary_query.cpp
@@ -1,0 +1,161 @@
+#include <GUnit/GTest.h>
+
+#include <ozo/binary_query.h>
+
+#include <iterator>
+
+GTEST("ozo::binary_query::params_count", "without parameters should be equal to 0") {
+    const auto query = ozo::make_binary_query("");
+    EXPECT_EQ(query.params_count, 0);
+}
+
+GTEST("ozo::query") {
+    SHOULD("with more than 0 parameters should be equal to that number") {
+        const auto query = ozo::make_binary_query("", true, 42, std::string("text"));
+        EXPECT_EQ(query.params_count, 3);
+    }
+
+    SHOULD("from query concept with more than 0 parameters should be equal to that number") {
+        const auto query = ozo::make_binary_query(ozo::make_query("", true, 42, std::string("text")));
+        EXPECT_EQ(query.params_count, 3);
+    }
+}
+
+GTEST("ozo::binary_query::text", "query text should be equal to input") {
+    const auto query = ozo::make_binary_query("query");
+    EXPECT_STREQ(query.text(), "query");
+}
+
+GTEST("ozo::binary_query::types") {
+    SHOULD("type of the param should be equal to type oid") {
+        const auto query = ozo::make_binary_query("", std::int16_t());
+        EXPECT_EQ(query.types()[0], ozo::type_traits<std::int16_t>::oid());
+    }
+
+    SHOULD("nullptr type should be equal to 0") {
+        const auto query = ozo::make_binary_query("", nullptr);
+        EXPECT_EQ(query.types()[0], 0);
+    }
+
+    SHOULD("null std::optional<std::int32_t> type should be equal to std::int32_t oid") {
+        const auto query = ozo::make_binary_query("", std::optional<std::int32_t>());
+        EXPECT_EQ(query.types()[0], ozo::type_traits<std::int32_t>::oid());
+    }
+
+    SHOULD("null std::shared_ptr<std::int32_t> type should be equal to std::int32_t oid") {
+        const auto query = ozo::make_binary_query("", std::shared_ptr<std::int32_t>());
+        EXPECT_EQ(query.types()[0], ozo::type_traits<std::int32_t>::oid());
+    }
+
+    SHOULD("null std::unique_ptr<std::int32_t> type should be equal to std::int32_t oid") {
+        const auto query = ozo::make_binary_query("", std::vector<std::int32_t>());
+        EXPECT_EQ(query.types()[0], ozo::type_traits<std::vector<std::int32_t>>::oid());
+    }
+
+    SHOULD("null std::weak_ptr<std::int32_t> type should be equal to std::int32_t oid") {
+        const auto query = ozo::make_binary_query("", std::weak_ptr<std::int32_t>());
+        EXPECT_EQ(query.types()[0], ozo::type_traits<std::int32_t>::oid());
+    }
+
+    SHOULD("std::vector<float> type should be equal to std::vector<float> oid") {
+        const auto value = 42.13f;
+        const auto query = ozo::make_binary_query("", std::cref(value));
+        EXPECT_EQ(*reinterpret_cast<const float*>(query.values()[0]), 42.13f);
+    }
+}
+
+GTEST("ozo::binary_query::formats", "format of the param should be equal to 1") {
+    const auto query = ozo::make_binary_query("", std::int16_t());
+    EXPECT_EQ(query.formats()[0], 1);
+}
+
+GTEST("ozo::binary_query::lengths") {
+    SHOULD("length of the param should be equal to its binary serialized data size") {
+        const auto query = ozo::make_binary_query("", std::int16_t());
+        EXPECT_EQ(query.lengths()[0], sizeof(std::int16_t));
+    }
+
+    SHOULD("string length should be equal to number of chars") {
+        const auto query = ozo::make_binary_query("", std::string("std::string"));
+        EXPECT_EQ(query.lengths()[0], 11);
+    }
+}
+
+GTEST("ozo::binary_query::values") {
+    SHOULD("value of the floating point type param should be equal to input") {
+        const auto query = ozo::make_binary_query("", 42.13f);
+        EXPECT_EQ(*reinterpret_cast<const float*>(query.values()[0]), 42.13f);
+    }
+
+    SHOULD("string value should be equal to input") {
+        using namespace ::testing;
+        const auto query = ozo::make_binary_query("", std::string("string"));
+        EXPECT_THAT(std::vector<char>(query.values()[0], query.values()[0] + 6),
+            ElementsAre('s', 't', 'r', 'i', 'n', 'g'));
+    }
+
+    SHOULD("nullptr value should be equal to nullptr") {
+        const auto query = ozo::make_binary_query("", nullptr);
+        EXPECT_EQ(query.values()[0], nullptr);
+    }
+
+    SHOULD("nullopt value should be equal to nullptr") {
+        const auto query = ozo::make_binary_query("", std::nullopt);
+        EXPECT_EQ(query.values()[0], nullptr);
+    }
+
+    SHOULD("null std::optional<std::int32_t> value should be equal to nullptr") {
+        const auto query = ozo::make_binary_query("", std::optional<std::int32_t>());
+        EXPECT_EQ(query.values()[0], nullptr);
+    }
+
+    SHOULD("not null std::optional<std::string> value should be equal to input") {
+        using namespace ::testing;
+        const auto query = ozo::make_binary_query("", std::optional<std::string>("string"));
+        EXPECT_THAT(std::vector<char>(query.values()[0], query.values()[0] + 6),
+            ElementsAre('s', 't', 'r', 'i', 'n', 'g'));
+    }
+
+    SHOULD("null std::shared_ptr<std::int32_t> value should be equal to nullptr") {
+        const auto query = ozo::make_binary_query("", std::shared_ptr<std::int32_t>());
+        EXPECT_EQ(query.values()[0], nullptr);
+    }
+
+    SHOULD("not null std::shared_ptr<std::string> value should be equal to input") {
+        using namespace ::testing;
+        const auto query = ozo::make_binary_query("", std::make_shared<std::string>("string"));
+        EXPECT_THAT(std::vector<char>(query.values()[0], query.values()[0] + 6),
+            ElementsAre('s', 't', 'r', 'i', 'n', 'g'));
+    }
+
+    SHOULD("null std::unique_ptr<std::int32_t> value should be equal to nullptr") {
+        const auto query = ozo::make_binary_query("", std::unique_ptr<std::int32_t>());
+        EXPECT_EQ(query.values()[0], nullptr);
+    }
+
+    SHOULD("not null std::unique_ptr<std::string> value should be equal to input") {
+        using namespace ::testing;
+        const auto query = ozo::make_binary_query("", std::make_unique<std::string>("string"));
+        EXPECT_THAT(std::vector<char>(query.values()[0], query.values()[0] + 6),
+            ElementsAre('s', 't', 'r', 'i', 'n', 'g'));
+    }
+
+    SHOULD("null std::weak_ptr<std::int32_t> value should be equal to nullptr") {
+        const auto query = ozo::make_binary_query("", std::weak_ptr<std::int32_t>());
+        EXPECT_EQ(query.values()[0], nullptr);
+    }
+
+    SHOULD("not null std::weak_ptr<std::string> value should be equal to input") {
+        using namespace ::testing;
+        const auto ptr = std::make_shared<std::string>("string");
+        const auto query = ozo::make_binary_query("", std::weak_ptr<std::string>(ptr));
+        EXPECT_THAT(std::vector<char>(query.values()[0], query.values()[0] + 6),
+            ElementsAre('s', 't', 'r', 'i', 'n', 'g'));
+    }
+
+    SHOULD("std::reference_wrapper<std::int8_t> value should be equal to input") {
+        const auto value = 42.13f;
+        const auto query = ozo::make_binary_query("", std::cref(value));
+        EXPECT_EQ(*reinterpret_cast<const float*>(query.values()[0]), 42.13f);
+    }
+}

--- a/tests/binary_serialization.cpp
+++ b/tests/binary_serialization.cpp
@@ -1,0 +1,63 @@
+#include <GUnit/GTest.h>
+
+#include <ozo/binary_serialization.h>
+
+GTEST("ozo::send") {
+    SHOULD("with std::int8_t should return as is") {
+        using namespace testing;
+        std::vector<char> buffer;
+        ozo::send(std::int8_t(42), ozo::register_types<>(), std::back_inserter(buffer));
+        EXPECT_THAT(buffer, ElementsAre(42));
+    }
+
+    SHOULD("with std::int16_t should return bytes in big-endian order") {
+        using namespace testing;
+        std::vector<char> buffer;
+        ozo::send(std::int16_t(42), ozo::register_types<>(), std::back_inserter(buffer));
+        EXPECT_THAT(buffer, ElementsAre(0, 42));
+    }
+
+    SHOULD("with std::int32_t should return bytes in big-endian order") {
+        using namespace testing;
+        std::vector<char> buffer;
+        ozo::send(std::int32_t(42), ozo::register_types<>(), std::back_inserter(buffer));
+        EXPECT_THAT(buffer, ElementsAre(0, 0, 0, 42));
+    }
+
+    SHOULD("with std::int64_t should return bytes in big-endian order") {
+        using namespace testing;
+        std::vector<char> buffer;
+        ozo::send(std::int64_t(42), ozo::register_types<>(), std::back_inserter(buffer));
+        EXPECT_THAT(buffer, ElementsAre(0, 0, 0, 0, 0, 0, 0, 42));
+    }
+
+    SHOULD("with float should return bytes in same order") {
+        using namespace testing;
+        std::vector<char> buffer;
+        ozo::send(42.13f, ozo::register_types<>(), std::back_inserter(buffer));
+        EXPECT_THAT(buffer, ElementsAre(0x1F, 0x85, 0x28, 0x42));
+    }
+
+    SHOULD("with std::string should return bytes in same order") {
+        using namespace testing;
+        std::vector<char> buffer;
+        ozo::send(std::string("text"), ozo::register_types<>(), std::back_inserter(buffer));
+        EXPECT_THAT(buffer, ElementsAre('t', 'e', 'x', 't'));
+    }
+
+    SHOULD("with std::vector<float> should return bytes with one dimension array header and values") {
+        using namespace testing;
+        std::vector<char> buffer;
+        ozo::send(std::vector<float>({42.13f}), ozo::register_types<>(), std::back_inserter(buffer));
+        EXPECT_EQ(buffer, std::vector<char>({
+            0, 0, 0, 1,
+            0, 0, 0, 0,
+            0, 0, 2, '\xBC',
+            0, 0, 0, 1,
+            0, 0, 0, 0,
+            0, 0, 0, 1,
+            0, 0, 0, 4,
+            0x1F, char(0x85), 0x28, 0x42,
+        }));
+    }
+}

--- a/tests/query_builder.cpp
+++ b/tests/query_builder.cpp
@@ -1,0 +1,124 @@
+#include <GUnit/GTest.h>
+
+#include <ozo/query_builder.h>
+
+#include <boost/hana/size.hpp>
+
+GTEST("ozo::detail::to_string") {
+    SHOULD("with 0 returns \"0\"_s") {
+        using namespace boost::hana::literals;
+        EXPECT_EQ(ozo::detail::to_string<std::size_t(0)>(), "0"_s);
+    }
+
+    SHOULD("with one digit number returns string with same digit") {
+        using namespace boost::hana::literals;
+        EXPECT_EQ(ozo::detail::to_string<std::size_t(7)>(), "7"_s);
+    }
+
+    SHOULD("with two digits number returns string with digits in same order") {
+        using namespace boost::hana::literals;
+        EXPECT_EQ(ozo::detail::to_string<std::size_t(42)>(), "42"_s);
+    }
+}
+
+GTEST("ozo::query_builder::text") {
+    SHOULD("with one text element returns input") {
+        using namespace ozo::literals;
+        using namespace boost::hana::literals;
+        EXPECT_EQ("SELECT 1"_SQL.text(), "SELECT 1"_s);
+    }
+
+    SHOULD("with two text elements returns concatenation") {
+        using namespace ozo::literals;
+        using namespace boost::hana::literals;
+        EXPECT_EQ(("SELECT 1"_SQL + " + 1"_SQL).text(), "SELECT 1 + 1"_s);
+    }
+
+    SHOULD("with text and int32 param elements returns text with placeholder for param") {
+        using namespace ozo::literals;
+        using namespace boost::hana::literals;
+        EXPECT_EQ(("SELECT "_SQL + std::int32_t(42)).text(), "SELECT $1"_s);
+    }
+
+    SHOULD("with text and two int32 params elements returns text with placeholders for each param") {
+        using namespace ozo::literals;
+        using namespace boost::hana::literals;
+        EXPECT_EQ(("SELECT "_SQL + std::int32_t(42) + " + "_SQL + std::int32_t(42)).text(), "SELECT $1 + $2"_s);
+    }
+}
+
+GTEST("ozo::query_builder::params") {
+    SHOULD("with one text element returns empty tuple") {
+        using namespace ozo::literals;
+        EXPECT_EQ("SELECT 1"_SQL.params(), boost::hana::tuple<>());
+    }
+
+    SHOULD("with text and int32 param elements returns tuple with one value") {
+        using namespace ozo::literals;
+        EXPECT_EQ(("SELECT "_SQL + std::int32_t(42)).params(), boost::hana::make_tuple(std::int32_t(42)));
+    }
+
+    SHOULD("with text and not null pointer param elements returns tuple with one value") {
+        using namespace ozo::literals;
+        const auto ptr = std::make_unique<std::int32_t>(42);
+        const auto params = ("SELECT "_SQL + ptr.get()).params();
+        EXPECT_EQ(*params[boost::hana::size_c<0>], std::int32_t(42));
+    }
+}
+
+namespace ozo::testing {
+
+struct some_type {
+    std::size_t size() const {
+        return 1000;
+    }
+};
+
+} // namespace ozo::testing
+
+OZO_PG_DEFINE_CUSTOM_TYPE(ozo::testing::some_type, "some_type", dynamic_size)
+
+GTEST("ozo::query_builder::build") {
+    namespace hana = boost::hana;
+
+    SHOULD("with one text element returns query with text equal to input") {
+        using namespace ozo::literals;
+        EXPECT_EQ("SELECT 1"_SQL.build().text, "SELECT 1");
+    }
+
+    SHOULD("with one text element returns query without params") {
+        using namespace ozo::literals;
+        EXPECT_EQ("SELECT 1"_SQL.build().params, hana::tuple<>());
+    }
+
+    SHOULD("with text and int32 param elements return query with 1 param") {
+        using namespace ozo::literals;
+        EXPECT_EQ(("SELECT "_SQL + std::int32_t(42)).build().params, hana::make_tuple(42));
+    }
+
+    SHOULD("with text and reference_wrapper param element returns query with 1 param") {
+        using namespace ozo::literals;
+        const auto value = 42.13f;
+        EXPECT_EQ(("SELECT "_SQL + std::cref(value)).build().params, hana::make_tuple(std::cref(value)));
+    }
+
+    SHOULD("with text and not null std::unique_ptr param element returns query with 1 param") {
+        using namespace ozo::literals;
+        const auto ptr = std::make_unique<float>(42.13f);
+        const auto params = ("SELECT "_SQL + ptr).build().params;
+        EXPECT_EQ(decltype(hana::size(params))::value, 1);
+    }
+
+    SHOULD("with text and not null std::shared_ptr param element returns query with 1 param") {
+        using namespace ozo::literals;
+        const auto ptr = std::make_shared<float>(42.13f);
+        const auto params = ("SELECT "_SQL + ptr).build().params;
+        EXPECT_EQ(decltype(hana::size(params))::value, 1);
+    }
+
+    SHOULD("with text and custom type param element returns query with 1 param") {
+        using namespace ozo::literals;
+        const auto params = ("SELECT "_SQL + ozo::testing::some_type {}).build().params;
+        EXPECT_EQ(decltype(hana::size(params))::value, 1);
+    }
+}


### PR DESCRIPTION
Partial implementation of libpq query constructor with binary serialization and query text build. Now supports only arithmetic types and strings, but review of the concept is required. Based on type_traits branch rebased onto master.