### PR TITLE
[INCOMPATIBLE] unwrap() and Nullable  refactoring

### DIFF
--- a/examples/connection_pool.cpp
+++ b/examples/connection_pool.cpp
@@ -77,8 +77,12 @@ int main(int argc, char **argv) {
         // if there are no problems with target database, network or permissions for given user in connection
         // string.
         if (ec) {
-            std::cout << "Request failed with error: " << ec.message()
-                << ", error context: " << ozo::get_error_context(connection) << std::endl;
+            std::cout << "Request failed with error: " << ec.message();
+            // Here we should check if the connection is in null state to avoid UB.
+            if (!ozo::is_null_recursive(connection)) {
+                std::cout << ", error context: " << ozo::get_error_context(connection);
+            }
+            std::cout << std::endl;
             return;
         }
 

--- a/examples/request.cpp
+++ b/examples/request.cpp
@@ -55,8 +55,12 @@ int main(int argc, char **argv) {
         // if there are no problems with target database, network or permissions for given user in connection
         // string.
         if (ec) {
-            std::cout << "Request failed with error: " << ec.message()
-                << ", error context: " << ozo::get_error_context(connection) << std::endl;
+            std::cout << "Request failed with error: " << ec.message();
+            // Here we should check if the connection is in null state to avoid UB.
+            if (!ozo::is_null_recursive(connection)) {
+                std::cout << ", error context: " << ozo::get_error_context(connection);
+            }
+            std::cout << std::endl;
             return;
         }
 

--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -513,14 +513,14 @@ inline std::string_view error_message(T&& conn) {
 }
 
 /**
- * @brief Gives additional error context from OZO
+ * @brief Additional error context getter
  *
- * In parallel with libpq OZO provides additional context for different errors which
- * can be while interacting via connection. This function gives access for
- * such context.
+ * In addition to libpq OZO provides its own error context. This is
+ * a getter for such a context. Please be sure that the connection
+ * is not in the null state via `ozo::is_null_recursive()` function.
  *
- * @sa ozo::set_error_context(), ozo::reset_error_context()
- * @param conn --- #Connection to get context from
+ * @sa ozo::set_error_context(), ozo::reset_error_context(), ozo::is_null_recursive()
+ * @param conn --- #Connection to get context from, should not be in null state
  * @return `std::string` contains a context
  */
 template <typename T>
@@ -530,12 +530,13 @@ inline const auto& get_error_context(const T& conn) {
 }
 
 /**
- * @brief Set connection OZO-related error context
+ * @brief Additional error context setter
  *
- * Like libpq OZO provides additional context for errors.
- * This function sets such context for the specified connection.
+ * In addition to libpq OZO provides its own error context. This is
+ * a setter for such a context. Please be sure that the connection
+ * is not in the null state via `ozo::is_null_recursive()` function.
  *
- * @sa ozo::get_error_context(), ozo::reset_error_context()
+ * @sa ozo::get_error_context(), ozo::reset_error_context(), ozo::is_null_recursive()
  * @param conn --- #Connection to set context to
  * @param ctx --- context to set, now only `std::string` is supported
  */
@@ -546,12 +547,14 @@ inline void set_error_context(T& conn, Ctx&& ctx) {
 }
 
 /**
- * @brief Reset connection OZO-related error context
+ * @brief Reset additional error context
  *
- * This function resets OZO-related error context to default.
+ * This function resets additional error context to its default value.
+ * Please be sure that the connection  is not in the null state via
+ * `ozo::is_null_recursive()` function.
  *
- * @sa ozo::set_error_context(), ozo::get_error_context()
- * @param conn --- #Connection to reset context to
+ * @sa ozo::set_error_context(), ozo::get_error_context(), ozo::is_null_recursive()
+ * @param conn --- #Connection to reset context, should not be in null state
  */
 template <typename T>
 inline void reset_error_context(T& conn) {
@@ -565,8 +568,10 @@ inline void reset_error_context(T& conn) {
  *
  * This function gives access to a connection OID map, which represents mapping
  * of custom types to its' OIDs in a database connected to.
+ * Please be sure that the connection  is not in the null state via
+ * `ozo::is_null_recursive()` function.
  *
- * @param conn --- #Connection to access OID map of
+ * @param conn --- #Connection to access OID map, should not be in null state
  * @return OID map of the Connection
  */
 template <typename T>
@@ -580,7 +585,10 @@ inline decltype(auto) get_oid_map(T&& conn) noexcept {
  *
  * @note This feature is not implemented yet
  *
- * @param conn --- #Connection to access statistics of
+ * Please be sure that the connection  is not in the null state via
+ * `ozo::is_null_recursive()` function.
+ *
+ * @param conn --- #Connection to access statistics, should not be in null state
  * @return statistics of the Connection
  */
 template <typename T>
@@ -601,7 +609,10 @@ inline decltype(auto) get_statistics(T&& conn) noexcept {
  * <a href="https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/steady_timer.html">
  * boost::asio::steady_timer</a>).
  *
- * @param conn --- #Connection to access statistics of
+ * Please be sure that the connection  is not in the null state via
+ * `ozo::is_null_recursive()` function.
+ *
+ * @param conn --- #Connection to access statistics of, should not be in null state
  * @return a reference or proxy for a timer
  */
 template <typename T>

--- a/include/ozo/core/nullable.h
+++ b/include/ozo/core/nullable.h
@@ -11,31 +11,29 @@ template <typename T, typename Enable = void>
 struct is_nullable : std::false_type {};
 
 /**
- * @brief Indicates if type meets nullable requirements.
+ * @brief Indicates if type is marked as conformed to nullable requirements.
  *
- * `Nullable` type has to:
- * * have a null-state,
- * * be `bool` convertable - `false` indicates null state,
- * * be dereferenceable via `operator *`,
- * * have `allocate_nullable()` specialization (see the function documentation for how to).
+ * These next types are defined as `Nullable` via @ref group-ext of the library:
+ * * @ref group-ext-boost-optional,
+ * * @ref group-ext-boost-scoped_ptr,
+ * * @ref group-ext-boost-shared_ptr,
+ * * @ref group-ext-boost-weak_ptr,
+ * * @ref group-ext-std-nullopt,
+ * * @ref group-ext-std-nullptr,
+ * * @ref group-ext-std-optional,
+ * * @ref group-ext-std-shared_ptr,
+ * * @ref group-ext-std-unique_ptr,
+ * * @ref group-ext-std-weak_ptr.
  *
- * These next types are `Nullable` out of the box:
- * * `boost::optional`,
- * * `std::optional`,
- * * `boost::scoped_ptr`,
- * * `std::unique_ptr`,
- * * `boost::shared_ptr`,
- * * `std::shared_ptr`,
- * * `boost::weak_ptr`,
- * * `std::weak_ptr`.
- *
- * @note Raw pointers are not supported as `Nullable` by default, because this library uses RAII model for objects and
- * no special deallocation functions are used. But if it is really needed and you want to deallocate the allocated
- * objects manually you can add them as described below.
+ * If it is needed to mark type as nullable then `ozo::is_nullable` from the type should
+ * be specialized as `std::true_type` type. If the type has to be allocated in special way
+ * --- `ozo::allocate_nullable()` should be specialized (see @ref group-ext-std-shared_ptr as an example).
  *
  * ### Example
  *
- * If you want to add nullable type to the library --- you have to specialize `ozo::is_nullable` struct and specify allocation function like this:
+ * Raw pointers are not supported as `Nullable` by default, because this library uses RAII model for objects and
+ * no special deallocation functions are used. But if it is really needed and you want to deallocate the allocated
+ * objects manually you can add them as described below.
  *
  * @code
 //Add raw pointer to nullables
@@ -59,7 +57,7 @@ struct allocate_nullable_impl<T*> {
 
  * @endcode
  *
- * @sa ozo::unwrap(), is_null(), allocate_nullable(), init_nullable(), reset_nullable()
+ * @sa is_null(), allocate_nullable(), init_nullable(), reset_nullable()
  * @ingroup group-core-concepts
  * @hideinitializer
  */
@@ -97,6 +95,19 @@ struct allocate_nullable_impl {
     }
 };
 
+/**
+ * @brief Allocates nullable object of given type
+ *
+ * This function allocates memory and constructs nullable object of given type
+ * by means of given allocator if applicable. It uses `ozo::allocate_nullable_impl`
+ * functional object as an implementation.
+ * @note The function implementation may use no allocator and ignore the argument
+ * (e.g.: if it is not applicable to the given object type).
+ *
+ * @param out --- object to allocate to
+ * @param a --- allocator to use
+ * @ingroup group-core-functions
+ */
 template <typename T, typename Alloc>
 inline void allocate_nullable(T& out, const Alloc& a) {
     static_assert(Nullable<T>, "T must be nullable");

--- a/include/ozo/core/recursive.h
+++ b/include/ozo/core/recursive.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <ozo/core/nullable.h>
+#include <ozo/core/unwrap.h>
+
+namespace ozo {
+
+template <typename T, typename = hana::when<true>>
+struct unwrap_recursive_impl : unwrap_impl<T> {};
+
+/**
+ * @brief Unwraps argument underlying value recursively.
+ *
+ * This utility function unwraps argument recursively applying `ozo::unwrap()` function until
+ * the type of unwrapped value and type of it's argument become the same.
+ *
+ * @note Before applying the function it is better to check the object recursively for a null
+ * state via `ozo::is_null_recursive()`.
+ *
+ * The function is equal to this pesudo-code:
+ * @code
+constexpr decltype(auto) unwrap_recursive(auto&& arg) noexcept {
+    while (decltype(arg) != unwrap_type<decltype(arg)>) {
+        arg = unwrap(arg);
+    }
+    return arg;
+}
+ * @endcode
+ *
+ * @param value --- object to unwrap
+ * @return implementation depended result of recursively applied `ozo::unwrap()`
+ * @ingroup group-core-functions
+ * @sa ozo::is_null_recursive()
+ */
+template <typename T>
+inline constexpr decltype(auto) unwrap_recursive(T&& v) noexcept {
+    return unwrap_recursive_impl<std::decay_t<T>>::apply(std::forward<T>(v));
+}
+
+template <typename T>
+struct unwrap_recursive_impl<T, hana::when<!std::is_same_v<T, unwrap_type<T>>>> {
+    template <typename TT>
+    static constexpr decltype(auto) apply(TT&& v) noexcept {
+        return unwrap_recursive(unwrap(v));
+    }
+};
+
+template <typename T, typename = hana::when<true>>
+struct is_null_recursive_impl : is_null_impl<T> {};
+
+/**
+ * @brief Indicates if one of unwrapped values is in null state
+ *
+ * This utility function recursively examines the value for a null state.
+ * The function is useful to examine #Connection object for a null state
+ * because it is normal for such object to be wrapped.
+ *
+ * The function is equal to this pesudo-code:
+ * @code
+constexpr bool is_null_recursive(auto&& arg) noexcept {
+    while (decltype(arg) != unwrap_type<decltype(arg)>) {
+        if (is_null(arg)) {
+            return true;
+        }
+        arg = unwrap(arg);
+    }
+    return false;
+}
+ * @endcode
+ *
+ * @param v --- object to examine
+ * @return `true` --- one of the objects is in null-state,
+ * @return `false` --- overwise.
+ * @ingroup group-core-functions
+ * @sa ozo::is_null(), ozo::unwrap()
+ */
+template <typename T>
+inline constexpr bool is_null_recursive(T&& v) noexcept {
+    return is_null_recursive_impl<std::decay_t<T>>::apply(std::forward<T>(v));
+}
+
+template <typename T>
+struct is_null_recursive_impl<T, hana::when<!std::is_same_v<T, unwrap_type<T>>>> {
+    template <typename TT>
+    static constexpr bool apply(TT&& v) noexcept {
+        return is_null(v) ? true : is_null_recursive(unwrap(v));
+    }
+};
+
+} // namespace ozo

--- a/include/ozo/core/unwrap.h
+++ b/include/ozo/core/unwrap.h
@@ -2,51 +2,55 @@
 
 #include <ozo/core/nullable.h>
 #include <ozo/core/concept.h>
+#include <ozo/detail/functional.h>
+
+#include <boost/hana/core/when.hpp>
 
 namespace ozo {
 
-namespace detail {
-
-struct unwrap_with_forward {
-    template <typename T>
-    constexpr static decltype(auto) apply(T&& v) noexcept {
-        return std::forward<T>(v);
-    }
-};
-
-struct unwrap_with_dereference {
-    template <typename T>
-    constexpr static decltype(auto) apply(T&& v) noexcept(noexcept(*v)) {
-        return *v;
-    }
-};
-
-struct unwrap_with_get {
-    template <typename T>
-    constexpr static decltype(auto) apply(T&& v) noexcept(noexcept(v.get())) {
-        return v.get();
-    }
-};
-
-template <typename T, typename = std::void_t<>>
-struct unwrap_impl_default : unwrap_with_forward {};
-
-template <typename T>
-struct unwrap_impl_default <T, Require<Nullable<T>>> : unwrap_with_dereference {};
-
-} // namespace detail
-
-
-template <typename T>
-struct unwrap_impl : detail::unwrap_impl_default<T> {};
+namespace hana = boost::hana;
 
 /**
- * @brief Dereference #Nullable argument or forward it
+ * @brief Implementation of `ozo::unwrap()`
  *
- * This utility function gets value from #Nullable, and pass object as it is if it is not #Nullable
+ * This function defines how to unwrap ano object of type T by means of
+ * static member function apply. E.g. in most common cases it may be defined
+ * in general way like:
+ *
+ * @code
+template <typename Arg>
+constexpr static decltype(auto) apply(Arg&& v);
+ * @endcode
+ *
+ * In case if you want to specify different behaviour for different type of references
+ * the function may be implemented in specific way like:
+ *
+ * @code
+constexpr static decltype(auto) apply(T&& v);
+constexpr static decltype(auto) apply(T& v);
+constexpr static decltype(auto) apply(const T& v);
+ * @endcode
+ *
+ * @tparam T --- decayed type to apply function to.
+ * @tparam When --- boost::hana::when specified condition for the overloading.
+ * @ingroup group-core-types
+ */
+template <typename T, typename When = hana::when<true>>
+struct unwrap_impl : detail::functional::forward {};
+
+/**
+ * @brief Unwraps argument underlying value or forwards the argument.
+ *
+ * This utility function returns underlying value of it's argument as defined by
+ * the operation implementation `ozo::unwrap_impl<std::decay_t<T>>::apply(std::forward<T>(v))`.
+ *
+ * Default in-library implementations:
+ * - for #Nullable - returns result of argument object dereference,
+ * - for `std::reference_wrapper` - returns result of `std::reference_wrapper::get()` member function,
+ * - in other cases - returns result of `std::forward<T>(v)`
  *
  * @param value --- object to unwrap
- * @return dereferenced argument in case of #Nullable, pass as is if it is not.
+ * @return implementation depended value.
  * @ingroup group-core-functions
  */
 template <typename T>
@@ -56,7 +60,12 @@ constexpr decltype(auto) unwrap(T&& v) noexcept(
 }
 
 template <typename T>
-struct unwrap_impl<std::reference_wrapper<T>> : detail::unwrap_with_get {};
+struct unwrap_impl<std::reference_wrapper<T>> {
+    template <typename Ref>
+    constexpr static decltype(auto) apply(Ref&& v) noexcept {
+        return v.get();
+    }
+};
 
 /**
  * @brief Unwraps nullable or reference wrapped type

--- a/include/ozo/core/unwrap.h
+++ b/include/ozo/core/unwrap.h
@@ -11,9 +11,9 @@ namespace ozo {
 namespace hana = boost::hana;
 
 /**
- * @brief Implementation of `ozo::unwrap()`
+ * @brief Default implementation of `ozo::unwrap()`
  *
- * This function defines how to unwrap ano object of type T by means of
+ * This functional class defines how to unwrap an object of type T by means of
  * static member function apply. E.g. in most common cases it may be defined
  * in general way like:
  *
@@ -42,15 +42,15 @@ struct unwrap_impl : detail::functional::forward {};
  * @brief Unwraps argument underlying value or forwards the argument.
  *
  * This utility function returns underlying value of it's argument as defined by
- * the operation implementation `ozo::unwrap_impl<std::decay_t<T>>::apply(std::forward<T>(v))`.
+ * the operation implementation `ozo::unwrap_impl`.
  *
- * Default in-library implementations:
- * - for #Nullable - returns result of argument object dereference,
- * - for `std::reference_wrapper` - returns result of `std::reference_wrapper::get()` member function,
- * - in other cases - returns result of `std::forward<T>(v)`
+ * In-library implementations returns:
+ * - reference on an underlying value - `std::reference_wrapper` and other types like pointers,
+ *   optional values which are defined via @ref group-ext,
+ * - argument itself by default.
  *
  * @param value --- object to unwrap
- * @return implementation depended value.
+ * @return implementation depended result of `unwrap_impl<std::decay_t<T>>::apply(std::forward<T>(v))` call
  * @ingroup group-core-functions
  */
 template <typename T>

--- a/include/ozo/detail/functional.h
+++ b/include/ozo/detail/functional.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <utility>
+
+namespace ozo::detail::functional {
+
+struct forward {
+    template <typename T>
+    constexpr static decltype(auto) apply(T&& v) noexcept {
+        return std::forward<T>(v);
+    }
+};
+
+struct dereference {
+    template <typename T>
+    constexpr static decltype(auto) apply(T&& v) noexcept(noexcept(*v)) {
+        return *v;
+    }
+};
+
+struct operator_not {
+    template <typename T>
+    constexpr static decltype(auto) apply(T&& v) noexcept(noexcept(!v)) {
+        return !v;
+    }
+};
+
+struct always_true {
+    template <typename T>
+    constexpr static std::true_type apply(T&&) noexcept { return {};}
+};
+
+struct always_false {
+    template <typename T>
+    constexpr static std::false_type apply(T&&) noexcept { return {};}
+};
+
+} // namespace ozo::detail::functional

--- a/include/ozo/ext/boost.h
+++ b/include/ozo/ext/boost.h
@@ -1,5 +1,13 @@
 #pragma once
 
+/**
+ * @defgroup group-ext-boost Boost
+ * @ingroup group-ext
+ * @brief Library extentions for Boost.
+ *
+ * Contains extentions are related to Boost library types.
+ */
+
 #include <ozo/ext/boost/optional.h>
 #include <ozo/ext/boost/scoped_ptr.h>
 #include <ozo/ext/boost/shared_ptr.h>

--- a/include/ozo/ext/boost/optional.h
+++ b/include/ozo/ext/boost/optional.h
@@ -4,11 +4,25 @@
 #include <boost/optional.hpp>
 
 namespace ozo {
-
+/**
+ * @defgroup group-ext-boost-optional boost::optional
+ * @ingroup group-ext-boost
+ * @brief [Boost.Optional](https://www.boost.org/doc/libs/1_69_0/libs/optional/doc/html/index.html) library support
+ *
+ *@code
+#include <ozo/ext/boost/optional.h>
+ *@endcode
+ *
+ * The `boost::optional<T>` type is defined as #Nullable and uses default
+ * implementation of related functions.
+ *
+ * The `ozo::unwrap()` function is implemented via the dereference operator.
+ */
+///@{
 template <typename T>
 struct is_nullable<boost::optional<T>> : std::true_type {};
 
 template <typename T>
 struct unwrap_impl<boost::optional<T>> : detail::functional::dereference {};
-
+///@}
 } // namespace ozo

--- a/include/ozo/ext/boost/optional.h
+++ b/include/ozo/ext/boost/optional.h
@@ -8,4 +8,7 @@ namespace ozo {
 template <typename T>
 struct is_nullable<boost::optional<T>> : std::true_type {};
 
+template <typename T>
+struct unwrap_impl<boost::optional<T>> : detail::functional::dereference {};
+
 } // namespace ozo

--- a/include/ozo/ext/boost/scoped_ptr.h
+++ b/include/ozo/ext/boost/scoped_ptr.h
@@ -16,4 +16,7 @@ struct allocate_nullable_impl<boost::scoped_ptr<T>> {
     }
 };
 
+template <typename T>
+struct unwrap_impl<boost::scoped_ptr<T>> : detail::functional::dereference {};
+
 } // namespace ozo

--- a/include/ozo/ext/boost/scoped_ptr.h
+++ b/include/ozo/ext/boost/scoped_ptr.h
@@ -4,7 +4,23 @@
 #include <boost/scoped_ptr.hpp>
 
 namespace ozo {
-
+/**
+ * @defgroup group-ext-boost-scoped_ptr boost::scoped_ptr
+ * @ingroup group-ext-boost
+ * @brief [boost::scoped_ptr](https://www.boost.org/doc/libs/1_69_0/libs/smart_ptr/doc/html/smart_ptr.html#scoped_ptr) support
+ *
+ *@code
+#include <ozo/ext/boost/scoped_ptr.h>
+ *@endcode
+ *
+ * `boost::scoped_ptr<T>` is defined as #Nullable and uses the default implementation of `ozo::is_null()`.
+ *
+ * Function `ozo::allocate_nullable()` implementation is specialized via direct call of `operator new`, so the allocator
+ * argument is ignored.
+ *
+ * The `ozo::unwrap()` function is implemented via the dereference operator.
+ */
+///@{
 template <typename T>
 struct is_nullable<boost::scoped_ptr<T>> : std::true_type {};
 
@@ -18,5 +34,5 @@ struct allocate_nullable_impl<boost::scoped_ptr<T>> {
 
 template <typename T>
 struct unwrap_impl<boost::scoped_ptr<T>> : detail::functional::dereference {};
-
+///@}
 } // namespace ozo

--- a/include/ozo/ext/boost/shared_ptr.h
+++ b/include/ozo/ext/boost/shared_ptr.h
@@ -17,4 +17,7 @@ struct allocate_nullable_impl<boost::shared_ptr<T>> {
     }
 };
 
+template <typename T>
+struct unwrap_impl<boost::shared_ptr<T>> : detail::functional::dereference {};
+
 } // namespace ozo

--- a/include/ozo/ext/boost/shared_ptr.h
+++ b/include/ozo/ext/boost/shared_ptr.h
@@ -5,7 +5,23 @@
 #include <boost/make_shared.hpp>
 
 namespace ozo {
-
+/**
+ * @defgroup group-ext-boost-shared_ptr boost::shared_ptr
+ * @ingroup group-ext-boost
+ * @brief [boost::shared_ptr](https://www.boost.org/doc/libs/1_69_0/libs/smart_ptr/doc/html/smart_ptr.html#shared_ptr) support
+ *
+ *@code
+#include <ozo/ext/boost/shared_ptr.h>
+ *@endcode
+ *
+ * `boost::shared_ptr<T>` is defined as #Nullable and uses the default implementation of `ozo::is_null()`.
+ *
+ * Function `ozo::allocate_nullable()` implementation is specialized via
+ * [boost::allocate_shared()](https://www.boost.org/doc/libs/1_69_0/libs/smart_ptr/doc/html/smart_ptr.html#make_shared).
+ *
+ * The `ozo::unwrap()` function is implemented via the dereference operator.
+ */
+///@{
 template <typename T>
 struct is_nullable<boost::shared_ptr<T>> : std::true_type {};
 
@@ -19,5 +35,5 @@ struct allocate_nullable_impl<boost::shared_ptr<T>> {
 
 template <typename T>
 struct unwrap_impl<boost::shared_ptr<T>> : detail::functional::dereference {};
-
+///@}
 } // namespace ozo

--- a/include/ozo/ext/boost/weak_ptr.h
+++ b/include/ozo/ext/boost/weak_ptr.h
@@ -4,7 +4,23 @@
 #include <boost/weak_ptr.hpp>
 
 namespace ozo {
-
+/**
+ * @defgroup group-ext-boost-weak_ptr boost::weak_ptr
+ * @ingroup group-ext-boost
+ * @brief [boost::weak_ptr](https://www.boost.org/doc/libs/1_69_0/libs/smart_ptr/doc/html/smart_ptr.html#weak_ptr) support
+ *
+ *@code
+#include <ozo/ext/boost/weak_ptr.h>
+ *@endcode
+ *
+ * `boost::weak_ptr<T>` is defined as #Nullable and uses the implementation of `ozo::is_null()` examing the
+ * result of `boost::weak_ptr::lock()` method call.
+ *
+ * The `ozo::unwrap()` function is implemented dereferencing the result of `boost::weak_ptr::lock()`
+ * method call.
+ * @note `ozo::unwrap()` from `boost::weak_ptr` is not safe for reference holding since no object owning.
+ */
+///@{
 template <typename T>
 struct is_nullable<boost::weak_ptr<T>> : std::true_type {};
 
@@ -23,5 +39,5 @@ struct is_null_impl<boost::weak_ptr<T>> {
         return is_null(v.lock());
     }
 };
-
+///@}
 } // namespace ozo

--- a/include/ozo/ext/std.h
+++ b/include/ozo/ext/std.h
@@ -1,5 +1,13 @@
 #pragma once
 
+/**
+ * @defgroup group-ext-std STL
+ * @ingroup group-ext
+ * @brief Library extentions for STL.
+ *
+ * Contains extentions are related to the Standard C++ library types.
+ */
+
 #include <ozo/ext/std/list.h>
 #include <ozo/ext/std/nullopt_t.h>
 #include <ozo/ext/std/nullptr_t.h>

--- a/include/ozo/ext/std/array.h
+++ b/include/ozo/ext/std/array.h
@@ -4,7 +4,23 @@
 #include <array>
 
 namespace ozo {
-
+/**
+ * @defgroup group-ext-std-array std::array
+ * @ingroup group-ext-std
+ * @brief [std::array](https://en.cppreference.com/w/cpp/container/array) support
+ *
+ *@code
+#include <ozo/ext/std/array.h>
+ *@endcode
+ *
+ * `std::array<T, N>` is defined as an one dimensional #Array representation type
+ * with fixed size.
+ *
+ * The `ozo::fit_array_size()` function throws `ozo::system_error` exception,
+ * with `ozo::error::bad_array_size` error code, if it's size argument does not
+ * equal to the array size.
+ */
+///@{
 template <typename T, std::size_t size>
 struct is_array<std::array<T, size>> : std::true_type {};
 
@@ -18,5 +34,5 @@ struct fit_array_size_impl<std::array<T, S>> {
         }
     }
 };
-
+///@}
 } // namespace ozo

--- a/include/ozo/ext/std/list.h
+++ b/include/ozo/ext/std/list.h
@@ -4,8 +4,19 @@
 #include <list>
 
 namespace ozo {
-
+/**
+ * @defgroup group-ext-std-list std::list
+ * @ingroup group-ext-std
+ * @brief [std::list](https://en.cppreference.com/w/cpp/container/list) support
+ *
+ *@code
+#include <ozo/ext/std/list.h>
+ *@endcode
+ *
+ * `std::list<T, Allocator>` is defined as an one dimensional #Array representation type.
+ */
+///@{
 template <typename ...Ts>
 struct is_array<std::list<Ts...>> : std::true_type {};
-
+///@}
 }

--- a/include/ozo/ext/std/nullopt_t.h
+++ b/include/ozo/ext/std/nullopt_t.h
@@ -3,6 +3,7 @@
 #include <ozo/type_traits.h>
 #include <ozo/optional.h>
 #include <ozo/io/send.h>
+#include <ozo/detail/functional.h>
 
 namespace ozo {
 
@@ -10,11 +11,10 @@ template <>
 struct is_nullable<__OZO_NULLOPT_T> : std::true_type {};
 
 template <>
-struct unwrap_impl<__OZO_NULLOPT_T> : detail::unwrap_with_forward {};
+struct unwrap_impl<__OZO_NULLOPT_T> : detail::functional::forward {};
 
 template <>
-struct is_null_impl<__OZO_NULLOPT_T> :
-    detail::is_null_always<__OZO_NULLOPT_T, std::true_type> {};
+struct is_null_impl<__OZO_NULLOPT_T> : detail::functional::always_true {};
 
 template <>
 struct send_impl<__OZO_NULLOPT_T> {

--- a/include/ozo/ext/std/nullopt_t.h
+++ b/include/ozo/ext/std/nullopt_t.h
@@ -6,7 +6,22 @@
 #include <ozo/detail/functional.h>
 
 namespace ozo {
-
+/**
+ * @defgroup group-ext-std-nullopt std::nullopt_t
+ * @ingroup group-ext-std
+ * @brief [std::nullopt](https://en.cppreference.com/w/cpp/utility/optional/nullopt) support
+ *
+ *@code
+#include <ozo/ext/std/nullopt_t.h>
+ *@endcode
+ *
+ * The `std::nullopt_t` type is defined as #Nullable which is always in null state.
+ *
+ * The `ozo::unwrap()` function with `std::nullopt_t` type argument returns `std::nullopt`.
+ *
+ * The `std::nullopt_t` type is mapped as `NULL` for PostgreSQL.
+ */
+///@{
 template <>
 struct is_nullable<__OZO_NULLOPT_T> : std::true_type {};
 
@@ -21,7 +36,7 @@ struct send_impl<__OZO_NULLOPT_T> {
     template <typename M, typename T>
     static ostream& apply(ostream& out, M&&, T&&) { return out;}
 };
-
+///@}
 } // namespace ozo
 
 OZO_PG_DEFINE_TYPE(__OZO_NULLOPT_T, "null", null_oid, decltype(null_state_size))

--- a/include/ozo/ext/std/nullptr_t.h
+++ b/include/ozo/ext/std/nullptr_t.h
@@ -2,6 +2,7 @@
 
 #include <ozo/type_traits.h>
 #include <ozo/io/send.h>
+#include <ozo/detail/functional.h>
 
 namespace ozo {
 
@@ -9,11 +10,10 @@ template <>
 struct is_nullable<std::nullptr_t> : std::true_type {};
 
 template <>
-struct unwrap_impl<std::nullptr_t> : detail::unwrap_with_forward {};
+struct unwrap_impl<std::nullptr_t> : detail::functional::forward {};
 
 template <>
-struct is_null_impl<std::nullptr_t> :
-    detail::is_null_always<std::nullptr_t, std::true_type> {};
+struct is_null_impl<std::nullptr_t> : detail::functional::always_true {};
 
 template <>
 struct send_impl<std::nullptr_t> {

--- a/include/ozo/ext/std/nullptr_t.h
+++ b/include/ozo/ext/std/nullptr_t.h
@@ -5,7 +5,22 @@
 #include <ozo/detail/functional.h>
 
 namespace ozo {
-
+/**
+ * @defgroup group-ext-std-nullptr std::nullptr
+ * @ingroup group-ext-std
+ * @brief [std::nullptr](https://en.cppreference.com/w/cpp/utility/optional/nullptr) support
+ *
+ *@code
+#include <ozo/ext/std/nullptr_t.h>
+ *@endcode
+ *
+ * The `std::nullptr_t` type is defined as #Nullable which is always in null state.
+ *
+ * The `ozo::unwrap()` function with `std::nullptr_t` type argument returns std::nullptr.
+ *
+ * The `std::nullptr_t` type is mapped as `NULL` for PostgreSQL.
+ */
+///@{
 template <>
 struct is_nullable<std::nullptr_t> : std::true_type {};
 
@@ -20,7 +35,7 @@ struct send_impl<std::nullptr_t> {
     template <typename M, typename T>
     static ostream& apply(ostream& out, M&&, T&&) { return out;}
 };
-
+///@}
 } // namespace ozo
 
 OZO_PG_DEFINE_TYPE(std::nullptr_t, "null", null_oid, decltype(null_state_size))

--- a/include/ozo/ext/std/optional.h
+++ b/include/ozo/ext/std/optional.h
@@ -8,6 +8,9 @@ namespace ozo {
 #ifdef __OZO_STD_OPTIONAL
 template <typename T>
 struct is_nullable<__OZO_STD_OPTIONAL<T>> : std::true_type {};
+
+template <typename T>
+struct unwrap_impl<__OZO_STD_OPTIONAL<T>> : detail::functional::dereference {};
 #endif
 
 } // namespace ozo

--- a/include/ozo/ext/std/optional.h
+++ b/include/ozo/ext/std/optional.h
@@ -4,7 +4,21 @@
 #include <ozo/optional.h>
 
 namespace ozo {
-
+/**
+ * @defgroup group-ext-std-optional std::optional
+ * @ingroup group-ext-std
+ * @brief [std::optional](https://en.cppreference.com/w/cpp/utility/optional) type support
+ *
+ *@code
+#include <ozo/ext/std/optional.h>
+ *@endcode
+ *
+ * The `std::optional<T>` type is defined as #Nullable and uses default
+ * implementation of related functions.
+ *
+ * The `ozo::unwrap()` function is implemented via the dereference operator.
+ */
+///@{
 #ifdef __OZO_STD_OPTIONAL
 template <typename T>
 struct is_nullable<__OZO_STD_OPTIONAL<T>> : std::true_type {};
@@ -12,5 +26,5 @@ struct is_nullable<__OZO_STD_OPTIONAL<T>> : std::true_type {};
 template <typename T>
 struct unwrap_impl<__OZO_STD_OPTIONAL<T>> : detail::functional::dereference {};
 #endif
-
+///@}
 } // namespace ozo

--- a/include/ozo/ext/std/shared_ptr.h
+++ b/include/ozo/ext/std/shared_ptr.h
@@ -16,4 +16,7 @@ struct allocate_nullable_impl<std::shared_ptr<T>> {
     }
 };
 
+template <typename T>
+struct unwrap_impl<std::shared_ptr<T>> : detail::functional::dereference {};
+
 } // namespace ozo

--- a/include/ozo/ext/std/shared_ptr.h
+++ b/include/ozo/ext/std/shared_ptr.h
@@ -4,7 +4,23 @@
 #include <memory>
 
 namespace ozo {
-
+/**
+ * @defgroup group-ext-std-shared_ptr std::shared_ptr
+ * @ingroup group-ext-std
+ * @brief [std::shared_ptr](https://en.cppreference.com/w/cpp/memory/shared_ptr) support
+ *
+ *@code
+#include <ozo/ext/std/shared_ptr.h>
+ *@endcode
+ *
+ * `std::shared_ptr<T>` is defined as #Nullable and uses the default implementation of `ozo::is_null()`.
+ *
+ * Function `ozo::allocate_nullable()` implementation is specialized via
+ * [std::allocate_shared()](https://en.cppreference.com/w/cpp/memory/shared_ptr/allocate_shared).
+ *
+ * The `ozo::unwrap()` function is implemented via the dereference operator.
+ */
+///@{
 template <typename T>
 struct is_nullable<std::shared_ptr<T>> : std::true_type {};
 
@@ -18,5 +34,5 @@ struct allocate_nullable_impl<std::shared_ptr<T>> {
 
 template <typename T>
 struct unwrap_impl<std::shared_ptr<T>> : detail::functional::dereference {};
-
+///@}
 } // namespace ozo

--- a/include/ozo/ext/std/tuple.h
+++ b/include/ozo/ext/std/tuple.h
@@ -3,6 +3,18 @@
 #include <ozo/type_traits.h>
 #include <tuple>
 
+/**
+ * @defgroup group-ext-std-tuple std::tuple
+ * @ingroup group-ext-std
+ * @brief [std::tuple](https://en.cppreference.com/w/cpp/utility/tuple) support
+ *
+ *@code
+#include <ozo/ext/std/tuple.h>
+ *@endcode
+ *
+ * `std::tuple<T...>` is defined as a generic composite type. and mapped as PostgreSQL
+ * `Record` type and its array.
+ */
 namespace ozo::definitions {
 
 template <typename ...Ts>

--- a/include/ozo/ext/std/unique_ptr.h
+++ b/include/ozo/ext/std/unique_ptr.h
@@ -16,4 +16,7 @@ struct allocate_nullable_impl<std::unique_ptr<T>> {
     }
 };
 
+template <typename T>
+struct unwrap_impl<std::unique_ptr<T>> : detail::functional::dereference {};
+
 } // namespace ozo

--- a/include/ozo/ext/std/unique_ptr.h
+++ b/include/ozo/ext/std/unique_ptr.h
@@ -4,7 +4,24 @@
 #include <memory>
 
 namespace ozo {
-
+/**
+ * @defgroup group-ext-std-unique_ptr std::unique_ptr
+ * @ingroup group-ext-std
+ * @brief [std::unique_ptr](https://www.std.org/doc/libs/1_69_0/libs/smart_ptr/doc/html/smart_ptr.html#unique_ptr) support
+ *
+ *@code
+#include <ozo/ext/std/unique_ptr.h>
+ *@endcode
+ *
+ * `std::unique_ptr<T>` is defined as #Nullable and uses the default implementation of `ozo::is_null()`.
+ *
+ * Function `ozo::allocate_nullable()` implementation is specialized via
+ * [std::make_unique<T>()](https://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique) so,
+ * the allocator argument is ignored.
+ *
+ * The `ozo::unwrap()` function is implemented via the dereference operator.
+ */
+///@{
 template <typename T, typename Deleter>
 struct is_nullable<std::unique_ptr<T, Deleter>> : std::true_type {};
 
@@ -18,5 +35,5 @@ struct allocate_nullable_impl<std::unique_ptr<T>> {
 
 template <typename T>
 struct unwrap_impl<std::unique_ptr<T>> : detail::functional::dereference {};
-
+///@}
 } // namespace ozo

--- a/include/ozo/ext/std/vector.h
+++ b/include/ozo/ext/std/vector.h
@@ -4,8 +4,19 @@
 #include <vector>
 
 namespace ozo {
-
+/**
+ * @defgroup group-ext-std-vector std::vector
+ * @ingroup group-ext-std
+ * @brief [std::vector](https://en.cppreference.com/w/cpp/container/vector) support
+ *
+ *@code
+#include <ozo/ext/std/vector.h>
+ *@endcode
+ *
+ * `std::vector<T, Allocator>` is defined as an one dimensional #Array representation type.
+ */
+///@{
 template <typename ...Ts>
 struct is_array<std::vector<Ts...>> : std::true_type {};
-
+///@}
 }

--- a/include/ozo/ext/std/weak_ptr.h
+++ b/include/ozo/ext/std/weak_ptr.h
@@ -4,7 +4,23 @@
 #include <memory>
 
 namespace ozo {
-
+/**
+ * @defgroup group-ext-std-weak_ptr std::weak_ptr
+ * @ingroup group-ext-std
+ * @brief [std::weak_ptr](https://en.cppreference.com/w/cpp/memory/weak_ptr) support
+ *
+ *@code
+#include <ozo/ext/std/weak_ptr.h>
+ *@endcode
+ *
+ * `std::weak_ptr<T>` is defined as #Nullable and uses the implementation of `ozo::is_null()` examing the
+ * result of `std::weak_ptr::lock()` method call.
+ *
+ * The `ozo::unwrap()` function is implemented dereferencing the result of `std::weak_ptr::lock()`
+ * method call.
+ * @note `ozo::unwrap()` from `std::weak_ptr` is not safe for reference holding since no object owning.
+ */
+///@{
 template <typename T>
 struct is_nullable<std::weak_ptr<T>> : std::true_type {};
 
@@ -23,5 +39,5 @@ struct is_null_impl<std::weak_ptr<T>> {
         return is_null(v.lock());
     }
 };
-
+///@}
 } // namespace ozo

--- a/include/ozo/impl/connection_pool.h
+++ b/include/ozo/impl/connection_pool.h
@@ -44,10 +44,20 @@ using pooled_connection_ptr = std::shared_ptr<pooled_connection<Source>>;
 } // namespace ozo::impl
 namespace ozo {
 template <typename T>
-struct unwrap_connection_impl<impl::pooled_connection<T>> {
+struct unwrap_impl<impl::pooled_connection<T>> {
     template <typename Conn>
     static constexpr decltype(auto) apply(Conn&& conn) noexcept {
-        return unwrap_connection(*(conn.handle_));
+        return unwrap(*conn.handle_);
+    }
+};
+
+template <typename T>
+struct is_nullable<impl::pooled_connection<T>> : std::true_type {};
+
+template <typename T>
+struct is_null_impl<impl::pooled_connection<T>> {
+    static bool apply(const impl::pooled_connection<T>& conn) {
+        return conn.empty() ? true : is_null(unwrap(conn));
     }
 };
 } // namespace ozo

--- a/include/ozo/impl/connection_pool.h
+++ b/include/ozo/impl/connection_pool.h
@@ -99,7 +99,7 @@ struct pooled_connection_wrapper {
         }
 
         auto conn = std::allocate_shared<connection>(get_allocator(), std::forward<Handle>(handle));
-        if (!conn->empty() && connection_good(conn)) {
+        if (connection_good(conn)) {
             ec = rebind_io_context(conn, io_);
             return handler_(std::move(ec), std::move(conn));
         }

--- a/include/ozo/impl/transaction.h
+++ b/include/ozo/impl/transaction.h
@@ -6,7 +6,7 @@ namespace ozo::impl {
 
 template <typename T>
 class transaction {
-    friend unwrap_connection_impl<transaction>;
+    friend unwrap_impl<transaction>;
 
 public:
     static_assert(Connection<T>, "T is not a Connection");
@@ -44,7 +44,7 @@ private:
         impl_type(T&& connection) : connection(std::move(connection)) {}
 
         bool has_connection() const {
-            return connection.has_value();
+            return connection.has_value() && !is_null(*connection);
         }
     };
 
@@ -61,10 +61,10 @@ auto make_transaction(T&& conn) {
 namespace ozo {
 
 template <typename T>
-struct unwrap_connection_impl<impl::transaction<T>> {
+struct unwrap_impl<impl::transaction<T>> {
     template <typename Transaction>
     static constexpr decltype(auto) apply(Transaction&& self) noexcept {
-        return unwrap_connection(*self.impl->connection);
+        return unwrap(*self.impl->connection);
     }
 };
 

--- a/include/ozo/ozo.h
+++ b/include/ozo/ozo.h
@@ -34,6 +34,15 @@
  * @brief Database requests related types.
  */
 
+/**
+ * @defgroup group-ext Extentions
+ * @brief Library extentions.
+ *
+ * The Library can be extended via specialization of different
+ * functors and traits. Here in-library extentions are collected.
+ * Use it as an example of extentions.
+ */
+
 #include <ozo/connection_pool.h>
 
 namespace ozo {

--- a/include/ozo/type_traits.h
+++ b/include/ozo/type_traits.h
@@ -101,8 +101,9 @@ constexpr null_oid_t null_oid;
  * Representation means that you can obtain PostgreSQL array into the supported
  * container.
  * Array by default can be represented via next containers:
- *   * `std::vector<T>`
- *   * `std::list<T>`
+ *   * @ref group-ext-std-vector
+ *   * @ref group-ext-std-list
+ *   * @ref group-ext-std-array
  *
  * @tparam T --- type to examine.
  *

--- a/tests/impl/transaction.cpp
+++ b/tests/impl/transaction.cpp
@@ -58,6 +58,11 @@ TEST_F(impl_transaction, transaction_without_connection_is_null) {
     EXPECT_TRUE(is_null(transaction));
 }
 
+TEST_F(impl_transaction, transaction_without_null_state_connection_is_null) {
+    ozo::impl::transaction<decltype(conn)> transaction(nullptr);
+    EXPECT_TRUE(is_null(transaction));
+}
+
 TEST_F(impl_transaction, transaction_become_null_after_take_connection) {
     auto transaction = ozo::impl::make_transaction(std::move(conn));
 

--- a/tests/type_traits.cpp
+++ b/tests/type_traits.cpp
@@ -2,6 +2,7 @@
 #include <ozo/io/size_of.h>
 #include <ozo/ext/boost.h>
 #include <ozo/ext/std.h>
+#include <ozo/core/recursive.h>
 
 #include <boost/make_shared.hpp>
 #include <boost/fusion/adapted/std_tuple.hpp>
@@ -68,6 +69,22 @@ TEST(is_null, should_return_false_for_non_nullable_type) {
     EXPECT_TRUE(!ozo::is_null(int()));
 }
 
+TEST(is_null_recursive, should_return_true_if_nested_nullable_type_is_null) {
+    boost::optional<boost::optional<std::shared_ptr<int>>> obj{{{nullptr}}};
+    EXPECT_FALSE(ozo::is_null(obj));
+    EXPECT_TRUE(ozo::is_null_recursive(obj));
+}
+
+TEST(is_null_recursive, should_return_false_if_nested_nullable_types_contains_no_null) {
+    boost::optional<boost::optional<std::shared_ptr<int>>> obj{{{std::make_shared<int>(0)}}};
+    EXPECT_FALSE(ozo::is_null(obj));
+    EXPECT_FALSE(ozo::is_null_recursive(obj));
+}
+
+TEST(is_null_recursive, should_return_false_for_non_nullable_type) {
+    EXPECT_FALSE(ozo::is_null_recursive(int()));
+}
+
 TEST(unwrap, should_unwrap_type) {
     boost::optional<int> n(7);
     EXPECT_EQ(ozo::unwrap(n), 7);
@@ -82,6 +99,27 @@ TEST(unwrap, should_unwrap_std_reference_wrapper) {
     int n(7);
     EXPECT_EQ(ozo::unwrap(std::ref(n)), 7);
 }
+
+TEST(unwrap_recursive, should_unwrap_type) {
+    boost::optional<int> n(7);
+    EXPECT_EQ(ozo::unwrap_recursive(n), 7);
+}
+
+TEST(unwrap_recursive, should_unwrap_type_recursively) {
+    boost::optional<boost::optional<int>> n{{7}};
+    EXPECT_EQ(ozo::unwrap_recursive(n), 7);
+}
+
+TEST(unwrap_recursive, should_unwrap_type_recursively_different_types) {
+    boost::optional<std::shared_ptr<int>> n{std::make_shared<int>(7)};
+    EXPECT_EQ(ozo::unwrap_recursive(n), 7);
+}
+
+TEST(unwrap_recursive, should_unwrap_notnullable_type) {
+    int n(7);
+    EXPECT_EQ(ozo::unwrap_recursive(n), 7);
+}
+
 
 }
 


### PR DESCRIPTION
Refactoring of the unwrap() function and Nullable concept usage. This refactoring is dedicated to the decoupling of these two. This PR may break user code in rare cases - the code won't compile if a user expects the dereferencing on calling unwrap() with custom Nullable type argument with no unwrap_impl specialization.