### PR TITLE
Fix size_of() for strong_typedef_wrapper wrapped types

### DIFF
--- a/include/ozo/io/size_of.h
+++ b/include/ozo/io/size_of.h
@@ -65,7 +65,7 @@ struct size_of_default_impl {
 template <typename T>
 struct size_of_default_impl<T, Require<DynamicSize<T>>> {
     static constexpr auto apply(const T& v) noexcept(noexcept(std::size(v))){
-        return std::size(v) * sizeof(decltype(*v.begin()));
+        return std::size(v) * sizeof(decltype(*std::begin(v)));
     }
 };
 
@@ -73,7 +73,7 @@ template <typename T, typename = std::void_t<>>
 struct size_of_impl_dispatcher { using type = size_of_impl<std::decay_t<T>>; };
 
 template <typename T, typename Tag>
-struct size_of_impl_dispatcher<ozo::strong_typedef_wrapper<T, Tag>> : size_of_impl_dispatcher<T> {};
+struct size_of_impl_dispatcher<strong_typedef_wrapper<T, Tag>> { using type = size_of_impl<std::decay_t<T>>; };
 
 template <typename T>
 using get_size_of_impl = typename size_of_impl_dispatcher<unwrap_type<T>>::type;


### PR DESCRIPTION
The problem is what the previous fix is not correct. It leads to application
of size calculation algorithm for arrays instead of default algorithm for
dynamic size data.

New test are added to address this problem.