### PR TITLE
Connection provider

### DIFF
--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -319,6 +319,17 @@ struct async_get_connection_impl {
     }
 };
 
+template <typename, typename = std::void_t<>>
+struct is_connection_source : std::false_type {};
+
+template <typename T>
+struct is_connection_source<T, std::void_t<
+    connection_type<T>
+>> : std::true_type {};
+
+template <typename T>
+constexpr auto ConnectionSource = is_connection_source<std::decay_t<T>>::value;
+
 template <typename T, typename Handler>
 inline auto async_get_connection(T&& provider, Handler&& handler)
          -> decltype(async_get_connection_impl<std::decay_t<T>>::apply(std::forward<T>(provider), std::forward<Handler>(handler))) {

--- a/include/ozo/connection_info.h
+++ b/include/ozo/connection_info.h
@@ -10,30 +10,48 @@ namespace ozo {
 template <
     typename OidMap = empty_oid_map,
     typename Statistics = no_statistics>
-class connection_info {
-    io_context& io_;
-    std::string conn_str_;
-    Statistics statistics_;
-
+struct connection_info {
     using connection = impl::connection_impl<OidMap, Statistics>;
-
-public:
     using connection_type = std::shared_ptr<connection>;
 
-    connection_info(io_context& io, std::string conn_str,
-            Statistics statistics = Statistics{})
-    : io_(io), conn_str_(std::move(conn_str)), statistics_(std::move(statistics)) {}
+    std::string conn_str;
+    Statistics statistics;
 
-    template <typename Handler>
-    void async_get_connection(Handler&& h) const {
-        impl::async_connect(conn_str_,
-            std::make_shared<connection>(io_, statistics_),
-            std::forward<Handler>(h));
-    }
+    connection_info(std::string conn_str, Statistics statistics = Statistics{})
+            : conn_str(std::move(conn_str)), statistics(std::move(statistics)) {}
 };
 
-static_assert(
-    ConnectionProvider<connection_info<>>,
-    "connection_info does not fit ConnectionProvider concept");
+static_assert(ConnectionSource<connection_info<>>, "is not a ConnectionSource");
+
+template <typename OidMap = empty_oid_map, typename Statistics = no_statistics>
+class connection_info_connector {
+public:
+    using source_type = connection_info<OidMap, Statistics>;
+    using connection = typename source_type::connection;
+    using connection_type = typename source_type::connection_type;
+
+    connection_info_connector(const source_type& base, io_context& io)
+            : base(base), io(io) {}
+
+    template <typename Handler>
+    void async_get_connection(Handler&& handler) const {
+        impl::async_connect(
+            base.conn_str,
+            std::make_shared<connection>(io, base.statistics),
+            std::forward<Handler>(handler)
+        );
+    }
+
+private:
+    const source_type& base;
+    io_context& io;
+};
+
+static_assert(ConnectionProvider<connection_info_connector<>>, "is not a ConnectionProvider");
+
+template <typename OidMap, typename Statistics>
+auto make_connector(const connection_info<OidMap, Statistics>& base, io_context& io) {
+    return connection_info_connector<OidMap, Statistics>(base, io);
+}
 
 } // namespace ozo

--- a/include/ozo/connection_pool.h
+++ b/include/ozo/connection_pool.h
@@ -11,29 +11,60 @@ struct connection_pool_config {
     std::size_t queue_capacity = 128;
 };
 
-template <typename P>
+template <typename Source>
 class connection_pool {
 public:
-    static_assert(ConnectionProvider<P>, "P must be ConnectionProvider");
-
-    connection_pool(P provider, const connection_pool_config& config)
-    : impl_(config.capacity, config.queue_capacity), provider_(std::move(provider)) {}
+    connection_pool(Source source, const connection_pool_config& config)
+    : impl_(config.capacity, config.queue_capacity), source_(std::move(source)) {}
 
     using duration = yamail::resource_pool::time_traits::duration;
     using time_point = yamail::resource_pool::time_traits::time_point;
-    using connection_type = impl::pooled_connection_ptr<P>;
+    using connection_type = impl::pooled_connection_ptr<Source>;
 
     template <typename Handler>
     void get_connection(io_context& io, duration timeout, Handler&& handler) {
-        impl_.get_auto_recycle(io,
-            impl::wrap_pooled_connection_handler(io, provider_, std::forward<Handler>(handler)),
-            timeout);
+        impl_.get_auto_recycle(
+            io,
+            impl::wrap_pooled_connection_handler(io, make_connector(source_, io), std::forward<Handler>(handler)),
+            timeout
+        );
     }
 
 private:
-    impl::connection_pool<P> impl_;
-    P provider_;
+    impl::connection_pool<Source> impl_;
+    Source source_;
 };
+
+static_assert(ConnectionSource<connection_pool<connection_info<>>>, "is not a ConnectionSource");
+
+template <typename Source>
+class connection_pool_connector {
+public:
+    using base_type = connection_pool<Source>;
+    using duration = typename base_type::duration;
+    using connection_type = typename connection_pool<Source>::connection_type;
+
+    connection_pool_connector(base_type& base, io_context& io, duration timeout)
+            : base(base), io(io), timeout(timeout) {}
+
+    template <typename Handler>
+    void async_get_connection(Handler&& handler) {
+        base.get_connection(io, timeout, std::forward<Handler>(handler));
+    }
+
+private:
+    base_type& base;
+    io_context& io;
+    duration timeout;
+};
+
+static_assert(ConnectionProvider<connection_pool_connector<connection_info<>>>, "is not a ConnectionProvider");
+
+template <typename Source>
+auto make_connector(connection_pool<Source>& base, io_context& io,
+        typename connection_pool_connector<Source>::duration timeout = connection_pool_connector<Source>::duration::max()) {
+    return connection_pool_connector<Source>(base, io, timeout);
+}
 
 template <typename T>
 struct is_connection_pool : std::false_type {};
@@ -44,41 +75,10 @@ struct is_connection_pool<connection_pool<Args...>> : std::true_type {};
 template <typename T>
 constexpr auto ConnectionPool = is_connection_pool<std::decay_t<T>>::value;
 
-template <typename P>
-auto make_connection_pool(P&& provider, const connection_pool_config& config) {
-    static_assert(ConnectionProvider<P>, "is not a ConnectionProvider");
-    return connection_pool<std::decay_t<P>>{std::forward<P>(provider), config};
-}
-
-template <typename Pool>
-class connection_pool_provider {
-public:
-    static_assert(ConnectionPool<Pool>, "Pool must be ConnectionPool");
-
-    using duration = typename Pool::duration;
-    using connection_type = typename Pool::connection_type;
-
-    connection_pool_provider(Pool& pool, io_context& io, duration timeout)
-    : pool_(pool), io_(io), timeout_(timeout) {}
-
-    connection_pool_provider(Pool& pool, io_context& io)
-    : connection_pool_provider(pool, io, duration::max()) {}
-
-    template <typename Handler>
-    void async_get_connection(Handler&& h) {
-        pool_.get_connection(io_, timeout_, std::forward<Handler>(h));
-    }
-
-private:
-    Pool& pool_;
-    io_context& io_;
-    duration timeout_;
-};
-
-template <typename T>
-inline auto make_provider(connection_pool<T>& pool, io_context& io,
-    typename connection_pool<T>::duration timeout = connection_pool<T>::duration::max()) {
-    return connection_pool_provider<connection_pool<T>> {pool, io, timeout};
+template <typename Source>
+auto make_connection_pool(Source&& source, const connection_pool_config& config) {
+    static_assert(ConnectionSource<Source>, "is not a ConnectionSource");
+    return connection_pool<std::decay_t<Source>>{std::forward<Source>(source), config};
 }
 
 } // namespace ozo

--- a/include/ozo/impl/connection_pool.h
+++ b/include/ozo/impl/connection_pool.h
@@ -6,19 +6,19 @@
 
 namespace ozo::impl {
 
-template <typename Provider>
+template <typename Source>
 struct get_connection_pool {
     using type = yamail::resource_pool::async::pool<
-        std::decay_t<decltype(unwrap_connection(std::declval<connection_type<Provider>&>()))>
+        std::decay_t<decltype(unwrap_connection(std::declval<connection_type<Source>&>()))>
     >;
 };
 
-template <typename Provider>
-using connection_pool = typename get_connection_pool<Provider>::type;
+template <typename Source>
+using connection_pool = typename get_connection_pool<Source>::type;
 
-template <typename Provider>
+template <typename Source>
 struct pooled_connection {
-    using handle_type = typename connection_pool<Provider>::handle;
+    using handle_type = typename connection_pool<Source>::handle;
     using underlying_type = typename handle_type::value_type;
 
     handle_type handle_;
@@ -44,8 +44,8 @@ struct pooled_connection {
         return unwrap_connection(*(conn.handle_));
     }
 };
-template <typename Provider>
-using pooled_connection_ptr = std::shared_ptr<pooled_connection<Provider>>;
+template <typename Source>
+using pooled_connection_ptr = std::shared_ptr<pooled_connection<Source>>;
 
 template <typename IoContext, typename Provider, typename Handler>
 struct pooled_connection_wrapper {
@@ -53,8 +53,8 @@ struct pooled_connection_wrapper {
     Provider provider_;
     Handler handler_;
 
-    using connection = pooled_connection<Provider>;
-    using connection_ptr = pooled_connection_ptr<Provider>;
+    using connection = pooled_connection<typename Provider::source_type>;
+    using connection_ptr = pooled_connection_ptr<typename Provider::source_type>;
 
     struct wrapper {
         Handler handler_;

--- a/tests/connection_info.cpp
+++ b/tests/connection_info.cpp
@@ -7,9 +7,9 @@ namespace {
 
 TEST(connection_info, sould_return_error_and_bad_connect_for_invalid_connection_info) {
     ozo::io_context io;
-    ozo::connection_info<> conn_info(io, "invalid connection info");
+    ozo::connection_info<> conn_info("invalid connection info");
 
-    ozo::get_connection(conn_info, [](ozo::error_code ec, auto conn){
+    ozo::get_connection(ozo::make_connector(conn_info, io), [](ozo::error_code ec, auto conn){
         EXPECT_TRUE(ec);
         EXPECT_TRUE(!ozo::error_message(conn).empty());
         EXPECT_TRUE(ozo::connection_bad(conn));

--- a/tests/connection_pool.cpp
+++ b/tests/connection_pool.cpp
@@ -11,7 +11,7 @@ namespace {
 
 TEST(make_connection_pool, sould_not_throw) {
     boost::asio::io_context io;
-    const ozo::connection_info<> conn_info(io, "conn info string");
+    ozo::connection_info<> conn_info("conn info string");
     const ozo::connection_pool_config config;
     EXPECT_NO_THROW(ozo::make_connection_pool(conn_info, config));
 }
@@ -59,6 +59,7 @@ struct connection_provider {
     connection_provider_mock* mock_ = nullptr;
 
     using connection_type = std::shared_ptr<connection<>>;
+    using source_type = connection_provider;
 
     template <typename Handler>
     friend void async_get_connection(connection_provider self, Handler&& h) {

--- a/tests/request_integration.cpp
+++ b/tests/request_integration.cpp
@@ -30,10 +30,10 @@ TEST(request, should_return_error_and_bad_connect_for_invalid_connection_info) {
     using namespace hana::literals;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(io, "invalid connection info");
+    ozo::connection_info<> conn_info("invalid connection info");
 
     ozo::result res;
-    ozo::request(conn_info, "SELECT 1"_SQL + " + 1"_SQL, res,
+    ozo::request(ozo::make_connector(conn_info, io), "SELECT 1"_SQL + " + 1"_SQL, res,
             [](ozo::error_code ec, auto conn) {
         EXPECT_TRUE(ec);
         EXPECT_TRUE(ozo::connection_bad(conn));
@@ -47,11 +47,11 @@ TEST(request, should_return_selected_variable) {
     using namespace hana::literals;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(io, OZO_PG_TEST_CONNINFO);
+    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
 
     ozo::result res;
     const std::string foo = "foo";
-    ozo::request(conn_info, "SELECT "_SQL + foo, res,
+    ozo::request(ozo::make_connector(conn_info, io), "SELECT "_SQL + foo, res,
             [&](ozo::error_code ec, auto conn) {
         ASSERT_FALSE(ec) << ec.message() << " | " << error_message(conn) << " | " << get_error_context(conn);
         ASSERT_EQ(1u, res.size());
@@ -68,12 +68,12 @@ TEST(request, should_return_selected_string_array) {
     using namespace hana::literals;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(io, OZO_PG_TEST_CONNINFO);
+    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
 
     const std::vector<std::string> foos = {"foo", "buzz", "bar"};
 
     rows_of<std::vector<std::string>> res;
-    ozo::request(conn_info, "SELECT "_SQL + foos, std::back_inserter(res),
+    ozo::request(ozo::make_connector(conn_info, io), "SELECT "_SQL + foos, std::back_inserter(res),
             [&](ozo::error_code ec, auto conn) {
         ASSERT_FALSE(ec) << ec.message() << " | " << error_message(conn) << " | " << get_error_context(conn);
         ASSERT_EQ(1u, res.size());
@@ -89,12 +89,12 @@ TEST(request, should_return_selected_int_array) {
     using namespace hana::literals;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(io, OZO_PG_TEST_CONNINFO);
+    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
 
     const std::vector<int32_t> foos = {1, 22, 333};
 
     rows_of<std::vector<int32_t>> res;
-    ozo::request(conn_info, "SELECT "_SQL + foos, std::back_inserter(res),
+    ozo::request(ozo::make_connector(conn_info, io), "SELECT "_SQL + foos, std::back_inserter(res),
             [&](ozo::error_code ec, auto conn) {
         ASSERT_FALSE(ec) << ec.message() << " | " << error_message(conn) << " | " << get_error_context(conn);
         ASSERT_EQ(1u, res.size());
@@ -111,14 +111,14 @@ TEST(request, should_fill_oid_map_when_oid_map_is_not_empty) {
 
     ozo::io_context io;
     constexpr const auto oid_map = ozo::register_types<custom_type>();
-    ozo::connection_info<> conn_info(io, OZO_PG_TEST_CONNINFO);
-    ozo::connection_info<std::decay_t<decltype(oid_map)>> conn_info_with_oid_map(io, OZO_PG_TEST_CONNINFO);
+    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    ozo::connection_info<std::decay_t<decltype(oid_map)>> conn_info_with_oid_map(OZO_PG_TEST_CONNINFO);
 
     asio::spawn(io, [&] (asio::yield_context yield) {
         ozo::result result;
-        auto conn = ozo::request(conn_info, "DROP TYPE IF EXISTS custom_type"_SQL, result, yield);
+        auto conn = ozo::request(ozo::make_connector(conn_info, io), "DROP TYPE IF EXISTS custom_type"_SQL, result, yield);
         ozo::request(conn, "CREATE TYPE custom_type AS ()"_SQL, result, yield);
-        auto conn_with_oid_map = ozo::get_connection(conn_info_with_oid_map, yield);
+        auto conn_with_oid_map = ozo::get_connection(ozo::make_connector(conn_info_with_oid_map, io), yield);
         EXPECT_NE(ozo::type_oid<custom_type>(ozo::get_oid_map(conn_with_oid_map)), ozo::null_oid);
     });
 
@@ -130,12 +130,12 @@ TEST(request, should_request_with_connection_pool) {
     namespace asio = boost::asio;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(io, OZO_PG_TEST_CONNINFO);
+    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
     const ozo::connection_pool_config config;
     auto pool = ozo::make_connection_pool(conn_info, config);
     asio::spawn(io, [&] (asio::yield_context yield) {
         ozo::result result;
-        ozo::request(ozo::connection_pool_provider(pool, io), "SELECT 1"_SQL, result, yield);
+        ozo::request(ozo::make_connector(pool, io), "SELECT 1"_SQL, result, yield);
     });
 
     io.run();


### PR DESCRIPTION
`connection_pool` is designed not to depend on `io_context` in construction. Each connection request could have own `io_context`. But to be constructed it is required connection provider which usually contains `io_context`. Despite design it require `io_context` to be constructed. I try to solve it here.