### PR TITLE
Add std array support

### DIFF
--- a/include/ozo/error.h
+++ b/include/ozo/error.h
@@ -85,6 +85,10 @@ enum code {
     result_status_empty_query, //!< the string sent to the server was empty
     result_status_bad_response, //!< the server's response was not understood
     oid_request_failed, //!< error during request oids from a database
+    bad_object_size, //!< an object size received does not equal to the expected
+    bad_array_size, //!< an array size received does not equal to the expected or not supported by the type
+    bad_array_dimension, //!< an array dimension count received does not equal to the expected or not supported by the type
+    bad_composite_size, //!< a composite's fields number received does not equal to the expected or not supported by the type
 };
 
 /**
@@ -439,6 +443,14 @@ public:
                 return "result_status_bad_response - the server's response was not understood";
             case oid_request_failed:
                 return "error during request oids from a database";
+            case bad_object_size:
+                return "an object size received does not equal to the expected";
+            case bad_array_size:
+                return "an array size received does not equal to the expected or not supported by the type";
+            case bad_array_dimension:
+                return "an array dimension count received does not equal to the expected or not supported by the type";
+            case bad_composite_size:
+                return "a composite's fields number received does not equal to the expected or not supported by the type";
         }
         return "no message for value: " + std::to_string(value);
     }

--- a/include/ozo/ext/std.h
+++ b/include/ozo/ext/std.h
@@ -9,3 +9,4 @@
 #include <ozo/ext/std/unique_ptr.h>
 #include <ozo/ext/std/vector.h>
 #include <ozo/ext/std/weak_ptr.h>
+#include <ozo/ext/std/array.h>

--- a/include/ozo/ext/std/array.h
+++ b/include/ozo/ext/std/array.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <ozo/io/array.h>
+#include <array>
+
+namespace ozo {
+
+template <typename T, std::size_t size>
+struct is_array<std::array<T, size>> : std::true_type {};
+
+template <typename T, std::size_t S>
+struct fit_array_size_impl<std::array<T, S>> {
+    static void apply(const std::array<T, S>& array, size_type size) {
+        if (size != static_cast<size_type>(array.size())) {
+            throw system_error(error::bad_array_size,
+                "received size " + std::to_string(size)
+                + " does not match array size " + std::to_string(array.size()));
+        }
+    }
+};
+
+} // namespace ozo

--- a/include/ozo/io/array.h
+++ b/include/ozo/io/array.h
@@ -96,7 +96,8 @@ struct recv_array_impl {
         read(in, array_header);
 
         if (array_header.dimensions_count > 1) {
-            throw std::range_error("multiply dimension count is not supported: "
+            throw system_error(error::bad_array_dimension,
+                "multiply dimension count is not supported: "
                  + std::to_string(array_header.dimensions_count));
         }
 

--- a/include/ozo/io/composite.h
+++ b/include/ozo/io/composite.h
@@ -96,7 +96,8 @@ inline Require<Composite<T>> read_and_verify_header(istream& in, const T& v) {
     pg_composite header;
     read(in, header);
     if (header.count != fields_number(v)) {
-        throw std::range_error("incoming composite fields count " + std::to_string(header.count)
+        throw system_error(error::bad_composite_size,
+            "incoming composite fields count " + std::to_string(header.count)
             + " does not match fields count " + std::to_string(fields_number(v))
             + " of type " + boost::core::demangle(typeid(v).name()));
     }

--- a/include/ozo/io/recv.h
+++ b/include/ozo/io/recv.h
@@ -108,7 +108,8 @@ struct recv_impl {
         if constexpr (DynamicSize<Out>) {
             out.resize(size);
         } else if (size != size_of(out)) {
-            throw std::range_error("data size " + std::to_string(size)
+            throw ozo::system_error(error::bad_object_size,
+                "data size " + std::to_string(size)
                 + " does not match type size " + std::to_string(size_of(out)));
         }
         return read(in, out);

--- a/tests/binary_deserialization.cpp
+++ b/tests/binary_deserialization.cpp
@@ -231,8 +231,7 @@ TEST_F(recv, should_throw_on_multidimential_arrays) {
     EXPECT_CALL(mock, get_isnull(_, _)).WillRepeatedly(Return(false));
 
     std::vector<std::string> got;
-    ;
-    EXPECT_THROW(ozo::recv(value, oid_map, got), std::range_error);
+    EXPECT_THROW(ozo::recv(value, oid_map, got), ozo::system_error);
 }
 
 TEST_F(recv, should_throw_on_inappropriate_element_oid) {
@@ -289,7 +288,7 @@ TEST_F(recv, should_throw_exception_when_size_of_integral_differs_from_given) {
     EXPECT_CALL(mock, get_isnull(_, _)).WillRepeatedly(Return(false));
 
     bool got = false;
-    EXPECT_THROW(ozo::recv(value, oid_map, got), std::range_error);
+    EXPECT_THROW(ozo::recv(value, oid_map, got), ozo::system_error);
 }
 
 TEST_F(recv, should_read_nothing_when_dimensions_count_is_zero) {

--- a/tests/binary_deserialization.cpp
+++ b/tests/binary_deserialization.cpp
@@ -211,6 +211,76 @@ TEST_F(recv, should_convert_TEXTARRAYOID_to_std_vector_of_std_string) {
     EXPECT_THAT(got, ElementsAre("test", "foo", "bar"));
 }
 
+TEST_F(recv, should_convert_TEXTARRAYOID_with_matched_size_to_std_array_of_std_string) {
+    const char bytes[] = {
+        0x00, 0x00, 0x00, 0x01, // dimension count
+        0x00, 0x00, 0x00, 0x00, // data offset
+        0x00, 0x00, 0x00, 0x19, // Oid
+        0x00, 0x00, 0x00, 0x03, // dimension size
+        0x00, 0x00, 0x00, 0x01, // dimension index
+        0x00, 0x00, 0x00, 0x04, // 1st element size
+        't', 'e', 's', 't',     // 1st element
+        0x00, 0x00, 0x00, 0x03, // 2nd element size
+        'f', 'o', 'o',          // 2ndst element
+        0x00, 0x00, 0x00, 0x03, // 3rd element size
+        'b', 'a', 'r',          // 3rd element
+    };
+    EXPECT_CALL(mock, field_type(_)).WillRepeatedly(Return(TEXTARRAYOID));
+    EXPECT_CALL(mock, get_value(_, _)).WillRepeatedly(Return(bytes));
+    EXPECT_CALL(mock, get_length(_, _)).WillRepeatedly(Return(sizeof bytes));
+    EXPECT_CALL(mock, get_isnull(_, _)).WillRepeatedly(Return(false));
+
+    std::array<std::string, 3> got;
+    ozo::recv(value, oid_map, got);
+    EXPECT_THAT(got, ElementsAre("test", "foo", "bar"));
+}
+
+TEST_F(recv, should_throw_exception_on_TEXTARRAYOID_with_greater_size_than_std_array) {
+    const char bytes[] = {
+        0x00, 0x00, 0x00, 0x01, // dimension count
+        0x00, 0x00, 0x00, 0x00, // data offset
+        0x00, 0x00, 0x00, 0x19, // Oid
+        0x00, 0x00, 0x00, 0x04, // dimension size
+        0x00, 0x00, 0x00, 0x01, // dimension index
+        0x00, 0x00, 0x00, 0x04, // 1st element size
+        't', 'e', 's', 't',     // 1st element
+        0x00, 0x00, 0x00, 0x03, // 2nd element size
+        'f', 'o', 'o',          // 2ndst element
+        0x00, 0x00, 0x00, 0x03, // 3rd element size
+        'b', 'a', 'r',          // 3rd element
+    };
+    EXPECT_CALL(mock, field_type(_)).WillRepeatedly(Return(TEXTARRAYOID));
+    EXPECT_CALL(mock, get_value(_, _)).WillRepeatedly(Return(bytes));
+    EXPECT_CALL(mock, get_length(_, _)).WillRepeatedly(Return(sizeof bytes));
+    EXPECT_CALL(mock, get_isnull(_, _)).WillRepeatedly(Return(false));
+
+    std::array<std::string, 2> got;
+    EXPECT_THROW(ozo::recv(value, oid_map, got), ozo::system_error);
+}
+
+TEST_F(recv, should_throw_exception_on_TEXTARRAYOID_with_less_size_than_std_array) {
+    const char bytes[] = {
+        0x00, 0x00, 0x00, 0x01, // dimension count
+        0x00, 0x00, 0x00, 0x00, // data offset
+        0x00, 0x00, 0x00, 0x19, // Oid
+        0x00, 0x00, 0x00, 0x04, // dimension size
+        0x00, 0x00, 0x00, 0x01, // dimension index
+        0x00, 0x00, 0x00, 0x04, // 1st element size
+        't', 'e', 's', 't',     // 1st element
+        0x00, 0x00, 0x00, 0x03, // 2nd element size
+        'f', 'o', 'o',          // 2ndst element
+        0x00, 0x00, 0x00, 0x03, // 3rd element size
+        'b', 'a', 'r',          // 3rd element
+    };
+    EXPECT_CALL(mock, field_type(_)).WillRepeatedly(Return(TEXTARRAYOID));
+    EXPECT_CALL(mock, get_value(_, _)).WillRepeatedly(Return(bytes));
+    EXPECT_CALL(mock, get_length(_, _)).WillRepeatedly(Return(sizeof bytes));
+    EXPECT_CALL(mock, get_isnull(_, _)).WillRepeatedly(Return(false));
+
+    std::array<std::string, 4> got;
+    EXPECT_THROW(ozo::recv(value, oid_map, got), ozo::system_error);
+}
+
 TEST_F(recv, should_throw_on_multidimential_arrays) {
     const char bytes[] = {
         0x00, 0x00, 0x00, 0x02, // dimension count

--- a/tests/binary_serialization.cpp
+++ b/tests/binary_serialization.cpp
@@ -85,6 +85,23 @@ TEST_F(send, with_std_vector_of_float_should_store_with_one_dimension_array_head
     }));
 }
 
+TEST_F(send, with_std_array_of_int_should_store_with_one_dimension_array_header_and_values) {
+    ozo::send(os, oid_map, std::array<int, 3>({1, 2, 3}));
+    EXPECT_EQ(buffer, std::vector<char>({
+        0, 0, 0, 1,
+        0, 0, 0, 0,
+        0, 0, 0, 0x17,
+        0, 0, 0, 3,
+        0, 0, 0, 0,
+        0, 0, 0, 4,
+        0, 0, 0, 0x1,
+        0, 0, 0, 4,
+        0, 0, 0, 0x2,
+        0, 0, 0, 4,
+        0, 0, 0, 0x3,
+    }));
+}
+
 TEST_F(send, should_send_nothing_for_std_nullptr_t) {
     ozo::send(os, oid_map, nullptr);
     EXPECT_TRUE(buffer.empty());

--- a/tests/composite.cpp
+++ b/tests/composite.cpp
@@ -228,7 +228,7 @@ TEST_F(recv_composite, should_throw_exception_if_wrong_number_of_fields_are_rece
 
     std::tuple<std::string, std::int64_t> got;
     ozo::set_type_oid<hana_test_struct>(oid_map, 0x10);
-    EXPECT_THROW(ozo::recv(value, oid_map, got), std::range_error);
+    EXPECT_THROW(ozo::recv(value, oid_map, got), ozo::system_error);
 }
 
 } // namespace


### PR DESCRIPTION
Adds support of std::array as a representation of array with fixed size.
Introduces ozo::fit_array_size() customisable function for resizing container to fit incoming array from DB. In case of fixed-size array in case of size mismatching it throws system_error with appropriate error code.
More detailed errors for size mismatches has been added.