### PR TITLE
Fix ussies with ozo::binder and ozo::connection_pool

### DIFF
--- a/include/ozo/detail/bind.h
+++ b/include/ozo/detail/bind.h
@@ -29,8 +29,14 @@ struct binder {
 
     using executor_type = decltype(asio::get_associated_executor(handler_));
 
-    auto get_executor() const noexcept {
+    executor_type get_executor() const noexcept {
         return asio::get_associated_executor(handler_);
+    }
+
+    using allocator_type = decltype(asio::get_associated_allocator(handler_));
+
+    allocator_type get_allocator() const noexcept {
+        return asio::get_associated_allocator(handler_);
     }
 };
 

--- a/include/ozo/impl/connection_pool.h
+++ b/include/ozo/impl/connection_pool.h
@@ -3,6 +3,7 @@
 #include <ozo/connection.h>
 #include <yamail/resource_pool/async/pool.hpp>
 #include <ozo/asio.h>
+#include <ozo/ext/std/shared_ptr.h>
 
 namespace ozo::impl {
 


### PR DESCRIPTION
First - add allocator forwarding to ozo::binder
Second - add missing include of std::shared_ptr adaptation in the
connection pool implementation header.