### PR TITLE
Connection provider

### DIFF
--- a/include/ozo/connection_info.h
+++ b/include/ozo/connection_info.h
@@ -11,7 +11,6 @@ template <
     typename OidMap = empty_oid_map,
     typename Statistics = no_statistics>
 class connection_info {
-    io_context& io_;
     std::string conn_str_;
     Statistics statistics_;
 
@@ -20,14 +19,13 @@ class connection_info {
 public:
     using connectable_type = std::shared_ptr<connection>;
 
-    connection_info(io_context& io, std::string conn_str,
-            Statistics statistics = Statistics{})
-    : io_(io), conn_str_(std::move(conn_str)), statistics_(std::move(statistics)) {}
+    connection_info(std::string conn_str, Statistics statistics = Statistics{})
+    : conn_str_(std::move(conn_str)), statistics_(std::move(statistics)) {}
 
     template <typename Handler>
-    friend void async_get_connection(const connection_info& self, Handler&& h) {
+    friend void async_get_connection(const connection_info& self, io_context& io, Handler&& h) {
         impl::async_connect(self.conn_str_,
-            std::make_shared<connection>(self.io_, self.statistics_),
+            std::make_shared<connection>(io, self.statistics_),
             std::forward<Handler>(h));
     }
 };

--- a/include/ozo/impl/async_request.h
+++ b/include/ozo/impl/async_request.h
@@ -324,12 +324,12 @@ inline auto make_async_request_op(Query&& query, Out&& out, Handler&& handler) {
     };
 }
 
-template <typename P, typename Q, typename Out, typename Handler>
-inline void async_request(P&& provider, Q&& query, Out&& out,
+template <typename C, typename Q, typename Out, typename Handler>
+inline void async_request(C&& connection, Q&& query, Out&& out,
         Handler&& handler) {
-    static_assert(ConnectionProvider<P>, "is not a ConnectionProvider");
+    static_assert(Connectable<C>, "is not a Connectable");
     static_assert(Query<Q> || QueryBuilder<Q>, "is neither Query nor QueryBuilder");
-    async_get_connection(std::forward<P>(provider),
+    async_use_connection(std::forward<C>(connection),
         impl::make_async_request_op(
             std::forward<Q>(query),
             std::forward<Out>(out),

--- a/include/ozo/impl/connection.h
+++ b/include/ozo/impl/connection.h
@@ -92,7 +92,7 @@ inline const auto& get_connection_error_context(
 inline auto connection_error_message(pg_native_handle_type handle) {
     std::string_view v(PQerrorMessage(handle));
     auto trim_pos = v.find_last_not_of(' ');
-    if(trim_pos != v.npos) {
+    if (trim_pos != v.npos) {
         v.remove_suffix(v.size() - trim_pos);
     }
     return v;

--- a/include/ozo/impl/connection_pool.h
+++ b/include/ozo/impl/connection_pool.h
@@ -89,7 +89,7 @@ struct pooled_connection_wrapper {
             return handler_(std::move(ec), std::move(conn));
         }
 
-        async_get_connection(provider_, wrapper{std::move(handler_), std::move(conn)});
+        async_get_connection(provider_, io_, wrapper{std::move(handler_), std::move(conn)});
     }
 
     template <typename Func>
@@ -102,17 +102,14 @@ struct pooled_connection_wrapper {
 template <typename P, typename IoContext, typename Handler>
 auto wrap_pooled_connection_handler(IoContext& io, P&& provider, Handler&& handler) {
 
-    static_assert(ConnectionProvider<P>, "is not a ConnectionProvider");
+    static_assert(ConnectionProvider<P, IoContext>, "is not a ConnectionProvider");
 
-    return pooled_connection_wrapper<IoContext, std::decay_t<P>, std::decay_t<Handler>> {
+    return pooled_connection_wrapper<std::decay_t<IoContext>, std::decay_t<P>, std::decay_t<Handler>> {
         io, std::forward<P>(provider), std::forward<Handler>(handler)
     };
 }
 
 static_assert(Connectable<pooled_connection_ptr<connection<empty_oid_map, no_statistics>>>,
     "pooled_connection_ptr is not a Connectable concept");
-
-static_assert(ConnectionProvider<pooled_connection_ptr<connection<empty_oid_map, no_statistics>>>,
-    "pooled_connection_ptr is not a ConnectionProvider concept");
 
 } // namespace ozo::impl

--- a/include/ozo/request.h
+++ b/include/ozo/request.h
@@ -4,7 +4,7 @@
 
 namespace ozo {
 
-template <typename P, typename Q, typename Out, typename CompletionToken, typename = Require<ConnectionProvider<P>>>
+template <typename P, typename Q, typename Out, typename CompletionToken, typename = Require<Connectable<P>>>
 inline auto request(P&& provider, Q&& query, Out&& out, CompletionToken&& token) {
     using signature_t = void (error_code, connectable_type<P>);
     async_completion<CompletionToken, signature_t> init(token);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,6 +73,7 @@ set(SOURCES
     base36.cpp
     request_oid_map.cpp
     connection_binder.cpp
+    connection_integration.cpp
     main.cpp
 )
 

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -213,23 +213,23 @@ TEST(reset_error_context, should_resets_error_context) {
     EXPECT_TRUE(conn->error_context_.empty());
 }
 
-struct async_get_connection : Test {
+struct async_use_connection : Test {
     io_context_mock io;
 };
 
-TEST_F(async_get_connection, should_pass_through_the_connection_to_handler) {
+TEST_F(async_use_connection, should_pass_through_the_connection_to_handler) {
     auto conn = std::make_shared<connection<>>(io);
     using callback_mock = callback_gmock<decltype(conn)>;
     StrictMock<callback_mock> cb_mock{};
     EXPECT_CALL(cb_mock, context_preserved()).WillOnce(Return());
     EXPECT_CALL(cb_mock, call(error_code{}, conn)).WillOnce(Return());
-    ozo::async_get_connection(conn, wrap(cb_mock));
+    ozo::async_use_connection(conn, wrap(cb_mock));
 }
 
-TEST_F(async_get_connection, should_reset_connection_error_context) {
+TEST_F(async_use_connection, should_reset_connection_error_context) {
     auto conn = std::make_shared<connection<>>(io);
     conn->error_context_ = "some context here";
-    ozo::async_get_connection(conn, [](error_code, auto conn) {
+    ozo::async_use_connection(conn, [](error_code, auto conn) {
         EXPECT_TRUE(conn->error_context_.empty());
     });
 }

--- a/tests/connection_info.cpp
+++ b/tests/connection_info.cpp
@@ -7,9 +7,9 @@ namespace {
 
 TEST(connection_info, sould_return_error_and_bad_connect_for_invalid_connection_info) {
     ozo::io_context io;
-    ozo::connection_info<> conn_info(io, "invalid connection info");
+    ozo::connection_info<> conn_info("invalid connection info");
 
-    ozo::get_connection(conn_info, [](ozo::error_code ec, auto conn){
+    ozo::get_connection(conn_info, io, [](ozo::error_code ec, auto conn){
         EXPECT_TRUE(ec);
         EXPECT_TRUE(ozo::connection_bad(conn));
     });

--- a/tests/connection_integration.cpp
+++ b/tests/connection_integration.cpp
@@ -1,0 +1,23 @@
+#include <ozo/connection.h>
+#include <ozo/connection_info.h>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace {
+
+TEST(get_connection, should_return_error_and_bad_connect_for_invalid_connection_info) {
+    ozo::io_context io;
+    ozo::connection_info<> conn_info("invalid connection info");
+
+    ozo::result res;
+    ozo::get_connection(conn_info, io, [](ozo::error_code ec, auto conn) {
+        EXPECT_TRUE(ec);
+        EXPECT_TRUE(ozo::connection_bad(conn));
+        EXPECT_EQ(ozo::error_message(conn), "missing \"=\" after \"invalid\" in connection info string");
+    });
+
+    io.run();
+}
+
+} // namespace

--- a/tests/request_integration.cpp
+++ b/tests/request_integration.cpp
@@ -17,6 +17,7 @@ OZO_PG_DEFINE_CUSTOM_TYPE(ozo::tests::custom_type, "custom_type", dynamic_size)
 
 namespace {
 
+namespace asio = boost::asio;
 namespace hana = boost::hana;
 
 using namespace testing;
@@ -25,34 +26,21 @@ using namespace ozo::tests;
 template <typename ...Ts>
 using rows_of = std::vector<std::tuple<Ts...>>;
 
-TEST(request, should_return_error_and_bad_connect_for_invalid_connection_info) {
-    using namespace ozo::literals;
-    using namespace hana::literals;
-
-    ozo::io_context io;
-    ozo::connection_info<> conn_info(io, "invalid connection info");
-
-    ozo::result res;
-    ozo::request(conn_info, "SELECT 1"_SQL + " + 1"_SQL, res,
-            [](ozo::error_code ec, auto conn) {
-        EXPECT_TRUE(ec);
-        EXPECT_TRUE(ozo::connection_bad(conn));
-    });
-
-    io.run();
-}
-
 TEST(request, should_return_selected_variable) {
     using namespace ozo::literals;
     using namespace hana::literals;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(io, OZO_PG_TEST_CONNINFO);
-
+    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
     ozo::result res;
     const std::string foo = "foo";
-    ozo::request(conn_info, "SELECT "_SQL + foo, res,
-            [&](ozo::error_code ec, auto conn) {
+
+    asio::spawn(io, [&] (asio::yield_context yield) {
+        auto conn = ozo::get_connection(conn_info, io, yield);
+
+        ozo::error_code ec;
+        ozo::request(conn, "SELECT "_SQL + foo, res, yield[ec]);
+
         ASSERT_FALSE(ec) << ec.message() << " | " << error_message(conn) << " | " << get_error_context(conn);
         ASSERT_EQ(1u, res.size());
         ASSERT_EQ(1u, res[0].size());
@@ -68,13 +56,16 @@ TEST(request, should_return_selected_string_array) {
     using namespace hana::literals;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(io, OZO_PG_TEST_CONNINFO);
-
+    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
     const std::vector<std::string> foos = {"foo", "buzz", "bar"};
 
-    rows_of<std::vector<std::string>> res;
-    ozo::request(conn_info, "SELECT "_SQL + foos, std::back_inserter(res),
-            [&](ozo::error_code ec, auto conn) {
+    asio::spawn(io, [&] (asio::yield_context yield) {
+        auto conn = ozo::get_connection(conn_info, io, yield);
+
+        rows_of<std::vector<std::string>> res;
+        ozo::error_code ec;
+        ozo::request(conn, "SELECT "_SQL + foos, std::back_inserter(res), yield[ec]);
+
         ASSERT_FALSE(ec) << ec.message() << " | " << error_message(conn) << " | " << get_error_context(conn);
         ASSERT_EQ(1u, res.size());
         EXPECT_THAT(std::get<0>(res[0]), ElementsAre("foo", "buzz", "bar"));
@@ -89,13 +80,16 @@ TEST(request, should_return_selected_int_array) {
     using namespace hana::literals;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(io, OZO_PG_TEST_CONNINFO);
-
+    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
     const std::vector<int32_t> foos = {1, 22, 333};
 
-    rows_of<std::vector<int32_t>> res;
-    ozo::request(conn_info, "SELECT "_SQL + foos, std::back_inserter(res),
-            [&](ozo::error_code ec, auto conn) {
+    asio::spawn(io, [&] (asio::yield_context yield) {
+        auto conn = ozo::get_connection(conn_info, io, yield);
+
+        rows_of<std::vector<int32_t>> res;
+        ozo::error_code ec;
+        ozo::request(conn, "SELECT "_SQL + foos, std::back_inserter(res), yield[ec]);
+
         ASSERT_FALSE(ec) << ec.message() << " | " << error_message(conn) << " | " << get_error_context(conn);
         ASSERT_EQ(1u, res.size());
         EXPECT_THAT(std::get<0>(res[0]), ElementsAre(1, 22, 333));
@@ -111,14 +105,15 @@ TEST(request, should_fill_oid_map_when_oid_map_is_not_empty) {
 
     ozo::io_context io;
     constexpr const auto oid_map = ozo::register_types<custom_type>();
-    ozo::connection_info<> conn_info(io, OZO_PG_TEST_CONNINFO);
-    ozo::connection_info<std::decay_t<decltype(oid_map)>> conn_info_with_oid_map(io, OZO_PG_TEST_CONNINFO);
+    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    ozo::connection_info<std::decay_t<decltype(oid_map)>> conn_info_with_oid_map(OZO_PG_TEST_CONNINFO);
 
     asio::spawn(io, [&] (asio::yield_context yield) {
         ozo::result result;
-        auto conn = ozo::request(conn_info, "DROP TYPE IF EXISTS custom_type"_SQL, result, yield);
+        auto conn = ozo::get_connection(conn_info, io, yield);
+        ozo::request(conn, "DROP TYPE IF EXISTS custom_type"_SQL, result, yield);
         ozo::request(conn, "CREATE TYPE custom_type AS ()"_SQL, result, yield);
-        auto conn_with_oid_map = ozo::get_connection(conn_info_with_oid_map, yield);
+        auto conn_with_oid_map = ozo::get_connection(conn_info_with_oid_map, io, yield);
         EXPECT_NE(ozo::type_oid<custom_type>(ozo::get_oid_map(conn_with_oid_map)), ozo::null_oid);
     });
 
@@ -127,15 +122,17 @@ TEST(request, should_fill_oid_map_when_oid_map_is_not_empty) {
 
 TEST(request, should_request_with_connection_pool) {
     using namespace ozo::literals;
-    namespace asio = boost::asio;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(io, OZO_PG_TEST_CONNINFO);
+    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
     const ozo::connection_pool_config config;
     auto pool = ozo::make_connection_pool(conn_info, config);
+    auto provider = ozo::make_provider(pool);
+
     asio::spawn(io, [&] (asio::yield_context yield) {
+        auto connection = ozo::get_connection(provider, io, yield);
         ozo::result result;
-        ozo::request(ozo::connection_pool_provider(pool, io), "SELECT 1"_SQL, result, yield);
+        ozo::request(connection, "SELECT 1"_SQL, result, yield);
     });
 
     io.run();


### PR DESCRIPTION
`connection_pool` is designed not to depend on `io_context` in construction. Each connection request could have own `io_context`. But to be constructed it is required connection provider which usually contains `io_context`. Despite design it require `io_context` to be constructed. I try to solve it here.