### PR TITLE
Add connection implementation.

### DIFF
--- a/include/apq/asio.h
+++ b/include/apq/asio.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <boost/asio.hpp>
+
+namespace libapq {
+
+namespace asio = ::boost::asio;
+
+using io_context = asio::io_service;
+
+} // namespace libapq

--- a/include/apq/async_connect.h
+++ b/include/apq/async_connect.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <apq/connection.h>
+#include <apq/impl/async_connect.h>
+
+namespace libapq {
+namespace detail {
+
+template <typename Handler, typename Connection>
+struct connection_binder {
+    Handler handler_;
+    Connection conn_;
+
+    void operator() (error_code ec) {
+        handler_(std::move(ec), std::move(conn_));
+    }
+
+    template <typename Func>
+    friend void asio_handler_invoke(Func&& f, connection_binder* ctx) {
+        using ::boost::asio::asio_handler_invoke;
+        asio_handler_invoke(std::forward<Func>(f), 
+            std::addressof(ctx->handler_));
+    }
+};
+
+template <typename Handler, typename Connection>
+inline auto bind_connection_handler(Handler&& base, Connection&& conn) {
+    return connection_binder<std::decay_t<Handler>, std::decay_t<Connection>> {
+        std::forward<Handler>(base), std::forward<Connection>(conn)
+    };
+}
+
+} // namespace detail
+
+template <typename T, typename Handler>
+inline Require<Connectable<T>> async_connect(std::string conn_info, T&& conn,
+        Handler&& handler) {
+
+    decltype(auto) conn_ref = unwrap_connection(conn);
+    impl::async_connect(conn_info, conn_ref,
+            detail::bind_connection_handler(std::forward<Handler>(handler),
+                std::forward<T>(conn)));
+}
+
+} // namespace libapq

--- a/include/apq/async_result.h
+++ b/include/apq/async_result.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <boost/asio/async_result.hpp>
+#include <utility>
+#include <apq/asio.h>
+
+namespace libapq {
+
+//We can reuse boost::asio::async_result since it is not binded to error code type
+using asio::async_result;
+using asio::handler_type;
+
+/**
+* This is a part of compatibility layer with Boos.Asio 1.66
+*/
+template <typename CompletionToken, typename Signature>
+struct async_completion {
+    explicit async_completion(CompletionToken& token)
+    : completion_handler(std::move(token)),
+      result(completion_handler) {
+    }
+
+    using completion_handler_type = typename libapq::handler_type<CompletionToken, Signature>::type;
+
+    completion_handler_type completion_handler;
+    async_result<completion_handler_type> result;
+};
+
+} // namespace libapq

--- a/include/apq/concept.h
+++ b/include/apq/concept.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <typeinfo>
+
+namespace libapq {
+
+/**
+* This is requirement simulation type, which is the alias to std::enable_if_t
+* It is pretty simple to use it with pseudo-concepts such as OperatorNot below.
+*/
+template <bool Condition, typename Type = void>
+using Require = std::enable_if_t<Condition, Type>;
+
+
+template <typename T, typename = std::void_t<>>
+struct has_operator_not : std::false_type {};
+template <typename T>
+struct has_operator_not<T, std::void_t<decltype(!std::declval<T>())>>
+    : std::true_type {};
+
+template <typename T>
+constexpr auto OperatorNot = has_operator_not<std::decay_t<T>>::value;
+
+} // namespace libapq

--- a/include/apq/connection.h
+++ b/include/apq/connection.h
@@ -1,10 +1,376 @@
 #pragma once
+#include <iostream>
+
+#include <apq/async_result.h>
+#include <apq/error.h>
+#include <apq/type_traits.h>
+#include <apq/asio.h>
+#include <apq/concept.h>
+
+#include <apq/detail/bind.h>
+#include <apq/impl/connection.h>
 
 namespace libapq {
 
-class connection {
-public:
-    connection() {}
+using impl::pg_conn_handle;
+
+using no_statistics = decltype(hana::make_map());
+
+/**
+* Marker to tag a connection type.
+*/
+template <typename, typename = std::void_t<>>
+struct is_connection : std::false_type {};
+
+/**
+* We define the connection to database not as a concrete class or type,
+* but as an entity which must support some traits. The reason why we
+* choose such strategy is - we want to provide flexibility and extension ability
+* for implementation and testing. User can implemet a connection bound additional
+* functionality.
+*
+* This is how connection is determined. Connection is an object for which these
+* next free functions are applicable:
+*
+*   * get_connection_oid_map()
+*     Must return reference or proxy for connection's oid map object, which allows
+*     to read and modify it. Object must be created via register_types<>() template
+*     function or be empty_oid_map in case if no custom types are used with the
+*     connection.
+*
+*   * get_connection_socket()
+*     Must return reference or proxy for socket io stream object which allows to bind
+*     the connection to the asio io_context, currently boost::asio::posix::stream_descriptor
+*     is suppurted only.
+*
+*   * get_connection_handle()
+*     Must return reference or proxy for pg_conn_handle object
+*
+*   * get_connection_error_context()
+*     Must return reference or proxy for additional error context. There is no
+*     mechanism to privide context depent information via [std|boost]::error_code. So
+*     we decide to use connection for this purpose since native libpq error message is
+*     bound to connection and all asyncronous operation of the library is bound to
+*     connection too. Currently std::string supported as a context object.
+*/
+template <typename T>
+struct is_connection<T, std::void_t<
+    decltype(get_connection_oid_map(std::declval<T&>())),
+    decltype(get_connection_socket(std::declval<T&>())),
+    decltype(get_connection_handle(std::declval<T&>())),
+    decltype(get_connection_error_context(std::declval<T&>())),
+    decltype(get_connection_oid_map(std::declval<const T&>())),
+    decltype(get_connection_socket(std::declval<const T&>())),
+    decltype(get_connection_handle(std::declval<const T&>())),
+    decltype(get_connection_error_context(std::declval<const T&>()))
+>> : std::true_type {};
+
+
+template <typename, typename = std::void_t<>>
+struct is_connection_wrapper : std::false_type {};
+
+template <typename T>
+struct is_connection_wrapper<::std::shared_ptr<T>> : std::true_type {};
+template <typename T, typename D>
+struct is_connection_wrapper<::std::unique_ptr<T, D>> : std::true_type {};
+template <typename T>
+struct is_connection_wrapper<::std::optional<T>> : std::true_type {};
+template <typename T>
+struct is_connection_wrapper<::boost::shared_ptr<T>> : std::true_type {};
+template <typename T>
+struct is_connection_wrapper<::boost::scoped_ptr<T>> : std::true_type {};
+template <typename T>
+struct is_connection_wrapper<::boost::optional<T>> : std::true_type {};
+
+template <typename T>
+constexpr auto ConnectionWrapper = is_connection_wrapper<std::decay_t<T>>::value;
+
+template <typename T>
+constexpr auto Connection = is_connection<std::decay_t<T>>::value;
+
+/**
+* Connection type traits
+*/
+template <typename T>
+struct connection_traits {
+    using oid_map = std::decay_t<decltype(get_connection_oid_map(std::declval<T&>()))>;
+    using socket = std::decay_t<decltype(get_connection_socket(std::declval<T&>()))>;
+    using handle = std::decay_t<decltype(get_connection_handle(std::declval<T&>()))>;
+    using error_context = std::decay_t<decltype(get_connection_error_context(std::declval<T&>()))>;
 };
 
-} // namespace apq
+/**
+* Connection public access functions section 
+*/
+
+/**
+* Overloaded version of unwrap function for Connection.
+* Returns connection object itself.
+*/
+template <typename T>
+inline decltype(auto) unwrap_connection(T&& conn, 
+        Require<!ConnectionWrapper<T>>* = 0) noexcept {
+    return std::forward<T>(conn);
+}
+
+/**
+* Unwraps wrapped connection recusively.
+* Returns unwrapped connection object.
+*/
+template <typename T>
+inline decltype(auto) unwrap_connection(T&& conn, 
+        Require<ConnectionWrapper<T>>* = 0) noexcept {
+    return unwrap_connection(*conn);
+}
+
+template <typename, typename = std::void_t<>>
+struct is_connectiable : std::false_type {};
+
+template <typename T>
+struct is_connectiable <T, std::void_t<
+    decltype(unwrap_connection(std::declval<T&>()))
+>>: std::integral_constant<bool, Connection<
+    decltype(unwrap_connection(std::declval<T&>()))
+>> {};
+
+template <typename T>
+constexpr auto Connectable = is_connectiable<std::decay_t<T>>::value;
+
+/**
+* Function to get connection traits type from object
+*/
+template <typename T, typename = Require<Connectable<T>>>
+constexpr connection_traits<std::decay_t<decltype(unwrap_connection(std::declval<T>()))>>
+    get_connection_traits(T&&) noexcept {return {};}
+
+/**
+* Returns PostgreSQL connection handle of the connection.
+*/
+template <typename T, typename = Require<Connectable<T>>>
+inline decltype(auto) get_handle(T&& conn) noexcept {
+    using impl::get_connection_handle;
+    return get_connection_handle(
+        unwrap_connection(std::forward<T>(conn)));
+}
+
+/**
+* Returns PostgreSQL native connection handle of the connection.
+*/
+template <typename T, typename = Require<Connectable<T>>>
+inline decltype(auto) get_native_handle(T&& conn) noexcept {
+    return get_handle(std::forward<T>(conn)).get();
+}
+
+/**
+* Returns socket stream object of the connection.
+*/
+template <typename T, typename = Require<Connectable<T>>>
+inline decltype(auto) get_socket(T&& conn) noexcept {
+    using impl::get_connection_socket;
+    return get_connection_socket(unwrap_connection(std::forward<T>(conn)));
+}
+
+/**
+* Returns io_context for connection is bound to.
+*/
+template <typename T, typename = Require<Connectable<T>>>
+inline decltype(auto) get_io_context(T& conn) noexcept {
+    return get_socket(conn).get_io_service();
+}
+
+/**
+* Rebinds io_context for the connection
+*/
+template <typename T, typename = Require<Connectable<T>>>
+inline error_code rebind_io_context(T& conn, io_context& io) {
+    using impl::rebind_connection_io_context;
+    return rebind_connection_io_context(unwrap_connection(conn), io);
+}
+
+/**
+* Indicates if connection is bad
+*/
+template <typename T>
+inline Require<Connectable<T> && !OperatorNot<T>,
+bool> connection_bad(const T& conn) noexcept { 
+    using impl::connection_status_bad;
+    return connection_status_bad(get_native_handle(conn));
+}
+
+/**
+* Indicates if connection is bad. Overloaded version for
+* ConnectionWraper with operator !
+*/
+template <typename T>
+inline Require<ConnectionWrapper<T> && OperatorNot<T>,
+bool> connection_bad(const T& conn) noexcept {
+    using impl::connection_status_bad;
+    return !conn || connection_status_bad(get_native_handle(conn));
+}
+
+/**
+* Indicates if connection is not bad
+*/
+template <typename T, typename = Require<Connectable<T>>>
+inline bool connection_good(const T& conn) noexcept {
+    return !connection_bad(conn);
+}
+
+/**
+* Returns string view on native libpq connection error
+*/
+template <typename T, typename = Require<Connectable<T>>>
+inline std::string_view error_message(T&& conn) {
+    using impl::connection_error_message;
+    return connection_error_message(get_native_handle(conn));
+}
+
+/**
+* Getter of additional error context. for error occured while operating
+* with connection.
+*/
+template <typename T, typename = Require<Connectable<T>>>
+inline const auto& get_error_context(const T& conn) {
+    using impl::get_connection_error_context;
+    return get_connection_error_context(unwrap_connection(conn));
+}
+
+/**
+* Set the connection error context.
+*/
+template <typename T, typename Ctx>
+inline Require<Connectable<T>> set_error_context(T& conn, Ctx&& ctx) {
+    using impl::get_connection_error_context;
+    get_connection_error_context(unwrap_connection(conn)) = std::forward<Ctx>(ctx);
+}
+
+/**
+* Reset the connection error context.
+*/
+template <typename T>
+inline Require<Connectable<T>> reset_error_context(T& conn) {
+    using ctx_type = std::decay_t<decltype(get_error_context(conn))>;
+    set_error_context(conn, ctx_type{});
+}
+
+/**
+* Returns type oids map of the connection
+*/
+template <typename T, typename = Require<Connectable<T>>>
+inline decltype(auto) get_oid_map(T&& conn) noexcept {
+    using impl::get_connection_oid_map;
+    return get_connection_oid_map(unwrap_connection(std::forward<T>(conn)));
+}
+
+/**
+* Returns statistics object of the connection
+*/
+template <typename T, typename = Require<Connectable<T>>>
+inline decltype(auto) get_statistics(T&& conn) noexcept {
+    using impl::get_connection_statistics;
+    return get_connection_statistics(unwrap_connection(std::forward<T>(conn)));
+}
+
+// Oid Map helpers
+
+template <typename T, typename C, typename = Require<Connectable<C>>>
+inline decltype(auto) type_oid(C&& conn) noexcept {
+    return type_oid<std::decay_t<T>>(
+        get_oid_map(std::forward<C>(conn)));
+}
+
+template <typename T, typename C, typename = Require<Connectable<C>>>
+inline decltype(auto) type_oid(C&& conn, const T&) noexcept {
+    return type_oid<std::decay_t<T>>(std::forward<C>(conn));
+}
+
+template <typename T, typename C, typename = Require<Connectable<C>>>
+inline void set_type_oid(C&& conn, oid_t oid) noexcept {
+    set_type_oid<T>(get_oid_map(std::forward<C>(conn)), oid);
+}
+
+
+template <typename ConnectionProvider, typename Enable = void>
+struct get_connectiable_type {
+    using type = typename std::decay_t<ConnectionProvider>::connectiable_type;
+};
+
+template <typename ConnectionProvider>
+using connectiable_type = typename get_connectiable_type<ConnectionProvider>::type;
+
+/**
+* Connection is Connection Provider itself, so we need to define connection
+* type it provides.
+*/
+template <typename T>
+struct get_connectiable_type<T, Require<Connectable<T>>> {
+    using type = std::decay_t<T>;
+};
+
+template <typename, typename = std::void_t<>>
+struct is_connection_provider_functor : std::false_type {};
+template <typename T>
+struct is_connection_provider_functor<T, std::void_t<
+    decltype( std::declval<T>() (std::declval<void(error_code, connectiable_type<T>)>()) )
+>> : std::true_type {};
+
+template <typename T>
+constexpr auto ConnectionProviderFunctor = is_connection_provider_functor<std::decay_t<T>>::value;
+
+/**
+* Function to get connection from provider asynchronously via callback. 
+* This is customization point which allows to work with different kinds
+* of connection providing. E.g. single connection, get connection from 
+* pool, lazy connection, retriable connection and so on. 
+*/
+template <typename T, typename Handler>
+inline Require<ConnectionProviderFunctor<T>>
+async_get_connection(T&& provider, Handler&& handler) {
+    provider(std::forward<Handler>(handler));
+}
+
+template <typename T, typename Handler>
+inline Require<Connectable<T>>
+async_get_connection(T&& conn, Handler&& handler) {
+    reset_error_context(conn);
+    decltype(auto) io = get_io_context(conn);
+    io.dispatch(detail::bind(
+        std::forward<Handler>(handler), error_code{}, std::forward<T>(conn)));
+}
+
+template <typename, typename = std::void_t<>>
+struct is_connection_provider : std::false_type {};
+template <typename T>
+struct is_connection_provider<T, std::void_t<decltype(
+    async_get_connection(
+        std::declval<T&>(),
+        std::declval<std::function<void(error_code, connectiable_type<T>)>>()
+    )
+)>> : std::true_type {};
+
+template <typename T>
+constexpr auto ConnectionProvider = is_connection_provider<std::decay_t<T>>::value;
+
+/**
+* Function to get a connection from provider. 
+* Accepts:
+*   provider - connection provider which will be asked for connection
+*   token - completion token which determine the continuation of operation
+*           it can be callback, yield_context, use_future and other Boost.Asio
+*           compatible tokens.
+* Returns:
+*   completion token depent value like void for callback, connection for the
+*   yield_context, std::future<connection> for use_future, and so on.
+*/
+template <typename T, typename CompletionToken, typename = Require<ConnectionProvider<T>>>
+auto get_connection(T&& provider, CompletionToken&& token) {
+    using signature_t = void (error_code, connectiable_type<T>);
+    async_completion<std::decay_t<CompletionToken>, signature_t> init(token);
+
+    async_get_connection(std::forward<T>(provider), 
+            std::move(init.completion_handler));
+
+    return init.result.get();
+}
+
+} // namespace libapq

--- a/include/apq/connection_info.h
+++ b/include/apq/connection_info.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <apq/connection.h>
+#include <apq/async_connect.h>
+
+#include <chrono>
+
+namespace libapq {
+
+template <
+    typename OidMap = empty_oid_map, 
+    typename Statistics = no_statistics>
+class connection_info {
+    io_context& io_;
+    std::string conn_str_;
+    Statistics statistics_;
+
+    using connection = impl::connection<OidMap, Statistics>;
+
+public:
+    using connectiable_type = std::shared_ptr<connection>;
+
+    connection_info(io_context& io, std::string conn_str,
+            Statistics statistics = Statistics{})
+    : io_(io), conn_str_(std::move(conn_str)), statistics_(std::move(statistics)) {}
+
+    template <typename Handler>
+    friend void async_get_connection(const connection_info& self, Handler&& h) {
+        async_connect(self.conn_str_,
+            std::make_shared<connection>(self.io_, self.statistics_),
+            std::forward<Handler>(h));
+    }
+};
+
+static_assert(
+    ConnectionProvider<connection_info<>>,
+    "connection_info does not fit ConnectionProvider concept");
+
+} // namespace libapq

--- a/include/apq/connection_pool.h
+++ b/include/apq/connection_pool.h
@@ -1,13 +1,168 @@
 #pragma once
 
+#include <apq/impl/async_connect.h>
+#include <apq/connection_info.h>
 #include <apq/connection.h>
 #include <yamail/resource_pool/async/pool.hpp>
 
 namespace libapq {
+namespace impl {
 
+template <typename ...Ts>
+using connection_pool = yamail::resource_pool::async::pool<connection<Ts...>>;
+
+template <typename ...Ts>
+struct pooled_connection {
+    using handle_type = yamail::resource_pool::handle<connection_pool<Ts...>>;
+
+    handle_type handle_;
+
+    pooled_connection(handle_type&& handle) : handle_(std::move(handle)) {}
+
+    decltype(auto) empty() const {return handle_.empty();}
+
+    void reset(typename handle_type::value_type&& v) {
+        reset(std::move(v));
+    }
+
+    ~pooled_connection() {
+        if (connection_bad(*this)) {
+            handle_.waste();
+        }
+    }
+
+    friend auto& unwrap_connection(pooled_connection& conn) noexcept {
+        return *(conn.handle_);
+    }
+    friend const auto& unwrap_connection(const pooled_connection& conn) noexcept {
+        return *(conn.handle_);
+    }
+};
+template <typename ...Ts>
+using pooled_connection_ptr = std::shared_ptr<pooled_connection<Ts...>>;
+
+template <typename Connector, typename OidMap, typename Statistics, typename Handler>
+struct pooled_connection_wrapper {
+    io_context& io_;
+    Connector connector_;
+    Statistics statistics_;
+    Handler handler_;
+
+    template <typename Handle>
+    void operator ()(error_code ec, Handle&& handle) {
+        if (ec) {
+            return handler_(std::move(ec), pooled_connection_ptr<OidMap, Statistics>{});
+        }
+
+        auto conn = std::make_shared<pooled_connection<OidMap, Statistics>>(std::move(handle));
+        if (!conn->empty() && connection_good(conn)) {
+            return handler_(std::move(ec), std::move(conn));
+        }
+
+        conn->reset({io_, statistics_});
+        connector_(std::move(conn), std::move<Handler>(handler_));
+    }
+
+    template <typename Func>
+    friend void asio_handler_invoke(Func&& f, pooled_connection_wrapper* ctx) {
+        using ::boost::asio::asio_handler_invoke;
+        asio_handler_invoke(std::forward<Func>(f), std::addressof(ctx->handler_));
+    }
+};
+
+template <typename Connector, typename OidMap, typename Statistics, typename Handler>
+auto wrap_pooled_connection_handler(io_context& io, Connector&& connector,
+    Statistics&& stat, Handler&& handler) {
+    return pooled_connection_wrapper<std::decay_t<Connector>, OidMap,
+            std::decay_t<Statistics>, std::decay_t<Handler>>{
+        io, std::forward<Connector>(connector), std::forward<Statistics>(stat),
+        std::forward<Handler>(handler)};
+}
+
+} // namespace impl
+
+struct async_connector {
+    std::string conn_info_;
+    template <typename T, typename Handler>
+    Require<Connectable<T>> operator()(T&& conn, Handler&& handler) const {
+        async_connect(conn_info_, std::forward<T>(conn),
+            std::forward<Handler>(handler));
+    }
+};
+
+// struct async_timed_connector {
+//     std::string conn_info_;
+//     std::chrono::steady_clock::duration timeout_;
+//     template <typename T, typename Handler>
+//     Require<Connectable<T>> operator()(T&& conn, Handler&& handler) const {
+//         decltype(auto) socket = get_socket(conn);
+//         async_connect(conn_info_, std::forward<T>(conn),
+//             with_timeout(socket, timeout_, std::forward<Handler>(handler)));
+//     }
+// };
+
+static_assert(Connectable<impl::pooled_connection_ptr<empty_oid_map, no_statistics>>,
+    "pooled_connection_ptr is not a Connectable concept");
+
+static_assert(ConnectionProvider<impl::pooled_connection_ptr<empty_oid_map, no_statistics>>,
+    "pooled_connection_ptr is not a ConnectionProvider concept");
+
+template <typename Connector, typename OidMap, typename Statistics>
 class connection_pool {
 public:
-    connection_pool() {}
+    connection_pool(Connector connector, std::size_t capacity,
+         std::size_t queue_capacity, Statistics statistics)
+    : impl_(capacity, queue_capacity), connector_(std::move(connector)),
+      statistics_(std::move(statistics)) {}
+
+    using oid_map_type = OidMap;
+    using statistics_type = Statistics;
+    using duration = yamail::resource_pool::time_traits::duration;
+    using time_point = yamail::resource_pool::time_traits::time_point;
+
+    template <typename Handler>
+    void get_connection(io_context& io, duration timeout, Handler&& handler) {
+        impl_.get_auto_recycle(io,
+            impl::wrap_pooled_connection_handler(
+                io, connector_, statistics_, std::forward<Handler>(handler)),
+            timeout);
+    }
+
+private:
+    impl::connection_pool<OidMap, Statistics> impl_;
+    Connector connector_;
+    Statistics statistics_;
 };
+
+template <typename T>
+struct is_connection_pool : std::false_type {};
+
+template <typename ...Args>
+struct is_connection_pool<connection_pool<Args...>> : std::true_type {};
+
+template <typename T>
+constexpr auto ConnectionPool = is_connection_pool<std::decay_t<T>>::value;
+
+template <
+    typename Connector = async_connector,
+    typename OidMap = empty_oid_map,
+    typename Statistics = no_statistics>
+auto make_connection_pool(Connector&& connector, std::size_t capacity,
+         std::size_t queue_capacity, OidMap&& = OidMap{},
+        Statistics&& statistics = Statistics{}) {
+    return connection_pool<std::decay_t<Connector>,
+            std::decay_t<OidMap>, std::decay_t<Statistics>>{
+        std::forward<Connector>(connector), capacity, queue_capacity,
+        std::forward<Statistics>(statistics)};
+}
+
+template <typename T>
+inline auto make_provider(T& pool, io_context& io,
+    Require<ConnectionPool<T>, typename T::duration> timeout = T::time_point::max()) {
+
+    return [&pool, &io, timeout](auto handler) {
+        pool.get_connection(io, timeout, std::move(handler));
+    };
+}
 
 } // namespace apq

--- a/include/apq/detail/bind.h
+++ b/include/apq/detail/bind.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <tuple>
+#include <utility>
+#include <boost/asio/handler_invoke_hook.hpp>
+
+namespace libapq {
+namespace detail {
+
+/**
+ * This binder preserves handler context just like
+ * boost::asio::detail::bind_handler does. It is
+ * needed because in other case you will loose the handler
+ * context. 
+ * 
+ * For more information see the link below:
+ *
+ *     https://stackoverflow.com/questions/32857101/when-to-use-asio-handler-invoke
+ */
+template <typename Handler, typename Tuple>
+struct binder {
+    Handler handler_;
+    Tuple args_;
+
+    binder(Handler handler, Tuple&& args)
+    : handler_(std::move(handler)), args_(std::move(args)) {}
+
+    auto operator() () { return std::apply(handler_, args_); }
+
+    template <typename Function>
+    friend void asio_handler_invoke(Function&& f, binder* ctx) {
+        using ::boost::asio::asio_handler_invoke;
+        asio_handler_invoke(std::forward<Function>(f), std::addressof(ctx->handler_));
+    }
+};
+
+template <typename Handler, typename ... Args>
+inline auto bind(Handler&& h, Args&& ... args) {
+    return binder<std::decay_t<Handler>, 
+                std::decay_t<decltype(std::make_tuple(std::forward<Args>(args)...))>> (
+        std::forward<Handler>(h), std::make_tuple(std::forward<Args>(args)...));
+}
+
+} // namespace detail
+} // namespace libapq

--- a/include/apq/error.h
+++ b/include/apq/error.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <boost/system/system_error.hpp>
+
+namespace libapq {
+
+using error_code = ::boost::system::error_code;
+using system_error = ::boost::system::system_error;
+using error_category = ::boost::system::error_category;
+
+namespace error {
+
+enum code {
+    ok, // to do not use error code 0
+    pq_connection_start_failed, // PQConnectionStart function failed
+    pq_socket_failed, // PQSocket returned -1 as fd - it seems like there is no connection
+    pq_connection_status_bad, // PQstatus returned CONNECTION_BAD 
+    pq_connect_poll_failed, // PQconnectPoll function failed
+};
+
+const error_category& category() noexcept;
+
+} // namespace error
+} // namespace libapq
+
+namespace boost {
+namespace system {
+
+template <>
+struct is_error_code_enum<libapq::error::code> : std::true_type {};
+
+} // namespace system
+} // namespace boost
+
+namespace libapq {
+namespace error {
+
+inline auto make_error_code(const code e) {
+    return boost::system::error_code(static_cast<int>(e), category());
+}
+
+namespace impl {
+
+class category : public error_category {
+public:
+    const char* name() const throw() { return "libapq::error::category"; }
+
+    std::string message(int value) const {
+        switch (code(value)) {
+            case ok:
+                return "no error";
+            case pq_connection_start_failed:
+                return "pq_connection_start_failed - PQConnectionStart function failed";
+            case pq_socket_failed:
+                return "pq_socket_failed - PQSocket returned -1 as fd - it seems like there is no connection";
+            case pq_connection_status_bad:
+                return "pq_connection_status_bad - PQstatus returned CONNECTION_BAD";
+            case pq_connect_poll_failed:
+                return "pq_connect_poll_failed - PQconnectPoll function failed";
+        }
+        return "no message for value: " + std::to_string(value);
+    }
+};
+
+} // namespace impl
+
+inline const error_category& category() noexcept {
+    static impl::category instance;
+    return instance;
+}
+
+} // namespace error
+} // namespace libapq

--- a/include/apq/impl/async_connect.h
+++ b/include/apq/impl/async_connect.h
@@ -1,0 +1,164 @@
+#pragma once
+
+#include <apq/connection.h>
+#include <apq/error.h>
+#include <apq/detail/bind.h>
+#include <libpq-fe.h>
+
+namespace libapq {
+namespace impl {
+namespace pq {
+
+template <typename T, typename Handler, typename = Require<Connectable<T>>>
+inline void pq_write_poll(T& conn, Handler&& h) {
+    get_socket(conn).async_write_some(
+            asio::null_buffers(), std::forward<Handler>(h));
+}
+
+template <typename T, typename Handler, typename = Require<Connectable<T>>>
+inline void pq_read_poll(T& conn, Handler&& h) {
+    get_socket(conn).async_read_some(
+            asio::null_buffers(), std::forward<Handler>(h));
+}
+
+template <typename T, typename = Require<Connectable<T>>>
+inline decltype(auto) pq_connect_poll(T& conn) {
+    return PQconnectPoll(get_native_handle(conn));
+}
+
+template <typename T, typename = Require<Connectable<T>>>
+inline error_code pq_start_connection(T& conn, const std::string& conninfo) {
+    pg_conn_handle handle(PQconnectStart(conninfo.c_str()), PQfinish);
+    if (!handle) {
+        return make_error_code(error::pq_connection_start_failed);
+    }
+    get_handle(conn) = std::move(handle);
+    return {};
+}
+
+template <typename T, typename = Require<Connectable<T>>>
+inline error_code pq_assign_socket(T& conn) {
+    int fd = PQsocket(get_native_handle(conn));
+    if (fd == -1) {
+        return error::pq_socket_failed;
+    }
+
+    int new_fd = dup(fd);
+    if (new_fd == -1) {
+        set_error_context(conn, "error while dup(fd) for socket stream");
+        return error_code{errno, boost::system::generic_category()};
+    }
+
+    error_code ec;
+    get_socket(conn).assign(new_fd, ec);
+
+    if (ec) {
+        set_error_context(conn, "assign socket failed");
+    }
+    return ec;
+}
+} // namespace pq
+
+template <typename T, typename = Require<Connectable<T>>>
+inline error_code start_connection(T& conn, const std::string& conninfo) {
+    using pq::pq_start_connection;
+    return pq_start_connection(unwrap_connection(conn), conninfo);
+}
+
+template <typename T, typename = Require<Connectable<T>>>
+inline error_code assign_socket(T& conn) {
+    using pq::pq_assign_socket;
+    return pq_assign_socket(unwrap_connection(conn));
+}
+
+template <typename T, typename Handler, typename = Require<Connectable<T>>>
+inline void write_poll(T& conn, Handler&& h) {
+    using pq::pq_write_poll;
+    pq_write_poll(unwrap_connection(conn), std::forward<Handler>(h));
+}
+
+template <typename T, typename Handler, typename = Require<Connectable<T>>>
+inline void read_poll(T& conn, Handler&& h) {
+    using pq::pq_read_poll;
+    pq_read_poll(unwrap_connection(conn), std::forward<Handler>(h));
+}
+
+template <typename T, typename = Require<Connectable<T>>>
+inline decltype(auto) connect_poll(T& conn) {
+    using pq::pq_connect_poll;
+    return pq_connect_poll(unwrap_connection(conn));
+}
+
+/**
+* Asynchronous connection operation
+*/
+template <typename Handler, typename Connection>
+struct async_connect_op {
+    static_assert(Connectable<Connection>,
+        "Connection type does not meet Connectable requirements");
+
+    Connection& conn_;
+    Handler handler_;
+
+    void done(error_code ec = error_code{}) {
+        get_io_context(conn_)
+            .post(detail::bind(std::move(handler_), std::move(ec)));
+    }
+
+    void perform(const std::string& conninfo) {
+        if (error_code ec = start_connection(conn_, conninfo)) {
+            return done(ec);
+        }
+
+        if (connection_bad(conn_)) {
+            return done(error::pq_connection_status_bad);
+        }
+
+        if (error_code ec = assign_socket(conn_)) {
+            return done(ec);
+        }
+
+        return write_poll(conn_, std::move(*this));
+    }
+
+    void operator () (error_code ec, std::size_t = 0) {
+        if (ec) {
+            set_error_context(conn_, "error while connection polling");
+            return done(ec);
+        }
+
+        switch (connect_poll(conn_)) {
+        case PGRES_POLLING_OK:
+            return done();
+
+        case PGRES_POLLING_WRITING:
+            return write_poll(conn_, std::move(*this));
+
+        case PGRES_POLLING_READING:
+            return read_poll(conn_, std::move(*this));
+
+        case PGRES_POLLING_FAILED:
+        case PGRES_POLLING_ACTIVE:
+            break;
+        }
+
+        done(error::pq_connect_poll_failed);
+    }
+
+    template <typename Func>
+    friend void asio_handler_invoke(Func&& f, async_connect_op* ctx) {
+        using ::boost::asio::asio_handler_invoke;
+        asio_handler_invoke(std::forward<Func>(f), std::addressof(ctx->handler_));
+    }
+};
+
+template <typename Connection, typename Handler>
+inline void async_connect(const std::string& conninfo, Connection& conn,
+        Handler&& handler) {
+    async_connect_op<std::decay_t<Handler>, std::decay_t<Connection>> {
+        conn, std::forward<Handler>(handler)
+    }.perform(conninfo);
+}
+
+} // namespace impl
+} // namespace libapq

--- a/include/apq/impl/connection.h
+++ b/include/apq/impl/connection.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include <libpq-fe.h>
+
+#include <apq/asio.h>
+#include <boost/algorithm/string/trim.hpp>
+#include <string>
+#include <sstream>
+
+
+namespace libapq {
+
+namespace impl {
+
+using pg_native_handle_type = PGconn*;
+
+using pg_conn_handle = std::unique_ptr<PGconn, decltype(&PQfinish)>;
+
+template <typename OidMap, typename Statistics>
+struct connection {
+    connection(io_context& io, Statistics statistics)
+    : handle_(nullptr, &PQfinish), socket_(io), statistics_(std::move(statistics)) {}
+
+    pg_conn_handle handle_;
+    asio::posix::stream_descriptor socket_;
+    OidMap oid_map_;
+    Statistics statistics_; // statistics metatypes to be defined - counter, duration, whatever?
+    std::string error_context_;
+};
+
+template <typename ...Ts>
+inline const auto& get_connection_handle(const connection<Ts...>& ctx) noexcept {
+    return ctx.handle_;
+}
+
+template <typename ...Ts>
+inline auto& get_connection_handle(connection<Ts...>& ctx) noexcept {
+    return ctx.handle_;
+}
+
+inline bool connection_status_bad(pg_native_handle_type handle) noexcept {
+    return !handle || PQstatus(handle) == CONNECTION_BAD;
+}
+
+template <typename ...Ts>
+inline const auto& get_connection_socket(
+        const connection<Ts...>& ctx) noexcept {
+    return ctx.socket_;
+}
+
+template <typename ...Ts>
+inline auto& get_connection_socket(
+        connection<Ts...>& ctx) noexcept {
+    return ctx.socket_;
+}
+
+template <typename ...Ts>
+inline const auto& get_connection_oid_map(
+        const connection<Ts...>& ctx) noexcept {
+    return ctx.oid_map_;
+}
+
+template <typename ...Ts>
+inline auto& get_connection_oid_map(
+        connection<Ts...>& ctx) noexcept {
+    return ctx.oid_map_;
+}
+
+template <typename ...Ts>
+inline const auto& get_connection_statistics(
+        const connection<Ts...>& ctx) noexcept {
+    return ctx.statistics_;
+}
+
+template <typename ...Ts>
+inline auto& get_connection_statistics(
+        connection<Ts...>& ctx) noexcept {
+    return ctx.statistics_;
+}
+
+template <typename ...Ts>
+inline auto& get_connection_error_context(connection<Ts...>& ctx) {
+    return ctx.error_context_;
+}
+
+template <typename ...Ts>
+inline const auto& get_connection_error_context(
+        const connection<Ts...>& ctx) {
+    return ctx.error_context_;
+}
+
+inline auto connection_error_message(pg_native_handle_type handle) {
+    std::string_view v(PQerrorMessage(handle));
+    auto trim_pos = v.find_last_not_of(' ');
+    if(trim_pos != v.npos) {
+        v.remove_suffix(v.size() - trim_pos);
+    }
+    return v;
+}
+
+template <typename Connection>
+inline error_code rebind_connection_io_context(Connection& conn, io_context& io) {
+    if (std::addressof(get_io_service(conn)) != std::addressof(io)) {
+        decltype(auto) socket = get_socket(conn);
+        std::decay_t<decltype(socket)> s{io};
+        error_code ec;
+        s.assign(socket.native_handle(), ec);
+        if (ec) {
+            return ec;
+        }
+        socket.release();
+        socket = std::move(s);
+    }
+    return {};
+}
+
+} // namespace impl
+} // namespace libapq

--- a/include/apq/type_traits.h
+++ b/include/apq/type_traits.h
@@ -276,6 +276,8 @@ constexpr decltype(auto) register_types() noexcept {
     );
 }
 
+using empty_oid_map = std::decay_t<decltype(register_types<>())>;
+
 /**
 * Function sets oid for type in oid map.
 */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,8 +27,12 @@ include_directories(SYSTEM "${source_dir}/libs/json/src")
 link_directories("${source_dir}/libs/gherkin-cpp")
 
 set(SOURCES
+    bind.cpp
+    async_connect.cpp
     connection_pool.cpp
     type_traits.cpp
+    connection.cpp
+    connection_info.cpp
 )
 
 set(LIBRARIES
@@ -36,6 +40,7 @@ set(LIBRARIES
     gmock_main
     gherkin-cpp
     ${Boost_LIBRARIES}
+    ${PostgreSQL_LIBRARIES}
 )
 
 add_executable(apq_tests ${SOURCES})

--- a/tests/async_connect.cpp
+++ b/tests/async_connect.cpp
@@ -1,0 +1,297 @@
+#include <apq/impl/async_connect.h>
+#include "test_error.h"
+#include "test_asio.h"
+#include <GUnit/GTest.h>
+
+namespace {
+
+namespace hana = ::boost::hana;
+
+enum class native_handle {bad, good};
+
+inline bool connection_status_bad(const native_handle* h) { 
+    return *h == native_handle::bad;
+}
+
+using libapq::testing::asio_post;
+using libapq::testing::socket_mock;
+using libapq::empty_oid_map;
+
+struct connection_mock {
+    using handler = std::function<void(libapq::error_code)>;
+
+    virtual void write_poll(handler) const = 0;
+    virtual void read_poll(handler) const = 0;
+    virtual int connect_poll() const = 0;
+    virtual libapq::error_code start_connection(const std::string&) = 0;
+    virtual libapq::error_code assign_socket() = 0;
+    virtual ~connection_mock() = default;
+};
+
+using callback_mock = libapq::testing::callback_mock<>;
+using libapq::testing::wrap;
+
+template <typename OidMap = empty_oid_map>
+struct connection {
+    using handle_type = std::unique_ptr<native_handle>;
+
+    handle_type handle_;
+    socket_mock socket_;
+    OidMap oid_map_;
+    connection_mock* mock_ = nullptr;
+    std::string error_context_;
+
+    friend OidMap& get_connection_oid_map(connection& conn) {
+        return conn.oid_map_;
+    }
+    friend const OidMap& get_connection_oid_map(const connection& conn) {
+        return conn.oid_map_;
+    }
+    friend auto& get_connection_socket(connection& conn) {
+        return conn.socket_;
+    }
+    friend const auto& get_connection_socket(const connection& conn) {
+        return conn.socket_;
+    }
+    friend handle_type& get_connection_handle(connection& conn) {
+        return conn.handle_;
+    }
+    friend const handle_type& get_connection_handle(const connection& conn) {
+        return conn.handle_;
+    }
+    friend std::string& get_connection_error_context(connection& conn) {
+        return conn.error_context_;
+    }
+    friend const std::string& get_connection_error_context(const connection& conn) {
+        return conn.error_context_;
+    }
+
+    template <typename Handler>
+    friend void pq_write_poll(connection& c, Handler&& h) {
+        c.mock_->write_poll([h] (auto e) {
+            asio_post(libapq::detail::bind(std::move(h), std::move(e)));
+        });
+    }
+
+    template <typename Handler>
+    friend void pq_read_poll(connection& c, Handler&& h) {
+        c.mock_->read_poll([h] (auto e) {
+            asio_post(libapq::detail::bind(std::move(h), std::move(e)));
+        });
+    }
+
+    friend int pq_connect_poll(connection& c) {
+        return c.mock_->connect_poll();
+    }
+
+    friend libapq::error_code pq_start_connection(
+            connection& c, const std::string& conninfo) {
+        return c.mock_->start_connection(conninfo);
+    }
+
+    friend libapq::error_code pq_assign_socket(connection& c) {
+        return c.mock_->assign_socket();
+    }
+};
+
+template <typename ...Ts>
+using connection_ptr = std::shared_ptr<connection<Ts...>>;
+
+static_assert(libapq::Connection<connection<>>,
+    "connection does not meet Connection requirements");
+static_assert(libapq::ConnectionWrapper<connection_ptr<>>,
+    "connection_ptr does not meet ConnectionWrapper requirements");
+static_assert(libapq::Connectable<connection<>>,
+    "connection does not meet Connectable requirements");
+static_assert(libapq::Connectable<connection_ptr<>>,
+    "connection_ptr does not meet Connectable requirements");
+
+inline auto make_connection(connection_mock& mock) {
+    return std::make_shared<connection<>>(connection<>{
+            std::make_unique<native_handle>(native_handle::bad),
+            socket_mock{},
+            empty_oid_map{},
+            std::addressof(mock),
+            ""
+        });
+}
+
+GTEST("libapq::async_connect()") {
+    using namespace testing;
+    using libapq::error_code;
+
+    SHOULD("start connection, assign socket and wait for write complete") {
+        StrictGMock<connection_mock> conn_mock{};
+        StrictGMock<callback_mock> cb_mock{};
+        auto conn = make_connection(object(conn_mock));
+        *(conn->handle_) = native_handle::good;
+
+        EXPECT_CALL(conn_mock, (start_connection)("conninfo")).WillOnce(Return(error_code{}));
+        EXPECT_CALL(conn_mock, (assign_socket)()).WillOnce(Return(error_code{}));
+        EXPECT_CALL(conn_mock, (write_poll)(_));
+        libapq::impl::async_connect("conninfo", conn, wrap(cb_mock));
+    }
+
+    SHOULD("call handler with pq_connection_start_failed on error in start_connection") {
+        StrictGMock<connection_mock> conn_mock{};
+        StrictGMock<callback_mock> cb_mock{};
+        auto conn = make_connection(object(conn_mock));
+        *(conn->handle_) = native_handle::good;
+
+        EXPECT_CALL(conn_mock, (start_connection)("conninfo"))
+            .WillOnce(Return(error_code{libapq::error::pq_connection_start_failed}));
+
+        EXPECT_INVOKE(cb_mock, context_preserved);
+        EXPECT_INVOKE(cb_mock, call, error_code{libapq::error::pq_connection_start_failed});
+
+        libapq::impl::async_connect("conninfo", conn, wrap(cb_mock));
+    }
+
+    SHOULD("call handler with pq_connection_status_bad if connection status is bad") {
+        StrictGMock<connection_mock> conn_mock{};
+        StrictGMock<callback_mock> cb_mock{};
+        auto conn = make_connection(object(conn_mock));
+        *(conn->handle_) = native_handle::bad;
+
+        EXPECT_CALL(conn_mock, (start_connection)("conninfo")).WillOnce(Return(error_code{}));
+
+        EXPECT_INVOKE(cb_mock, context_preserved);
+        EXPECT_INVOKE(cb_mock, call, error_code{libapq::error::pq_connection_status_bad});
+
+        libapq::impl::async_connect("conninfo", conn, wrap(cb_mock));
+    }
+
+    SHOULD("call handler with error if assign_socket returns error") {
+        StrictGMock<connection_mock> conn_mock{};
+        StrictGMock<callback_mock> cb_mock{};
+        auto conn = make_connection(object(conn_mock));
+        *(conn->handle_) = native_handle::good;
+
+        EXPECT_CALL(conn_mock, (start_connection)("conninfo")).WillOnce(Return(error_code{}));
+        EXPECT_CALL(conn_mock, (assign_socket)()).WillOnce(Return(error_code{libapq::testing::error::error}));
+
+        EXPECT_INVOKE(cb_mock, context_preserved);
+        EXPECT_INVOKE(cb_mock, call, error_code{libapq::testing::error::error});
+
+        libapq::impl::async_connect("conninfo", conn, wrap(cb_mock));
+    }
+
+    SHOULD("wait for write complete if connect_poll() returns PGRES_POLLING_WRITING") {
+        StrictGMock<connection_mock> conn_mock{};
+        StrictGMock<callback_mock> cb_mock{};
+        auto conn = make_connection(object(conn_mock));
+        *(conn->handle_) = native_handle::good;
+
+        testing::InSequence s;
+        EXPECT_CALL(conn_mock, (start_connection)("conninfo")).WillOnce(Return(error_code{}));
+        EXPECT_CALL(conn_mock, (assign_socket)()).WillOnce(Return(error_code{}));
+
+        EXPECT_CALL(conn_mock, (write_poll)(_)).WillOnce(InvokeArgument<0>(error_code{}));
+        EXPECT_INVOKE(cb_mock, context_preserved);
+
+        EXPECT_CALL(conn_mock, (connect_poll)()).WillOnce(Return(PGRES_POLLING_WRITING));
+
+        EXPECT_CALL(conn_mock, (write_poll)(_));
+        libapq::impl::async_connect("conninfo", conn, wrap(cb_mock));
+    }
+
+    SHOULD("wait for read complete if connect_poll() returns PGRES_POLLING_READING") {
+        StrictGMock<connection_mock> conn_mock{};
+        StrictGMock<callback_mock> cb_mock{};
+        auto conn = make_connection(object(conn_mock));
+        *(conn->handle_) = native_handle::good;
+
+        testing::InSequence s;
+        EXPECT_CALL(conn_mock, (start_connection)("conninfo")).WillOnce(Return(error_code{}));
+        EXPECT_CALL(conn_mock, (assign_socket)()).WillOnce(Return(error_code{}));
+
+        EXPECT_CALL(conn_mock, (write_poll)(_)).WillOnce(InvokeArgument<0>(error_code{}));
+        EXPECT_INVOKE(cb_mock, context_preserved);
+
+        EXPECT_CALL(conn_mock, (connect_poll)()).WillOnce(Return(PGRES_POLLING_READING));
+
+        EXPECT_CALL(conn_mock, (read_poll)(_));
+        libapq::impl::async_connect("conninfo", conn, wrap(cb_mock));
+    }
+
+    SHOULD("call handler with no error if connect_poll() returns PGRES_POLLING_OK") {
+        StrictGMock<connection_mock> conn_mock{};
+        StrictGMock<callback_mock> cb_mock{};
+        auto conn = make_connection(object(conn_mock));
+        *(conn->handle_) = native_handle::good;
+
+        testing::InSequence s;
+        EXPECT_CALL(conn_mock, (start_connection)("conninfo")).WillOnce(Return(error_code{}));
+        EXPECT_CALL(conn_mock, (assign_socket)()).WillOnce(Return(error_code{}));
+
+        EXPECT_CALL(conn_mock, (write_poll)(_)).WillOnce(InvokeArgument<0>(error_code{}));
+        EXPECT_INVOKE(cb_mock, context_preserved);
+
+        EXPECT_CALL(conn_mock, (connect_poll)()).WillOnce(Return(PGRES_POLLING_OK));
+
+        EXPECT_INVOKE(cb_mock, context_preserved);
+        EXPECT_INVOKE(cb_mock, call, error_code{});
+        libapq::impl::async_connect("conninfo", conn, wrap(cb_mock));
+    }
+
+    SHOULD("call handler with pq_connect_poll_failed if connect_poll() returns PGRES_POLLING_FAILED") {
+        StrictGMock<connection_mock> conn_mock{};
+        StrictGMock<callback_mock> cb_mock{};
+        auto conn = make_connection(object(conn_mock));
+        *(conn->handle_) = native_handle::good;
+
+        testing::InSequence s;
+        EXPECT_CALL(conn_mock, (start_connection)("conninfo")).WillOnce(Return(error_code{}));
+        EXPECT_CALL(conn_mock, (assign_socket)()).WillOnce(Return(error_code{}));
+
+        EXPECT_CALL(conn_mock, (write_poll)(_)).WillOnce(InvokeArgument<0>(error_code{}));
+        EXPECT_INVOKE(cb_mock, context_preserved);
+
+        EXPECT_CALL(conn_mock, (connect_poll)()).WillOnce(Return(PGRES_POLLING_FAILED));
+
+        EXPECT_INVOKE(cb_mock, context_preserved);
+        EXPECT_INVOKE(cb_mock, call, error_code{libapq::error::pq_connect_poll_failed});
+        libapq::impl::async_connect("conninfo", conn, wrap(cb_mock));
+    }
+
+    SHOULD("call handler with pq_connect_poll_failed if connect_poll() returns PGRES_POLLING_ACTIVE") {
+        StrictGMock<connection_mock> conn_mock{};
+        StrictGMock<callback_mock> cb_mock{};
+        auto conn = make_connection(object(conn_mock));
+        *(conn->handle_) = native_handle::good;
+
+        testing::InSequence s;
+        EXPECT_CALL(conn_mock, (start_connection)("conninfo")).WillOnce(Return(error_code{}));
+        EXPECT_CALL(conn_mock, (assign_socket)()).WillOnce(Return(error_code{}));
+
+        EXPECT_CALL(conn_mock, (write_poll)(_)).WillOnce(InvokeArgument<0>(error_code{}));
+        EXPECT_INVOKE(cb_mock, context_preserved);
+
+        EXPECT_CALL(conn_mock, (connect_poll)()).WillOnce(Return(PGRES_POLLING_ACTIVE));
+
+        EXPECT_INVOKE(cb_mock, context_preserved);
+        EXPECT_INVOKE(cb_mock, call, error_code{libapq::error::pq_connect_poll_failed});
+        libapq::impl::async_connect("conninfo", conn, wrap(cb_mock));
+    }
+
+    SHOULD("call handler with the error if polling operation invokes callback with it") {
+        StrictGMock<connection_mock> conn_mock{};
+        StrictGMock<callback_mock> cb_mock{};
+        auto conn = make_connection(object(conn_mock));
+        *(conn->handle_) = native_handle::good;
+
+        testing::InSequence s;
+        EXPECT_CALL(conn_mock, (start_connection)("conninfo")).WillOnce(Return(error_code{}));
+        EXPECT_CALL(conn_mock, (assign_socket)()).WillOnce(Return(error_code{}));
+
+        EXPECT_CALL(conn_mock, (write_poll)(_))
+            .WillOnce(InvokeArgument<0>(libapq::testing::error::error));
+        EXPECT_INVOKE(cb_mock, context_preserved);
+
+        EXPECT_INVOKE(cb_mock, context_preserved);
+        EXPECT_INVOKE(cb_mock, call, error_code{libapq::testing::error::error});
+        libapq::impl::async_connect("conninfo", conn, wrap(cb_mock));
+    }
+}
+
+} // namespace

--- a/tests/bind.cpp
+++ b/tests/bind.cpp
@@ -1,0 +1,54 @@
+#include <apq/detail/bind.h>
+#include <GUnit/GTest.h>
+
+template <typename Handler>
+inline void asio_post(Handler h) {
+    using boost::asio::asio_handler_invoke;
+    asio_handler_invoke(h, std::addressof(h));
+}
+
+struct callback_mock {
+    virtual void call(int) const = 0;
+    virtual void context_preserved() const = 0;
+    virtual ~callback_mock() = default;
+};
+
+struct callback_handler {
+    callback_mock& mock;
+
+    void operator() (int arg) const {
+        mock.call(arg);
+    }
+
+    template <typename Func>
+    friend void asio_handler_invoke(Func&& f, callback_handler* ctx) {
+        ctx->mock.context_preserved();
+        f();
+    }
+};
+
+inline auto wrap(callback_mock& mock) {
+    return callback_handler{mock};
+}
+
+GTEST("libapq::detail::bind()") {
+    SHOULD("preserve handler context") {
+        using namespace ::testing;
+        StrictGMock<callback_mock> cb_mock{};
+
+        EXPECT_INVOKE(cb_mock, context_preserved);
+        EXPECT_INVOKE(cb_mock, call, _);
+
+        asio_post(libapq::detail::bind(wrap(object(cb_mock)), 42));
+    }
+
+    SHOULD("forward binded value") {
+        using namespace ::testing;
+        StrictGMock<callback_mock> cb_mock{};
+
+        EXPECT_INVOKE(cb_mock, context_preserved);
+        EXPECT_INVOKE(cb_mock, call, 42);
+
+        asio_post(libapq::detail::bind(wrap(object(cb_mock)), 42));
+    }
+}

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -1,0 +1,192 @@
+#include <apq/connection.h>
+
+#include <boost/make_shared.hpp>
+#include <boost/fusion/adapted/std_tuple.hpp>
+#include <boost/fusion/adapted/struct/define_struct.hpp>
+#include <boost/fusion/include/define_struct.hpp>
+
+#include <boost/hana/adapt_adt.hpp>
+
+#include "test_asio.h"
+
+#include <GUnit/GTest.h>
+
+namespace {
+
+namespace hana = ::boost::hana;
+
+enum class native_handle { bad, good };
+
+using libapq::testing::socket_mock;
+
+inline bool connection_status_bad(const native_handle* h) {
+    return *h == native_handle::bad;
+}
+
+using libapq::empty_oid_map;
+
+template <typename OidMap = empty_oid_map>
+struct connection {
+    using handle_type = std::unique_ptr<native_handle>;
+
+    handle_type handle_ = std::make_unique<native_handle>();
+    socket_mock socket_;
+    OidMap oid_map_;
+    std::string error_context_;
+
+    friend OidMap& get_connection_oid_map(connection& conn) {
+        return conn.oid_map_;
+    }
+    friend const OidMap& get_connection_oid_map(const connection& conn) {
+        return conn.oid_map_;
+    }
+    friend socket_mock& get_connection_socket(connection& conn) {
+        return conn.socket_;
+    }
+    friend const socket_mock& get_connection_socket(const connection& conn) {
+        return conn.socket_;
+    }
+    friend handle_type& get_connection_handle(connection& conn) {
+        return conn.handle_;
+    }
+    friend const handle_type& get_connection_handle(const connection& conn) {
+        return conn.handle_;
+    }
+    friend std::string& get_connection_error_context(connection& conn) {
+        return conn.error_context_;
+    }
+    friend const std::string& get_connection_error_context(const connection& conn) {
+        return conn.error_context_;
+    }
+};
+
+template <typename ...Ts>
+using connection_ptr = std::shared_ptr<connection<Ts...>>;
+
+static_assert(libapq::Connection<connection<>>,
+    "connection does not meet Connection requirements");
+static_assert(libapq::ConnectionWrapper<connection_ptr<>>,
+    "connection_ptr does not meet ConnectionWrapper requirements");
+static_assert(libapq::Connectable<connection<>>,
+    "connection does not meet Connectable requirements");
+static_assert(libapq::Connectable<connection_ptr<>>,
+    "connection_ptr does not meet Connectable requirements");
+
+static_assert(!libapq::Connection<int>,
+    "int meets Connection requirements unexpectedly");
+static_assert(!libapq::ConnectionWrapper<int>,
+    "int meets ConnectionWrapper requirements unexpectedly");
+static_assert(!libapq::Connectable<int>,
+    "int meets Connectable requirements unexpectedly");
+
+GTEST("libapq::connection_good()") {
+    SHOULD("for object with bad handle returns false") {
+        auto conn = std::make_shared<connection<>>();
+        *(conn->handle_) = native_handle::bad;
+        EXPECT_FALSE(libapq::connection_good(conn));
+    }
+
+    SHOULD("for object with nullptr returns false") {
+        connection_ptr<> conn;
+        EXPECT_FALSE(libapq::connection_good(conn));
+    }
+
+    SHOULD("for object with good handle returns true") {
+        auto conn = std::make_shared<connection<>>();
+        *(conn->handle_) = native_handle::good;
+        EXPECT_TRUE(libapq::connection_good(conn));
+    }
+}
+
+GTEST("libapq::connection_bad()") {
+    SHOULD("for object with bad handle returns true") {
+        auto conn = std::make_shared<connection<>>();
+        *(conn->handle_) = native_handle::bad;
+        EXPECT_TRUE(libapq::connection_bad(conn));
+    }
+
+    SHOULD("for object with nullptr returns true") {
+        connection_ptr<> conn;
+        EXPECT_FALSE(libapq::connection_good(conn));
+    }
+
+    SHOULD("for object with good handle returns false") {
+        auto conn = std::make_shared<connection<>>();
+        *(conn->handle_) = native_handle::good;
+        EXPECT_FALSE(libapq::connection_bad(conn));
+    }
+}
+
+GTEST("libapq::unwrap_connection()") {
+    SHOULD("for wrapped connection returns connection reference") {
+        auto conn = std::make_shared<connection<>>();
+
+        EXPECT_EQ(
+            std::addressof(libapq::unwrap_connection(conn)),
+            conn.get()
+        );
+    }
+
+    SHOULD("for connection returns reference to itself") {
+        auto conn = connection<>();
+
+        EXPECT_EQ(
+            std::addressof(libapq::unwrap_connection(conn)),
+            std::addressof(conn)
+        );
+    }
+}
+
+GTEST("libapq::get_error_context()") {
+    SHOULD("for connection returns reference to error_context_") {
+        auto conn = std::make_shared<connection<>>();
+
+        EXPECT_EQ(
+            std::addressof(libapq::get_error_context(conn)),
+            std::addressof(conn->error_context_)
+        );
+    }
+}
+
+GTEST("libapq::set_error_context()") {
+    SHOULD("for connection sets error_context_") {
+        auto conn = std::make_shared<connection<>>();
+        libapq::set_error_context(conn, "brand new super context");
+
+        EXPECT_EQ(conn->error_context_, "brand new super context");
+    }
+}
+
+GTEST("libapq::reset_error_context()") {
+    SHOULD("for connection resets error_context_ into empty string") {
+        auto conn = std::make_shared<connection<>>();
+        conn->error_context_ = "brand new super context";
+        libapq::reset_error_context(conn);
+        EXPECT_TRUE(conn->error_context_.empty());
+    }
+}
+
+GTEST("libapq::get_connection()") {
+    using callback_mock = libapq::testing::callback_mock<std::shared_ptr<connection<>>>;
+    using libapq::testing::wrap;
+    using libapq::error_code;
+    using namespace ::testing;
+
+    SHOULD("pass through the connection to handler") {
+        auto conn = std::make_shared<connection<>>();
+        StrictGMock<callback_mock> cb_mock{};
+        EXPECT_INVOKE(cb_mock, context_preserved);
+        EXPECT_CALL(cb_mock, (call)(error_code{}, conn));
+        libapq::get_connection(conn, wrap(cb_mock));
+    }
+
+    SHOULD("resets connection error context") {
+        auto conn = std::make_shared<connection<>>();
+        conn->error_context_ = "some context here";
+        libapq::get_connection(conn, [](error_code, auto conn) {
+            EXPECT_TRUE(conn->error_context_.empty());
+        });
+    }
+}
+
+} //namespace

--- a/tests/connection_info.cpp
+++ b/tests/connection_info.cpp
@@ -1,0 +1,17 @@
+#include <apq/connection_info.h>
+#include <GUnit/GTest.h>
+
+
+GTEST("libapq::connection_info") {
+    SHOULD("return error and bad connect for invalid connection info") {
+        libapq::io_context io;
+        libapq::connection_info<> conn_info(io, "invalid connection info");
+
+        libapq::get_connection(conn_info, [](libapq::error_code ec, auto conn){
+            EXPECT_TRUE(ec);
+            EXPECT_TRUE(libapq::connection_bad(conn));
+        });
+
+        io.run();
+    }
+}

--- a/tests/connection_pool.cpp
+++ b/tests/connection_pool.cpp
@@ -2,6 +2,8 @@
 
 #include <GUnit/GTest.h>
 
-GTEST("libapq::connection_pool", "[constructor should not throw]") {
-    EXPECT_NO_THROW(libapq::connection_pool());
+GTEST("libapq::make_connection_pool") {
+    SHOULD("not throw") {
+        EXPECT_NO_THROW(libapq::make_connection_pool("conn info string", 1, 1));
+    }
 }

--- a/tests/test_asio.h
+++ b/tests/test_asio.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <apq/asio.h>
+
+#include <GUnit/GTest.h>
+
+namespace libapq {
+namespace testing {
+
+template <typename Handler>
+void asio_post(Handler h) {
+    using boost::asio::asio_handler_invoke;
+    asio_handler_invoke(h, std::addressof(h));
+}
+
+struct socket_mock {
+    socket_mock& get_io_service() { return *this;}
+    template <typename Handler>
+    void post(Handler&& h) {
+        asio_post(std::forward<Handler>(h));
+    }
+    template <typename Handler>
+    void dispatch(Handler&& h) {
+        asio_post(std::forward<Handler>(h));
+    }
+};
+
+template <typename ... Args>
+struct callback_mock {
+    virtual void call(libapq::error_code, Args...) const = 0;
+    virtual void context_preserved() const = 0;
+    virtual ~callback_mock() = default;
+};
+
+template <typename M>
+struct callback_handler{
+    M& mock_;
+
+    template <typename ...Args>
+    void operator() (libapq::error_code ec, Args&&... args) const {
+        mock_.call(ec, std::forward<Args>(args)...);
+    }
+
+    template <typename Func>
+    friend void asio_handler_invoke(Func&& f, callback_handler* ctx) {
+        ctx->mock_.context_preserved();
+        f();
+    }
+};
+
+template <typename T>
+inline callback_handler<typename T::type> wrap(T& mock) {
+    return {object(mock)};
+}
+
+
+} // namespace testing
+} // namespace libapq

--- a/tests/test_error.h
+++ b/tests/test_error.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <boost/system/system_error.hpp>
+
+namespace libapq {
+namespace testing {
+namespace error {
+
+enum code {
+    ok, // to do no use error code 0
+    error, // error
+};
+
+namespace detail {
+
+class category : public error_category {
+public:
+    const char* name() const throw() { return "yamail::resource_pool::error::detail::category"; }
+
+    std::string message(int value) const {
+        switch (code(value)) {
+            case ok:
+                return "no error";
+            case error:
+                return "test error";
+        }
+        std::ostringstream error;
+        error << "no message for value: " << value;
+        return error.str();
+    }
+};
+
+} // namespace detail
+
+inline const error_category& get_category() {
+    static detail::category instance;
+    return instance;
+}
+
+} // namespace error
+} // namespace testing
+} // namespace libapq
+
+namespace boost {
+namespace system {
+
+template <>
+struct is_error_code_enum<libapq::testing::error::code> : std::true_type {};
+
+} // namespace system
+} // namespace boost
+
+namespace libapq {
+namespace testing {
+namespace error {
+
+inline auto make_error_code(const code e) {
+    return boost::system::error_code(static_cast<int>(e), get_category());
+}
+
+} // namespace error
+} // namespace testing
+} // namespace libapq


### PR DESCRIPTION
Connection is a category which is defined in apq/connection.h
To obtain connection ConnectionProvider must exists. ConnectionProvider
category is defined in apq/connection.h too. Connection is
ConnectionProvider itself. To obtain a connection from connection
provider get_connection() function exists.
Connectable is a category of objects which contains Connection.
Connection is Connectable itself. Wrapped connection is Connectable
if wrapper is ConnectionWrapper.

The basic implementation of the Connection category can be found
in apq/impl/connection.h.

Calss connection_info is a ConnectionProvider which creates connection
via connection info string. To perform the connection async_connect
operation is defined.