### PR TITLE
Fix connection pool io context rebinding

### DIFF
--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -166,8 +166,8 @@ inline decltype(auto) get_io_context(T& conn) noexcept {
 /**
 * Rebinds io_context for the connection
 */
-template <typename T, typename = Require<Connectable<T>>>
-inline error_code rebind_io_context(T& conn, io_context& io) {
+template <typename T, typename IoContext, typename = Require<Connectable<T>>>
+inline error_code rebind_io_context(T& conn, IoContext& io) {
     using impl::rebind_connection_io_context;
     return rebind_connection_io_context(unwrap_connection(conn), io);
 }

--- a/include/ozo/connection_pool.h
+++ b/include/ozo/connection_pool.h
@@ -2,6 +2,7 @@
 
 #include <ozo/impl/connection_pool.h>
 #include <ozo/connection_info.h>
+#include <ozo/asio.h>
 
 namespace ozo {
 
@@ -25,7 +26,7 @@ public:
     template <typename Handler>
     void get_connection(io_context& io, duration timeout, Handler&& handler) {
         impl_.get_auto_recycle(io,
-            impl::wrap_pooled_connection_handler(provider_, std::forward<Handler>(handler)),
+            impl::wrap_pooled_connection_handler(io, provider_, std::forward<Handler>(handler)),
             timeout);
     }
 

--- a/include/ozo/impl/connection.h
+++ b/include/ozo/impl/connection.h
@@ -98,8 +98,8 @@ inline auto connection_error_message(pg_native_handle_type handle) {
     return v;
 }
 
-template <typename Connection>
-inline error_code rebind_connection_io_context(Connection& conn, io_context& io) {
+template <typename Connection, typename IoContext>
+inline error_code rebind_connection_io_context(Connection& conn, IoContext& io) {
     if (std::addressof(get_io_context(conn)) != std::addressof(io)) {
         decltype(auto) socket = get_socket(conn);
         std::decay_t<decltype(socket)> s{io};

--- a/include/ozo/impl/connection.h
+++ b/include/ozo/impl/connection.h
@@ -100,7 +100,7 @@ inline auto connection_error_message(pg_native_handle_type handle) {
 
 template <typename Connection>
 inline error_code rebind_connection_io_context(Connection& conn, io_context& io) {
-    if (std::addressof(get_io_service(conn)) != std::addressof(io)) {
+    if (std::addressof(get_io_context(conn)) != std::addressof(io)) {
         decltype(auto) socket = get_socket(conn);
         std::decay_t<decltype(socket)> s{io};
         error_code ec;

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -1,20 +1,25 @@
+#include "test_asio.h"
+
 #include <ozo/connection.h>
 
 #include <boost/make_shared.hpp>
 #include <boost/fusion/adapted/std_tuple.hpp>
 #include <boost/fusion/adapted/struct/define_struct.hpp>
 #include <boost/fusion/include/define_struct.hpp>
-
 #include <boost/hana/adapt_adt.hpp>
-
-#include "test_asio.h"
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
 namespace {
 
-namespace hana = ::boost::hana;
+namespace hana = boost::hana;
+
+using namespace testing;
+using namespace ozo::testing;
+
+using ozo::error_code;
+using ozo::empty_oid_map;
 
 enum class native_handle { bad, good };
 
@@ -22,17 +27,45 @@ inline bool connection_status_bad(const native_handle* h) {
     return *h == native_handle::bad;
 }
 
-using ozo::empty_oid_map;
-
-struct socket_mock {
-    socket_mock& get_io_service() { return *this;}
+struct io_context_mock {
     template <typename Handler>
     void post(Handler&& h) {
-        ozo::testing::asio_post(std::forward<Handler>(h));
+        asio_post(std::forward<Handler>(h));
     }
+
     template <typename Handler>
     void dispatch(Handler&& h) {
-        ozo::testing::asio_post(std::forward<Handler>(h));
+        asio_post(std::forward<Handler>(h));
+    }
+};
+
+struct native_handle_mock {
+    MOCK_METHOD1(assign, void (ozo::error_code&));
+    MOCK_METHOD0(release, void ());
+};
+
+struct socket_mock {
+    io_context_mock* io_;
+    std::shared_ptr<native_handle_mock> native_handle_ = std::make_shared<native_handle_mock>();
+
+    socket_mock(io_context_mock& io) : io_(std::addressof(io)) {}
+
+    io_context_mock& get_io_service() {
+        return *io_;
+    }
+
+    void assign(std::shared_ptr<native_handle_mock> handle, ozo::error_code& ec) {
+        native_handle_ = std::move(handle);
+        native_handle_->assign(ec);
+    }
+
+    std::shared_ptr<native_handle_mock> native_handle() const {
+        return native_handle_;
+    }
+
+    void release() {
+        native_handle_->release();
+        native_handle_.reset();
     }
 };
 
@@ -44,6 +77,8 @@ struct connection {
     socket_mock socket_;
     OidMap oid_map_;
     std::string error_context_;
+
+    explicit connection(io_context_mock& io) : socket_(io) {}
 
     friend OidMap& get_connection_oid_map(connection& conn) {
         return conn.oid_map_;
@@ -90,42 +125,51 @@ static_assert(!ozo::ConnectionWrapper<int>,
 static_assert(!ozo::Connectable<int>,
     "int meets Connectable requirements unexpectedly");
 
-TEST(connection_good, should_return_false_for_object_with_bad_handle) {
-    auto conn = std::make_shared<connection<>>();
+struct connection_good : Test {
+    io_context_mock io;
+};
+
+TEST_F(connection_good, should_return_false_for_object_with_bad_handle) {
+    auto conn = std::make_shared<connection<>>(io);
     *(conn->handle_) = native_handle::bad;
     EXPECT_FALSE(ozo::connection_good(conn));
 }
 
-TEST(connection_good, should_return_false_for_object_with_nullptr) {
+TEST_F(connection_good, should_return_false_for_object_with_nullptr) {
     connection_ptr<> conn;
     EXPECT_FALSE(ozo::connection_good(conn));
 }
 
-TEST(connection_good, should_return_true_for_object_with_good_handle) {
-    auto conn = std::make_shared<connection<>>();
+TEST_F(connection_good, should_return_true_for_object_with_good_handle) {
+    auto conn = std::make_shared<connection<>>(io);
     *(conn->handle_) = native_handle::good;
     EXPECT_TRUE(ozo::connection_good(conn));
 }
 
-TEST(connection_bad, should_return_true_for_object_with_bad_handle) {
-    auto conn = std::make_shared<connection<>>();
+struct connection_bad : Test {
+    io_context_mock io;
+};
+
+TEST_F(connection_bad, should_return_true_for_object_with_bad_handle) {
+    auto conn = std::make_shared<connection<>>(io);
     *(conn->handle_) = native_handle::bad;
     EXPECT_TRUE(ozo::connection_bad(conn));
 }
 
-TEST(connection_bad, should_return_true_for_object_with_nullptr) {
+TEST_F(connection_bad, should_return_true_for_object_with_nullptr) {
     connection_ptr<> conn;
     EXPECT_TRUE(ozo::connection_bad(conn));
 }
 
-TEST(connection_bad, should_return_false_for_object_with_good_handle) {
-    auto conn = std::make_shared<connection<>>();
+TEST_F(connection_bad, should_return_false_for_object_with_good_handle) {
+    auto conn = std::make_shared<connection<>>(io);
     *(conn->handle_) = native_handle::good;
     EXPECT_FALSE(ozo::connection_bad(conn));
 }
 
 TEST(unwrap_connection, should_return_connection_reference_for_connection_wrapper) {
-    auto conn = std::make_shared<connection<>>();
+    io_context_mock io;
+    auto conn = std::make_shared<connection<>>(io);
 
     EXPECT_EQ(
         std::addressof(ozo::unwrap_connection(conn)),
@@ -134,7 +178,8 @@ TEST(unwrap_connection, should_return_connection_reference_for_connection_wrappe
 }
 
 TEST(unwrap_connection, should_return_argument_reference_for_connection) {
-    auto conn = connection<>();
+    io_context_mock io;
+    connection<> conn(io);
 
     EXPECT_EQ(
         std::addressof(ozo::unwrap_connection(conn)),
@@ -143,7 +188,8 @@ TEST(unwrap_connection, should_return_argument_reference_for_connection) {
 }
 
 TEST(get_error_context, should_returns_reference_to_error_context) {
-    auto conn = std::make_shared<connection<>>();
+    io_context_mock io;
+    auto conn = std::make_shared<connection<>>(io);
 
     EXPECT_EQ(
         std::addressof(ozo::get_error_context(conn)),
@@ -152,38 +198,70 @@ TEST(get_error_context, should_returns_reference_to_error_context) {
 }
 
 TEST(set_error_context, should_set_error_context) {
-    auto conn = std::make_shared<connection<>>();
+    io_context_mock io;
+    auto conn = std::make_shared<connection<>>(io);
     ozo::set_error_context(conn, "brand new super context");
 
     EXPECT_EQ(conn->error_context_, "brand new super context");
 }
 
 TEST(reset_error_context, should_resets_error_context) {
-    auto conn = std::make_shared<connection<>>();
+    io_context_mock io;
+    auto conn = std::make_shared<connection<>>(io);
     conn->error_context_ = "brand new super context";
     ozo::reset_error_context(conn);
     EXPECT_TRUE(conn->error_context_.empty());
 }
 
-using ozo::error_code;
-using namespace ::testing;
+struct async_get_connection : Test {
+    io_context_mock io;
+};
 
-TEST(get_connection, should_pass_through_the_connection_to_handler) {
-    auto conn = std::make_shared<connection<>>();
-    using callback_mock = ozo::testing::callback_gmock<decltype(conn)>;
-    using ozo::testing::wrap;
+TEST_F(async_get_connection, should_pass_through_the_connection_to_handler) {
+    auto conn = std::make_shared<connection<>>(io);
+    using callback_mock = callback_gmock<decltype(conn)>;
     StrictMock<callback_mock> cb_mock{};
     EXPECT_CALL(cb_mock, context_preserved()).WillOnce(Return());
     EXPECT_CALL(cb_mock, call(error_code{}, conn)).WillOnce(Return());
-    ozo::get_connection(conn, wrap(cb_mock));
+    ozo::async_get_connection(conn, wrap(cb_mock));
 }
 
-TEST(get_connection, should_reset_connection_error_context) {
-    auto conn = std::make_shared<connection<>>();
+TEST_F(async_get_connection, should_reset_connection_error_context) {
+    auto conn = std::make_shared<connection<>>(io);
     conn->error_context_ = "some context here";
-    ozo::get_connection(conn, [](error_code, auto conn) {
+    ozo::async_get_connection(conn, [](error_code, auto conn) {
         EXPECT_TRUE(conn->error_context_.empty());
     });
+}
+
+TEST(rebind_connection_io_context, should_leave_same_io_context_and_socket_when_address_of_new_io_is_equal_to_old) {
+    io_context_mock io;
+    connection<> conn(io);
+    EXPECT_EQ(ozo::impl::rebind_connection_io_context(conn, io), error_code());
+    EXPECT_EQ(std::addressof(ozo::get_io_context(conn)), std::addressof(io));
+}
+
+TEST(rebind_connection_io_context, should_change_socket_when_address_of_new_io_is_not_equal_to_old) {
+    io_context_mock old_io;
+    connection<> conn(old_io);
+    io_context_mock new_io;
+
+    EXPECT_CALL(*ozo::get_socket(conn).native_handle(), assign(_)).WillOnce(Return());
+    EXPECT_CALL(*ozo::get_socket(conn).native_handle(), release()).WillOnce(Return());
+
+    EXPECT_EQ(ozo::impl::rebind_connection_io_context(conn, new_io), error_code());
+    EXPECT_EQ(std::addressof(ozo::get_io_context(conn)), std::addressof(new_io));
+}
+
+TEST(rebind_connection_io_context, should_return_error_when_socket_assign_fails_with_error) {
+    io_context_mock old_io;
+    connection<> conn(old_io);
+    io_context_mock new_io;
+
+    EXPECT_CALL(*ozo::get_socket(conn).native_handle(), assign(_))
+        .WillOnce(SetArgReferee<0>(error_code(error::code::error)));
+
+    EXPECT_EQ(ozo::impl::rebind_connection_io_context(conn, new_io), error_code(error::code::error));
 }
 
 } //namespace

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -38,6 +38,7 @@ struct connection_mock {
     virtual ozo::error_code start_connection(const std::string&) = 0;
     virtual ozo::error_code assign_socket() = 0;
     virtual void async_request() = 0;
+    virtual ozo::error_code rebind_io_context() = 0;
 
     virtual ~connection_mock() = default;
 };
@@ -54,6 +55,8 @@ struct connection_gmock : connection_mock {
     MOCK_METHOD1(start_connection, ozo::error_code(const std::string&));
     MOCK_METHOD0(assign_socket, ozo::error_code());
     MOCK_METHOD0(async_request, void());
+    MOCK_METHOD0(rebind_io_context, ozo::error_code());
+
 };
 
 inline boost::optional<pg_result> make_pg_result(
@@ -147,6 +150,11 @@ struct connection {
     template <typename Q, typename Out, typename Handler>
     friend void async_request(std::shared_ptr<connection>&& provider, Q&&, Out&&, Handler&&) {
         provider->mock_->async_request();
+    }
+
+    template <typename IoContext>
+    friend ozo::error_code rebind_connection_io_context(connection& c, IoContext&) {
+        return c.mock_->rebind_io_context();
     }
 };
 

--- a/tests/test_asio.h
+++ b/tests/test_asio.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ozo/detail/bind.h>
 #include <ozo/asio.h>
 
 #include <gmock/gmock.h>


### PR DESCRIPTION
We lost pooled connection rebinding to connection provider's io_context
Based on PR with GTest