### PR TITLE
Connection refactoring

### DIFF
--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -304,24 +304,6 @@ inline decltype(auto) get_statistics(T&& conn) noexcept {
     return get_connection_statistics(unwrap_connection(std::forward<T>(conn)));
 }
 
-// Oid Map helpers
-
-template <typename T, typename C, typename = Require<Connectable<C>>>
-inline decltype(auto) type_oid(C&& conn) noexcept {
-    return type_oid<std::decay_t<T>>(
-        get_oid_map(std::forward<C>(conn)));
-}
-
-template <typename T, typename C, typename = Require<Connectable<C>>>
-inline decltype(auto) type_oid(C&& conn, const T&) noexcept {
-    return type_oid<std::decay_t<T>>(std::forward<C>(conn));
-}
-
-template <typename T, typename C, typename = Require<Connectable<C>>>
-inline void set_type_oid(C&& conn, oid_t oid) noexcept {
-    set_type_oid<T>(get_oid_map(std::forward<C>(conn)), oid);
-}
-
 
 template <typename ConnectionProvider, typename Enable = void>
 struct get_connectable_type {

--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -10,8 +10,6 @@
 
 namespace ozo {
 
-using impl::pg_conn_handle;
-
 using no_statistics = decltype(hana::make_map());
 
 /**
@@ -99,7 +97,7 @@ constexpr auto get_connection_error_context(T&& conn)
 *     is suppurted only.
 *
 *   * get_connection_handle()
-*     Must return reference or proxy for pg_conn_handle object
+*     Must return reference or proxy for native_conn_handle object
 *
 *   * get_connection_error_context()
 *     Must return reference or proxy for additional error context. There is no

--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -20,6 +20,63 @@ using no_statistics = decltype(hana::make_map());
 template <typename, typename = std::void_t<>>
 struct is_connection : std::false_type {};
 
+template <typename T, typename = std::void_t<>>
+struct get_connection_oid_map_impl {
+    template <typename Conn>
+    constexpr static auto apply(Conn&& c) -> decltype((c.oid_map_)) {
+        return c.oid_map_;
+    }
+};
+
+template <typename T>
+constexpr auto get_connection_oid_map(T&& conn)
+        -> decltype (get_connection_oid_map_impl<std::decay_t<T>>::apply(std::forward<T>(conn))) {
+    return get_connection_oid_map_impl<std::decay_t<T>>::apply(std::forward<T>(conn));
+}
+
+template <typename T, typename = std::void_t<>>
+struct get_connection_socket_impl {
+    template <typename Conn>
+    constexpr static auto apply(Conn&& c) -> decltype((c.socket_)) {
+        return c.socket_;
+    }
+};
+
+template <typename T>
+constexpr auto get_connection_socket(T&& conn)
+        -> decltype(get_connection_socket_impl<std::decay_t<T>>::apply(std::forward<T>(conn))) {
+    return get_connection_socket_impl<std::decay_t<T>>::apply(std::forward<T>(conn));
+}
+
+template <typename T, typename = std::void_t<>>
+struct get_connection_handle_impl {
+    template <typename Conn>
+    constexpr static auto apply(Conn&& c) -> decltype((c.handle_)) {
+        return c.handle_;
+    }
+};
+
+template <typename T>
+constexpr auto get_connection_handle(T&& conn)
+        -> decltype(get_connection_handle_impl<std::decay_t<T>>::apply(std::forward<T>(conn))) {
+    return get_connection_handle_impl<std::decay_t<T>>::apply(std::forward<T>(conn));
+}
+
+template <typename T, typename = std::void_t<>>
+struct get_connection_error_context_impl {
+    template <typename Conn>
+    constexpr static auto apply(Conn&& c) -> decltype((c.error_context_)) {
+        return c.error_context_;
+    }
+};
+
+template <typename T>
+constexpr auto get_connection_error_context(T&& conn)
+        -> decltype(get_connection_error_context_impl<std::decay_t<T>>::apply(std::forward<T>(conn))) {
+    return get_connection_error_context_impl<std::decay_t<T>>::apply(std::forward<T>(conn));
+}
+
+
 /**
 * We define the connection to database not as a concrete class or type,
 * but as an entity which must support some traits. The reason why we
@@ -133,7 +190,6 @@ constexpr connection_traits<std::decay_t<decltype(unwrap_connection(std::declval
 */
 template <typename T, typename = Require<Connectable<T>>>
 inline decltype(auto) get_handle(T&& conn) noexcept {
-    using impl::get_connection_handle;
     return get_connection_handle(
         unwrap_connection(std::forward<T>(conn)));
 }
@@ -151,7 +207,6 @@ inline decltype(auto) get_native_handle(T&& conn) noexcept {
 */
 template <typename T, typename = Require<Connectable<T>>>
 inline decltype(auto) get_socket(T&& conn) noexcept {
-    using impl::get_connection_socket;
     return get_connection_socket(unwrap_connection(std::forward<T>(conn)));
 }
 
@@ -206,8 +261,7 @@ inline bool connection_good(const T& conn) noexcept {
 */
 template <typename T, typename = Require<Connectable<T>>>
 inline std::string_view error_message(T&& conn) {
-    using impl::connection_error_message;
-    return connection_error_message(get_native_handle(conn));
+    return impl::connection_error_message(get_native_handle(conn));
 }
 
 /**
@@ -216,7 +270,6 @@ inline std::string_view error_message(T&& conn) {
 */
 template <typename T, typename = Require<Connectable<T>>>
 inline const auto& get_error_context(const T& conn) {
-    using impl::get_connection_error_context;
     return get_connection_error_context(unwrap_connection(conn));
 }
 
@@ -225,7 +278,6 @@ inline const auto& get_error_context(const T& conn) {
 */
 template <typename T, typename Ctx>
 inline Require<Connectable<T>> set_error_context(T& conn, Ctx&& ctx) {
-    using impl::get_connection_error_context;
     get_connection_error_context(unwrap_connection(conn)) = std::forward<Ctx>(ctx);
 }
 
@@ -243,7 +295,6 @@ inline Require<Connectable<T>> reset_error_context(T& conn) {
 */
 template <typename T, typename = Require<Connectable<T>>>
 inline decltype(auto) get_oid_map(T&& conn) noexcept {
-    using impl::get_connection_oid_map;
     return get_connection_oid_map(unwrap_connection(std::forward<T>(conn)));
 }
 
@@ -252,7 +303,6 @@ inline decltype(auto) get_oid_map(T&& conn) noexcept {
 */
 template <typename T, typename = Require<Connectable<T>>>
 inline decltype(auto) get_statistics(T&& conn) noexcept {
-    using impl::get_connection_statistics;
     return get_connection_statistics(unwrap_connection(std::forward<T>(conn)));
 }
 

--- a/include/ozo/connection_info.h
+++ b/include/ozo/connection_info.h
@@ -18,7 +18,7 @@ class connection_info {
     using connection = impl::connection_impl<OidMap, Statistics>;
 
 public:
-    using connectable_type = std::shared_ptr<connection>;
+    using connection_type = std::shared_ptr<connection>;
 
     connection_info(io_context& io, std::string conn_str,
             Statistics statistics = Statistics{})

--- a/include/ozo/connection_info.h
+++ b/include/ozo/connection_info.h
@@ -15,7 +15,7 @@ class connection_info {
     std::string conn_str_;
     Statistics statistics_;
 
-    using connection = impl::connection<OidMap, Statistics>;
+    using connection = impl::connection_impl<OidMap, Statistics>;
 
 public:
     using connectable_type = std::shared_ptr<connection>;

--- a/include/ozo/connection_info.h
+++ b/include/ozo/connection_info.h
@@ -25,9 +25,9 @@ public:
     : io_(io), conn_str_(std::move(conn_str)), statistics_(std::move(statistics)) {}
 
     template <typename Handler>
-    friend void async_get_connection(const connection_info& self, Handler&& h) {
-        impl::async_connect(self.conn_str_,
-            std::make_shared<connection>(self.io_, self.statistics_),
+    void async_get_connection(Handler&& h) const {
+        impl::async_connect(conn_str_,
+            std::make_shared<connection>(io_, statistics_),
             std::forward<Handler>(h));
     }
 };

--- a/include/ozo/connection_pool.h
+++ b/include/ozo/connection_pool.h
@@ -65,7 +65,7 @@ public:
     : connection_pool_provider(pool, io, duration::max()) {}
 
     template <typename Handler>
-    void operator() (Handler&& h) {
+    void async_get_connection(Handler&& h) {
         pool_.get_connection(io_, timeout_, std::forward<Handler>(h));
     }
 

--- a/include/ozo/connection_pool.h
+++ b/include/ozo/connection_pool.h
@@ -21,7 +21,7 @@ public:
 
     using duration = yamail::resource_pool::time_traits::duration;
     using time_point = yamail::resource_pool::time_traits::time_point;
-    using connectable_type = impl::pooled_connection_ptr<P>;
+    using connection_type = impl::pooled_connection_ptr<P>;
 
     template <typename Handler>
     void get_connection(io_context& io, duration timeout, Handler&& handler) {
@@ -56,7 +56,7 @@ public:
     static_assert(ConnectionPool<Pool>, "Pool must be ConnectionPool");
 
     using duration = typename Pool::duration;
-    using connectable_type = typename Pool::connectable_type;
+    using connection_type = typename Pool::connection_type;
 
     connection_pool_provider(Pool& pool, io_context& io, duration timeout)
     : pool_(pool), io_(io), timeout_(timeout) {}

--- a/include/ozo/impl/async_connect.h
+++ b/include/ozo/impl/async_connect.h
@@ -12,8 +12,8 @@ namespace impl {
 */
 template <typename Handler, typename Connection>
 struct async_connect_op {
-    static_assert(Connectable<Connection>,
-        "Connection type does not meet Connectable requirements");
+    static_assert(ozo::Connection<Connection>,
+        "Connection type does not meet Connection requirements");
 
     Connection& conn_;
     Handler handler_;
@@ -114,7 +114,7 @@ inline auto bind_connection_handler(Handler&& base, Connection&& conn) {
 }
 
 template <typename T, typename Handler>
-inline Require<Connectable<T>> async_connect(std::string conninfo, T&& conn,
+inline Require<Connection<T>> async_connect(std::string conninfo, T&& conn,
         Handler&& handler) {
 
     decltype(auto) conn_ref = unwrap_connection(conn);

--- a/include/ozo/impl/connection.h
+++ b/include/ozo/impl/connection.h
@@ -17,8 +17,8 @@ using pg_native_handle_type = PGconn*;
 using pg_conn_handle = std::unique_ptr<PGconn, decltype(&PQfinish)>;
 
 template <typename OidMap, typename Statistics>
-struct connection {
-    connection(io_context& io, Statistics statistics)
+struct connection_impl {
+    connection_impl(io_context& io, Statistics statistics)
     : handle_(nullptr, &PQfinish), socket_(io), statistics_(std::move(statistics)) {}
 
     pg_conn_handle handle_;
@@ -28,68 +28,12 @@ struct connection {
     std::string error_context_;
 };
 
-template <typename ...Ts>
-inline const auto& get_connection_handle(const connection<Ts...>& ctx) noexcept {
-    return ctx.handle_;
-}
-
-template <typename ...Ts>
-inline auto& get_connection_handle(connection<Ts...>& ctx) noexcept {
-    return ctx.handle_;
-}
-
 inline bool connection_status_bad(pg_native_handle_type handle) noexcept {
     return !handle || PQstatus(handle) == CONNECTION_BAD;
 }
 
-template <typename ...Ts>
-inline const auto& get_connection_socket(
-        const connection<Ts...>& ctx) noexcept {
-    return ctx.socket_;
-}
-
-template <typename ...Ts>
-inline auto& get_connection_socket(
-        connection<Ts...>& ctx) noexcept {
-    return ctx.socket_;
-}
-
-template <typename ...Ts>
-inline const auto& get_connection_oid_map(
-        const connection<Ts...>& ctx) noexcept {
-    return ctx.oid_map_;
-}
-
-template <typename ...Ts>
-inline auto& get_connection_oid_map(
-        connection<Ts...>& ctx) noexcept {
-    return ctx.oid_map_;
-}
-
-template <typename ...Ts>
-inline const auto& get_connection_statistics(
-        const connection<Ts...>& ctx) noexcept {
-    return ctx.statistics_;
-}
-
-template <typename ...Ts>
-inline auto& get_connection_statistics(
-        connection<Ts...>& ctx) noexcept {
-    return ctx.statistics_;
-}
-
-template <typename ...Ts>
-inline auto& get_connection_error_context(connection<Ts...>& ctx) {
-    return ctx.error_context_;
-}
-
-template <typename ...Ts>
-inline const auto& get_connection_error_context(
-        const connection<Ts...>& ctx) {
-    return ctx.error_context_;
-}
-
-inline auto connection_error_message(pg_native_handle_type handle) {
+template <typename NativeHandleType>
+inline auto connection_error_message(NativeHandleType handle) {
     std::string_view v(PQerrorMessage(handle));
     auto trim_pos = v.find_last_not_of(' ');
     if(trim_pos != v.npos) {

--- a/include/ozo/impl/connection.h
+++ b/include/ozo/impl/connection.h
@@ -32,8 +32,10 @@ template <typename NativeHandleType>
 inline auto connection_error_message(NativeHandleType handle) {
     std::string_view v(PQerrorMessage(handle));
     auto trim_pos = v.find_last_not_of(' ');
-    if(trim_pos != v.npos) {
-        v.remove_suffix(v.size() - trim_pos);
+    if (trim_pos == v.npos) {
+        v.remove_suffix(v.size());
+    } else if (trim_pos < v.size()) {
+        v.remove_suffix(v.size() - trim_pos - 1);
     }
     return v;
 }

--- a/include/ozo/impl/connection.h
+++ b/include/ozo/impl/connection.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <libpq-fe.h>
+#include <ozo/native_conn_handle.h>
 
 #include <ozo/asio.h>
 #include <boost/algorithm/string/trim.hpp>
@@ -12,23 +12,19 @@ namespace ozo {
 
 namespace impl {
 
-using pg_native_handle_type = PGconn*;
-
-using pg_conn_handle = std::unique_ptr<PGconn, decltype(&PQfinish)>;
-
 template <typename OidMap, typename Statistics>
 struct connection_impl {
     connection_impl(io_context& io, Statistics statistics)
-    : handle_(nullptr, &PQfinish), socket_(io), statistics_(std::move(statistics)) {}
+    : socket_(io), statistics_(std::move(statistics)) {}
 
-    pg_conn_handle handle_;
+    native_conn_handle handle_;
     asio::posix::stream_descriptor socket_;
     OidMap oid_map_;
     Statistics statistics_; // statistics metatypes to be defined - counter, duration, whatever?
     std::string error_context_;
 };
 
-inline bool connection_status_bad(pg_native_handle_type handle) noexcept {
+inline bool connection_status_bad(PGconn* handle) noexcept {
     return !handle || PQstatus(handle) == CONNECTION_BAD;
 }
 

--- a/include/ozo/impl/connection_pool.h
+++ b/include/ozo/impl/connection_pool.h
@@ -109,10 +109,10 @@ auto wrap_pooled_connection_handler(IoContext& io, P&& provider, Handler&& handl
     };
 }
 
-static_assert(Connectable<pooled_connection_ptr<connection<empty_oid_map, no_statistics>>>,
+static_assert(Connectable<pooled_connection_ptr<connection_impl<empty_oid_map, no_statistics>>>,
     "pooled_connection_ptr is not a Connectable concept");
 
-static_assert(ConnectionProvider<pooled_connection_ptr<connection<empty_oid_map, no_statistics>>>,
+static_assert(ConnectionProvider<pooled_connection_ptr<connection_impl<empty_oid_map, no_statistics>>>,
     "pooled_connection_ptr is not a ConnectionProvider concept");
 
 } // namespace ozo::impl

--- a/include/ozo/impl/connection_pool.h
+++ b/include/ozo/impl/connection_pool.h
@@ -9,7 +9,7 @@ namespace ozo::impl {
 template <typename Provider>
 struct get_connection_pool {
     using type = yamail::resource_pool::async::pool<
-        std::decay_t<decltype(unwrap_connection(std::declval<connectable_type<Provider>&>()))>
+        std::decay_t<decltype(unwrap_connection(std::declval<connection_type<Provider>&>()))>
     >;
 };
 
@@ -62,7 +62,7 @@ struct pooled_connection_wrapper {
 
         template <typename Conn>
         void operator () (error_code ec, Conn&& conn) {
-            static_assert(std::is_same_v<connectable_type<Provider>, std::decay_t<Conn>>,
+            static_assert(std::is_same_v<connection_type<Provider>, std::decay_t<Conn>>,
                 "Conn must connectiable type of Provider");
             if (!ec) {
                 conn_->reset(std::move(unwrap_connection(conn)));
@@ -109,8 +109,8 @@ auto wrap_pooled_connection_handler(IoContext& io, P&& provider, Handler&& handl
     };
 }
 
-static_assert(Connectable<pooled_connection_ptr<connection_impl<empty_oid_map, no_statistics>>>,
-    "pooled_connection_ptr is not a Connectable concept");
+static_assert(Connection<pooled_connection_ptr<connection_impl<empty_oid_map, no_statistics>>>,
+    "pooled_connection_ptr is not a Connection concept");
 
 static_assert(ConnectionProvider<pooled_connection_ptr<connection_impl<empty_oid_map, no_statistics>>>,
     "pooled_connection_ptr is not a ConnectionProvider concept");

--- a/include/ozo/impl/io.h
+++ b/include/ozo/impl/io.h
@@ -46,24 +46,24 @@ inline const char* get_result_status_name(ExecStatusType status) {
 }
 namespace pq {
 
-template <typename T, typename Handler, typename = Require<Connectable<T>>>
+template <typename T, typename Handler, typename = Require<Connection<T>>>
 inline void pq_write_poll(T& conn, Handler&& h) {
     get_socket(conn).async_write_some(
             asio::null_buffers(), std::forward<Handler>(h));
 }
 
-template <typename T, typename Handler, typename = Require<Connectable<T>>>
+template <typename T, typename Handler, typename = Require<Connection<T>>>
 inline void pq_read_poll(T& conn, Handler&& h) {
     get_socket(conn).async_read_some(
             asio::null_buffers(), std::forward<Handler>(h));
 }
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline decltype(auto) pq_connect_poll(T& conn) {
     return PQconnectPoll(get_native_handle(conn));
 }
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline error_code pq_start_connection(T& conn, const std::string& conninfo) {
     native_conn_handle handle(PQconnectStart(conninfo.c_str()));
     if (!handle) {
@@ -73,7 +73,7 @@ inline error_code pq_start_connection(T& conn, const std::string& conninfo) {
     return {};
 }
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline error_code pq_assign_socket(T& conn) {
     int fd = PQsocket(get_native_handle(conn));
     if (fd == -1) {
@@ -127,7 +127,7 @@ inline int pq_ntuples(const PGresult& res) noexcept {
     return PQntuples(std::addressof(res));
 }
 
-template <typename T, typename ...Ts, typename = Require<Connectable<T>>>
+template <typename T, typename ...Ts, typename = Require<Connection<T>>>
 inline int pq_send_query_params(T& conn, const binary_query<Ts...>& q) noexcept {
     return PQsendQueryParams(get_native_handle(conn),
                 q.text(),
@@ -140,27 +140,27 @@ inline int pq_send_query_params(T& conn, const binary_query<Ts...>& q) noexcept 
             );
 }
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline int pq_set_nonblocking(T& conn) noexcept {
     return PQsetnonblocking(get_native_handle(conn), 1);
 }
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline int pq_consume_input(T& conn) noexcept {
     return PQconsumeInput(get_native_handle(conn));
 }
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline bool pq_is_busy(T& conn) noexcept {
     return PQisBusy(get_native_handle(conn));
 }
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline query_state pq_flush_output(T& conn) noexcept {
     return static_cast<query_state>(PQflush(get_native_handle(conn)));
 }
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline native_result_handle pq_get_result(T& conn) noexcept {
     return native_result_handle(PQgetResult(get_native_handle(conn)));
 }
@@ -178,37 +178,37 @@ inline error_code pq_result_error(const PGresult& res) noexcept {
 
 } // namespace pq
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline error_code start_connection(T& conn, const std::string& conninfo) {
     using pq::pq_start_connection;
     return pq_start_connection(unwrap_connection(conn), conninfo);
 }
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline error_code assign_socket(T& conn) {
     using pq::pq_assign_socket;
     return pq_assign_socket(unwrap_connection(conn));
 }
 
-template <typename T, typename Handler, typename = Require<Connectable<T>>>
+template <typename T, typename Handler, typename = Require<Connection<T>>>
 inline void write_poll(T& conn, Handler&& h) {
     using pq::pq_write_poll;
     pq_write_poll(unwrap_connection(conn), std::forward<Handler>(h));
 }
 
-template <typename T, typename Handler, typename = Require<Connectable<T>>>
+template <typename T, typename Handler, typename = Require<Connection<T>>>
 inline void read_poll(T& conn, Handler&& h) {
     using pq::pq_read_poll;
     pq_read_poll(unwrap_connection(conn), std::forward<Handler>(h));
 }
 
 // Shortcut for post operation with connection associated executor
-template <typename T, typename Oper, typename = Require<Connectable<T>>>
+template <typename T, typename Oper, typename = Require<Connection<T>>>
 inline void post(T& conn, Oper&& op) {
     get_io_context(conn).post(std::forward<Oper>(op));
 }
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline decltype(auto) connect_poll(T& conn) {
     using pq::pq_connect_poll;
     return pq_connect_poll(unwrap_connection(conn));
@@ -262,13 +262,13 @@ inline int ntuples(T&& res) noexcept {
     return pq_ntuples(std::forward<T>(res));
 }
 
-template <typename T, typename Query, typename = Require<Connectable<T>>>
+template <typename T, typename Query, typename = Require<Connection<T>>>
 inline decltype(auto) send_query_params(T& conn, Query&& q) noexcept {
     using pq::pq_send_query_params;
     return pq_send_query_params(unwrap_connection(conn), std::forward<Query>(q));
 }
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline error_code set_nonblocking(T& conn) noexcept {
     using pq::pq_set_nonblocking;
     if (pq_set_nonblocking(unwrap_connection(conn))) {
@@ -277,7 +277,7 @@ inline error_code set_nonblocking(T& conn) noexcept {
     return {};
 }
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline error_code consume_input(T& conn) noexcept {
     using pq::pq_consume_input;
     if (!pq_consume_input(unwrap_connection(conn))) {
@@ -286,19 +286,19 @@ inline error_code consume_input(T& conn) noexcept {
     return {};
 }
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline bool is_busy(T& conn) noexcept {
     using pq::pq_is_busy;
     return pq_is_busy(unwrap_connection(conn));
 }
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline query_state flush_output(T& conn) noexcept {
     using pq::pq_flush_output;
     return pq_flush_output(unwrap_connection(conn));
 }
 
-template <typename T, typename = Require<Connectable<T>>>
+template <typename T, typename = Require<Connection<T>>>
 inline decltype(auto) get_result(T& conn) noexcept {
     using pq::pq_get_result;
     return pq_get_result(unwrap_connection(conn));

--- a/include/ozo/impl/io.h
+++ b/include/ozo/impl/io.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ozo/native_result_handle.h>
+#include <ozo/native_conn_handle.h>
 #include <ozo/connection.h>
 #include <ozo/error.h>
 #include <ozo/binary_query.h>
@@ -64,7 +65,7 @@ inline decltype(auto) pq_connect_poll(T& conn) {
 
 template <typename T, typename = Require<Connectable<T>>>
 inline error_code pq_start_connection(T& conn, const std::string& conninfo) {
-    pg_conn_handle handle(PQconnectStart(conninfo.c_str()), PQfinish);
+    native_conn_handle handle(PQconnectStart(conninfo.c_str()));
     if (!handle) {
         return make_error_code(error::pq_connection_start_failed);
     }

--- a/include/ozo/native_conn_handle.h
+++ b/include/ozo/native_conn_handle.h
@@ -13,14 +13,14 @@
 namespace std {
 
 template <>
-struct default_delete<PGresult> {
-    void operator() (PGresult *ptr) const { PQclear(ptr); }
+struct default_delete<PGconn> {
+    void operator() (PGconn *ptr) const { PQfinish(ptr); }
 };
 
 } // namespace std
 
 namespace ozo {
 
-using native_result_handle = std::unique_ptr<PGresult>;
+using native_conn_handle = std::unique_ptr<PGconn>;
 
 } // namespace ozo

--- a/include/ozo/request.h
+++ b/include/ozo/request.h
@@ -6,7 +6,7 @@ namespace ozo {
 
 template <typename P, typename Q, typename Out, typename CompletionToken, typename = Require<ConnectionProvider<P>>>
 inline auto request(P&& provider, Q&& query, Out&& out, CompletionToken&& token) {
-    using signature_t = void (error_code, connectable_type<P>);
+    using signature_t = void (error_code, connection_type<P>);
     async_completion<CompletionToken, signature_t> init(token);
 
     impl::async_request(std::forward<P>(provider), std::forward<Q>(query), std::forward<Out>(out),

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -80,30 +80,6 @@ struct connection {
 
     explicit connection(io_context_mock& io) : socket_(io) {}
 
-    friend OidMap& get_connection_oid_map(connection& conn) {
-        return conn.oid_map_;
-    }
-    friend const OidMap& get_connection_oid_map(const connection& conn) {
-        return conn.oid_map_;
-    }
-    friend socket_mock& get_connection_socket(connection& conn) {
-        return conn.socket_;
-    }
-    friend const socket_mock& get_connection_socket(const connection& conn) {
-        return conn.socket_;
-    }
-    friend handle_type& get_connection_handle(connection& conn) {
-        return conn.handle_;
-    }
-    friend const handle_type& get_connection_handle(const connection& conn) {
-        return conn.handle_;
-    }
-    friend std::string& get_connection_error_context(connection& conn) {
-        return conn.error_context_;
-    }
-    friend const std::string& get_connection_error_context(const connection& conn) {
-        return conn.error_context_;
-    }
 };
 
 template <typename ...Ts>

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -240,4 +240,35 @@ TEST(rebind_connection_io_context, should_return_error_when_socket_assign_fails_
     EXPECT_EQ(ozo::impl::rebind_connection_io_context(conn, new_io), error_code(error::code::error));
 }
 
+struct fake_native_pq_handle {
+    std::string message;
+    friend const char* PQerrorMessage(const fake_native_pq_handle& self) {
+        return self.message.c_str();
+    }
+};
+
+TEST(connection_error_message, should_trim_trailing_soaces){
+    fake_native_pq_handle handle{"error message with trailing spaces   "};
+    EXPECT_EQ(std::string(ozo::impl::connection_error_message(handle)),
+        "error message with trailing spaces");
+}
+
+TEST(connection_error_message, should_preserve_string_without_trailing_spaces){
+    fake_native_pq_handle handle{"error message without trailing spaces"};
+    EXPECT_EQ(std::string(ozo::impl::connection_error_message(handle)),
+        "error message without trailing spaces");
+}
+
+TEST(connection_error_message, should_preserve_empty_string){
+    fake_native_pq_handle handle{""};
+    EXPECT_EQ(std::string(ozo::impl::connection_error_message(handle)),
+        "");
+}
+
+TEST(connection_error_message, should_return_empty_string_for_string_of_spaces){
+    fake_native_pq_handle handle{"    "};
+    EXPECT_EQ(std::string(ozo::impl::connection_error_message(handle)),
+        "");
+}
+
 } //namespace

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -89,17 +89,17 @@ static_assert(ozo::Connection<connection<>>,
     "connection does not meet Connection requirements");
 static_assert(ozo::ConnectionWrapper<connection_ptr<>>,
     "connection_ptr does not meet ConnectionWrapper requirements");
-static_assert(ozo::Connectable<connection<>>,
-    "connection does not meet Connectable requirements");
-static_assert(ozo::Connectable<connection_ptr<>>,
-    "connection_ptr does not meet Connectable requirements");
+static_assert(ozo::Connection<connection<>>,
+    "connection does not meet Connection requirements");
+static_assert(ozo::Connection<connection_ptr<>>,
+    "connection_ptr does not meet Connection requirements");
 
 static_assert(!ozo::Connection<int>,
     "int meets Connection requirements unexpectedly");
 static_assert(!ozo::ConnectionWrapper<int>,
     "int meets ConnectionWrapper requirements unexpectedly");
-static_assert(!ozo::Connectable<int>,
-    "int meets Connectable requirements unexpectedly");
+static_assert(!ozo::Connection<int>,
+    "int meets Connection requirements unexpectedly");
 
 struct connection_good : Test {
     io_context_mock io;

--- a/tests/connection_info.cpp
+++ b/tests/connection_info.cpp
@@ -11,6 +11,7 @@ TEST(connection_info, sould_return_error_and_bad_connect_for_invalid_connection_
 
     ozo::get_connection(conn_info, [](ozo::error_code ec, auto conn){
         EXPECT_TRUE(ec);
+        EXPECT_TRUE(!ozo::error_message(conn).empty());
         EXPECT_TRUE(ozo::connection_bad(conn));
     });
 

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -82,31 +82,6 @@ struct connection {
     connection_mock* mock_ = nullptr;
     std::string error_context_;
 
-    friend OidMap& get_connection_oid_map(connection& conn) {
-        return conn.oid_map_;
-    }
-    friend const OidMap& get_connection_oid_map(const connection& conn) {
-        return conn.oid_map_;
-    }
-    friend auto& get_connection_socket(connection& conn) {
-        return conn.socket_;
-    }
-    friend const auto& get_connection_socket(const connection& conn) {
-        return conn.socket_;
-    }
-    friend handle_type& get_connection_handle(connection& conn) {
-        return conn.handle_;
-    }
-    friend const handle_type& get_connection_handle(const connection& conn) {
-        return conn.handle_;
-    }
-    friend std::string& get_connection_error_context(connection& conn) {
-        return conn.error_context_;
-    }
-    friend const std::string& get_connection_error_context(const connection& conn) {
-        return conn.error_context_;
-    }
-
     friend int pq_set_nonblocking(connection& c) {
         return c.mock_->set_nonblocking();
     }

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -140,10 +140,10 @@ static_assert(ozo::Connection<connection<>>,
     "connection does not meet Connection requirements");
 static_assert(ozo::ConnectionWrapper<connection_ptr<>>,
     "connection_ptr does not meet ConnectionWrapper requirements");
-static_assert(ozo::Connectable<connection<>>,
-    "connection does not meet Connectable requirements");
-static_assert(ozo::Connectable<connection_ptr<>>,
-    "connection_ptr does not meet Connectable requirements");
+static_assert(ozo::Connection<connection<>>,
+    "connection does not meet Connection requirements");
+static_assert(ozo::Connection<connection_ptr<>>,
+    "connection_ptr does not meet Connection requirements");
 
 template <typename OidMap = empty_oid_map>
 inline auto make_connection(connection_mock& mock, io_context& io,

--- a/tests/connection_pool.cpp
+++ b/tests/connection_pool.cpp
@@ -48,8 +48,8 @@ struct connection_pool {
 
 struct connection_provider;
 struct connection_provider_mock {
-    using connectable_type = std::shared_ptr<connection<>>;
-    using handler_type = std::function<void(error_code, connectable_type)>;
+    using connection_type = std::shared_ptr<connection<>>;
+    using handler_type = std::function<void(error_code, connection_type)>;
     MOCK_METHOD1(async_get_connection, void(handler_type));
 
     virtual ~connection_provider_mock() = default;
@@ -58,7 +58,7 @@ struct connection_provider_mock {
 struct connection_provider {
     connection_provider_mock* mock_ = nullptr;
 
-    using connectable_type = std::shared_ptr<connection<>>;
+    using connection_type = std::shared_ptr<connection<>>;
 
     template <typename Handler>
     friend void async_get_connection(connection_provider self, Handler&& h) {


### PR DESCRIPTION
Slightly refactored connection related concepts.

Remove Connectable concept as unused. A wrapped connection is a connection too.
Move customization some points to metafunction implementations (as result - reduced amount of code)
Default async_get_connection() implementation now uses provider's async_get_connection() member function instead of operator().

So next step is to make pooled_connection as a connection but not a wrapper to avoid store io_context bound socket.