### PR TITLE
Transaction state check

### DIFF
--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -398,7 +398,7 @@ constexpr auto Connection = is_connection<std::decay_t<T>>::value;
  * In common cases you do not need this function. It's purpose is to support
  * extention and customization of the library. See get_native_handle for details.
  *
- * @param conn --- #Connection objec
+ * @param conn --- #Connection object
  * @return refernce to a wrapped PostgreSQL connection handle
  */
 template <typename T>
@@ -530,7 +530,7 @@ inline std::string_view error_message(T&& conn) {
 /**
  * @brief Gives additional error context from OZO
  *
- * Like libpq OZO provides additional context for different errors which
+ * In parallel with libpq OZO provides additional context for different errors which
  * can be while interacting via connection. This function gives access for
  * such context.
  *

--- a/include/ozo/impl/connection_pool.h
+++ b/include/ozo/impl/connection_pool.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ozo/connection.h>
+#include <ozo/transaction_status.h>
 #include <yamail/resource_pool/async/pool.hpp>
 #include <ozo/asio.h>
 #include <ozo/ext/std/shared_ptr.h>
@@ -31,7 +32,8 @@ struct pooled_connection {
     }
 
     ~pooled_connection() {
-        if (!empty() && connection_bad(*this)) {
+        if (!empty() && (connection_bad(*this)
+                || get_transaction_status(*this) != transaction_status::idle)) {
             handle_.waste();
         }
     }

--- a/include/ozo/impl/transaction_status.h
+++ b/include/ozo/impl/transaction_status.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <ozo/connection.h>
+#include <libpq-fe.h>
+
+namespace ozo {
+
+template <typename T>
+inline transaction_status get_transaction_status(T&& conn) {
+    static_assert(Connection<T>, "T must be a Connection");
+
+    if (is_null(conn)) {
+        return transaction_status::unknown;
+    }
+
+    const auto v = PQtransactionStatus(get_native_handle(conn));
+    switch (v) {
+        case PQTRANS_UNKNOWN: return transaction_status::unknown;
+        case PQTRANS_IDLE: return transaction_status::idle;
+        case PQTRANS_ACTIVE: return transaction_status::active;
+        case PQTRANS_INTRANS: return transaction_status::transaction;
+        case PQTRANS_INERROR: return transaction_status::error;
+    }
+    throw std::invalid_argument("unsupported transaction state");
+}
+
+} // namespace ozo

--- a/include/ozo/transaction_status.h
+++ b/include/ozo/transaction_status.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <ozo/connection.h>
+
+namespace ozo {
+
+/**
+ * @brief Transaction status of a #Connection
+ *
+ * Indicates current transaction status of a #Connection object. It reflects (but not equal!) libpq
+ * <a href="https://www.postgresql.org/docs/current/libpq-status.html">PGTransactionStatusType</a>.
+ *
+ * @note In case of developing own connection pool, it must be taking in account what #Connection
+ * can be reused only with `ozo::transaction_status::idle` status, in case of the other status
+ * the #Connection shall be closed rather than collected back into the pool.
+ *
+ * @ingroup group-connection-types
+ */
+enum class transaction_status {
+    unknown,  //!< transaction state is unknown due to bad or invalid connection object, reflects `PQTRANS_UNKNOWN`
+    idle, //!< connection is in idle state and can be reused, reflects `QTRANS_IDLE`
+    active, //!< command execution is in progress, reflects `PQTRANS_ACTIVE`
+    transaction, //!< idle, but within transaction block, reflects `PQTRANS_INTRANS`
+    error, //!< idle, within failed transaction, reflects `PQTRANS_INERROR`
+};
+
+/**
+ * @brief Returns current status of a #Connection object
+ *
+ * Returns current status of specified #Connection. If the #Connection is
+ * #Nullable in null-state returns `ozo::transaction_status::unknown`. In other
+ * case it returns value associated with libpq connection transaction status.
+ *
+ * @param conn --- #Connection
+ * @return transaction_status --- status of the #Connection
+ * @throws std::invalid_argument --- in case of unsupported value returned by libpq
+ * function. It is better to use `-Werror` compiler flag to prevent such possability by
+ * checking enumeration coverage in the `switch-case` statement.
+ */
+template <typename Connection>
+inline transaction_status get_transaction_status(Connection&& conn);
+
+} // namespace ozo
+
+#include <ozo/impl/transaction_status.h>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -81,6 +81,7 @@ set(SOURCES
     impl/async_start_transaction.cpp
     impl/async_end_transaction.cpp
     impl/transaction.cpp
+    transaction_status.cpp
     impl/async_request.cpp
     main.cpp
 )

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -17,6 +17,7 @@ struct native_handle {
     bool operator == (state rhs) const { return state_ == rhs; }
 
     native_handle(state s) : state_(s) {}
+    native_handle(state s, PGTransactionStatusType status) : state_(s), status_(status) {}
     native_handle() = default;
     state state_;
     PGTransactionStatusType status_ = PQTRANS_UNKNOWN;

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -8,11 +8,28 @@
 
 namespace ozo::tests {
 
-enum class native_handle {bad, good};
+struct native_handle {
+    enum state {bad, good};
+    native_handle& operator = (state v) {
+        state_ = v;
+        return *this;
+    }
+    bool operator == (state rhs) const { return state_ == rhs; }
+
+    native_handle(state s) : state_(s) {}
+    native_handle() = default;
+    state state_;
+    PGTransactionStatusType status_ = PQTRANS_UNKNOWN;
+};
 
 inline bool connection_status_bad(const native_handle* h) {
     return *h == native_handle::bad;
 }
+
+inline PGTransactionStatusType PQtransactionStatus(const native_handle* h) {
+    return h->status_;
+}
+
 struct pg_result {
     ExecStatusType status;
     error_code error;

--- a/tests/transaction_status.cpp
+++ b/tests/transaction_status.cpp
@@ -1,0 +1,57 @@
+#include <ozo/transaction_status.h>
+#include "connection_mock.h"
+#include <boost/asio/spawn.hpp>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace {
+
+struct get_transaction_status : testing::Test {
+    auto make_connection() {
+        using namespace ozo::tests;
+        return std::make_shared<connection<>>(connection<>{
+            std::make_unique<native_handle>(native_handle::good),
+            {}, {}, nullptr, "", {}
+        });
+    }
+};
+
+TEST_F(get_transaction_status, should_return_transaction_status_unknown_for_null_transaction) {
+    const auto conn = ozo::tests::connection_ptr<>();
+    EXPECT_EQ(ozo::transaction_status::unknown, ozo::get_transaction_status(conn));
+}
+
+TEST_F(get_transaction_status, should_return_throw_for_unsupported_status) {
+    const auto conn = make_connection();
+    conn->handle_->status_ = static_cast<PGTransactionStatusType>(-1);
+    EXPECT_THROW(ozo::get_transaction_status(conn), std::invalid_argument);
+}
+
+namespace with_params {
+
+struct get_transaction_status : ::get_transaction_status,
+        testing::WithParamInterface<std::tuple<PGTransactionStatusType, ozo::transaction_status>> {
+};
+
+TEST_P(get_transaction_status, should_return_status_for_connection){
+    const auto conn = make_connection();
+    conn->handle_->status_ = std::get<0>(GetParam());
+    EXPECT_EQ(std::get<1>(GetParam()), ozo::get_transaction_status(conn));
+}
+
+INSTANTIATE_TEST_CASE_P(
+    with_any_PGTransactionStatusType,
+    get_transaction_status,
+    testing::Values(
+        std::make_tuple(PQTRANS_UNKNOWN, ozo::transaction_status::unknown),
+        std::make_tuple(PQTRANS_IDLE, ozo::transaction_status::idle),
+        std::make_tuple(PQTRANS_ACTIVE, ozo::transaction_status::active),
+        std::make_tuple(PQTRANS_INTRANS, ozo::transaction_status::transaction),
+        std::make_tuple(PQTRANS_INERROR, ozo::transaction_status::error)
+    )
+);
+
+} // namespace with_params
+
+}


### PR DESCRIPTION
Add access to connection transaction status and check it before return connection into the connection pool.