### PR TITLE
Use get_query_name() and get_raw_query_name() to get name of query.

### DIFF
--- a/include/ozo/impl/connection_pool.h
+++ b/include/ozo/impl/connection_pool.h
@@ -113,8 +113,14 @@ struct pooled_connection_wrapper {
 
     using executor_type = decltype(asio::get_associated_executor(handler_));
 
-    auto get_executor() const noexcept {
+    executor_type get_executor() const noexcept {
         return asio::get_associated_executor(handler_);
+    }
+
+    using allocator_type = decltype(asio::get_associated_allocator(handler_));
+
+    allocator_type get_allocator() const noexcept {
+        return asio::get_associated_allocator(handler_);
     }
 
     template <typename Func>


### PR DESCRIPTION
It allows to overload get_raw_query_name() in cases when use of `name` static member is not possible.