### PR TITLE
Failover framework

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,6 +28,10 @@ add_executable(ozo_request request.cpp)
 target_compile_features(ozo_request PRIVATE cxx_std_17)
 target_link_libraries(ozo_request ${LIBRARIES})
 
+add_executable(ozo_retry_request retry_request.cpp)
+target_compile_features(ozo_retry_request PRIVATE cxx_std_17)
+target_link_libraries(ozo_retry_request ${LIBRARIES})
+
 add_executable(ozo_connection_pool connection_pool.cpp)
 target_compile_features(ozo_connection_pool PRIVATE cxx_std_17)
 target_link_libraries(ozo_connection_pool ${LIBRARIES})

--- a/examples/retry_request.cpp
+++ b/examples/retry_request.cpp
@@ -1,0 +1,62 @@
+#include <ozo/connection_info.h>
+#include <ozo/request.h>
+#include <ozo/shortcuts.h>
+#include <ozo/failover/retry.h>
+
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/spawn.hpp>
+
+#include <iostream>
+
+namespace asio = boost::asio;
+
+int main(int argc, char **argv) {
+    std::cout << "OZO request example" << std::endl;
+
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <connection string>\n";
+        return 1;
+    }
+
+    asio::io_context io;
+
+    auto conn_info = ozo::connection_info(argv[1]);
+
+    asio::spawn(io, [&] (asio::yield_context yield) {
+        ozo::rows_of<int> result;
+        ozo::error_code ec;
+        using namespace ozo::literals;
+        using namespace std::chrono_literals;
+        // Here we will retry operation no more than 3 times on any error
+        // Each try will have its own time constraint
+        //   1st try will be limited by 1/3 sec.
+        //   2nd try will be limited by  (1 - t(1st try)) / 2 sec, which is not less than 1/3 sec.
+        //   3rd try will be limited by  1 - (t(1st try) + t(2nd try)), which is not less than 1/3 sec too.
+        const auto connection = ozo::request[3*ozo::failover::retry(ozo::errc::connection_error)]
+                (conn_info[io], "SELECT 1"_SQL, 1s, ozo::into(result), yield[ec]);
+
+        // When request is completed we check is there an error. This example should not produce any errors
+        // if there are no problems with target database, network or permissions for given user in connection
+        // string.
+        if (ec) {
+            std::cout << "Request failed with error: " << ec.message();
+            // Here we should check if the connection is in null state to avoid UB.
+            if (!ozo::is_null_recursive(connection)) {
+                std::cout << ", libpq error message: " << ozo::error_message(connection)
+                    << ", error context: " << ozo::get_error_context(connection);
+            }
+            std::cout << std::endl;
+            return;
+        }
+
+        // Just print request result
+        std::cout << "Selected:" << std::endl;
+        for (auto value : result) {
+            std::cout << std::get<0>(value) << std::endl;
+        }
+    });
+
+    io.run();
+
+    return 0;
+}

--- a/include/ozo/failover/retry.h
+++ b/include/ozo/failover/retry.h
@@ -1,0 +1,286 @@
+#pragma once
+
+#include <ozo/failover/strategy.h>
+#include <boost/hana/is_empty.hpp>
+#include <boost/hana/tuple.hpp>
+#include <boost/hana/fold.hpp>
+#include <boost/hana/concat.hpp>
+
+/**
+ * @defgroup group-failover-retry Retry
+ * @ingroup group-failover
+ * @brief Failover by simple retry operation
+ */
+
+namespace ozo::failover {
+
+namespace detail {
+
+template <typename TimeConstraint, typename Now = decltype(time_traits::now)>
+inline auto get_try_time_constraint(TimeConstraint t, int n_tries, [[maybe_unused]] Now now = time_traits::now) {
+    if constexpr (t == none) {
+        return none;
+    } else if constexpr (std::is_same_v<TimeConstraint, time_traits::time_point>) {
+        return n_tries > 0 ? time_left(t, now()) / n_tries : time_traits::duration{0};
+    } else {
+        return n_tries > 0 ? t / n_tries : time_traits::duration{0};
+    }
+}
+
+template <typename ...ErrorConditions>
+constexpr auto make_errcs_tuple(ErrorConditions ...errcs) {
+    return hana::make_tuple(errcs...);
+}
+
+} // namespace detail
+
+/**
+ * @brief Operation try representation
+ *
+ * Controls current try state incluiding number of tries remain, context of operation call for
+ * current try.
+ *
+ * @tparam ErrorConditions --- error conditions to match on for retry, should model #HanaSequence
+ * @tparam Context --- operation call context, literally operation arguments except #CompletionToken
+ * @ingroup group-failover-retry
+ */
+template <typename ErrorConditions, typename Context>
+class basic_try {
+public:
+    static_assert(HanaSequence<ErrorConditions>, "ErrorConditions should models HanaSequence");
+
+    /**
+     * @brief Construct a new basic try object.
+     *
+     * @param n_tries --- number of tries allowed, should not be less than 0.
+     * @param errcs --- retry conditions should model #HanaSequence for `ozo::error_code` and
+     *                  `ozo::error_condition` comparable types
+     * @param ctx --- operation context, compartible with `ozo::failover::basic_context`
+     */
+    basic_try(int n_tries, ErrorConditions errcs, Context ctx)
+    : ctx_(std::move(ctx)), errcs_(errcs), tries_remain_(n_tries) {
+        if (n_tries < 0) {
+            throw std::invalid_argument("number of tries should not be less than 0");
+        }
+    };
+
+    /**
+     * @brief Get the operation context.
+     *
+     * @return auto --- operation context for the try with modified time constraint;
+     *                  see `ozo::retry_strategy::tries()` for details about calculations.
+     */
+    auto get_context() const {
+        return hana::concat(
+            hana::make_tuple(unwrap(ctx_).provider, time_constraint()),
+            unwrap(ctx_).args
+        );
+    }
+
+    /**
+     * @brief Number of tries remains
+     *
+     * @return int --- number of tries remains to execute an operation, not less than 0.
+     */
+    int tries_remain() const { return tries_remain_;}
+
+    /**
+     * @brief Retry conditions for the try
+     *
+     * @return ErrorConditions --- #HanaSequence of retry conditions which have a
+     *                             chance to be solved by this try execution.
+     */
+    ErrorConditions get_conditions() const { return errcs_; }
+
+    /**
+     * @brief Get the next try
+     *
+     * Return next try object for retry operation if it possible. See
+     * `ozo::fallback::get_next_try()` for details.
+     *
+     * @param ec --- error code which should be examined for retry ability.
+     * @param conn --- #Connection object which should be closed anyway.
+     * @return `std::optional` --- initialized with basic_try object if retry is possible.
+     * @return `std::nullopt` --- retry is not possible due to `ec` value or tries remain
+     *                            count.
+     */
+    template <typename Connection>
+    std::optional<basic_try> get_next_try(error_code ec, Connection&& conn) const {
+        if (!is_null_recursive(conn)) {
+            close_connection(conn);
+        }
+        if (tries_remain()) {
+            auto retval = basic_try(tries_remain() - 1, get_conditions(), ctx_);
+            if(retval.can_retry(ec)) {
+                return retval;
+            }
+        }
+        return std::nullopt;
+    }
+
+private:
+    auto time_constraint() const {
+        return detail::get_try_time_constraint(unwrap(ctx_).time_constraint, tries_remain());
+    }
+
+    bool can_retry([[maybe_unused]] error_code ec) const {
+        if(!tries_remain()) {
+            return false;
+        }
+
+        if constexpr (decltype(hana::is_empty(get_conditions()))::value) {
+            return true;
+        } else {
+            const auto f = [ec](bool v, auto errc) { return v || (ec == errc); };
+            return boost::hana::fold(get_conditions(), false, f);
+        }
+    }
+
+    Context ctx_;
+    ErrorConditions errcs_;
+    int tries_remain_ = 1;
+};
+
+/**
+ * @brief Retry strategy
+ *
+ * Retry strategy is a factory for `ozo::fallback::basic_try` object.
+ *
+ * @tparam ErrorConditions --- #HanaSequence of retry conditions,
+ *                             see `ozo::failover::retry` for details.
+ * @ingroup group-failover-retry
+ */
+template <typename ErrorConditions>
+class retry_strategy {
+public:
+    constexpr retry_strategy(ErrorConditions errcs) : errcs_(std::move(errcs)) {}
+
+    /**
+     * @brief Get the first try object
+     *
+     * Default implementation for `ozo::fallback::get_first_try()` failover
+     * strategy interface function.
+     *
+     * @param alloc --- allocator which should be used for try context.
+     * @param args --- operation arguments.
+     * @return basic_try --- first try object.
+     */
+    template <typename Operation, typename Allocator, typename ConnectionProvider,
+        typename TimeConstraint, typename ...Args>
+    auto get_first_try(const Operation&, const Allocator& alloc,
+            ConnectionProvider&& provider, TimeConstraint t, Args&& ...args) const {
+        auto ctx = detail::allocate_shared<basic_context>(
+            alloc, std::forward<ConnectionProvider>(provider), ozo::deadline(t),
+            std::forward<Args>(args)...
+        );
+        return basic_try(get_tries(), get_conditions(), std::move(ctx));
+    }
+
+    /**
+     * @brief Specify number of tries
+     *
+     * Specify number of tries for an operation.
+     *
+     * @param n --- number of tries
+     * @return `retry_strategy` specialization object
+     *
+     * If operation has time constraint `T` each try would have its own
+     * time constraint according to the rule, there t<small>i</small> --- actual time of i<small>th</small> try:
+     * | Try number | Time constraint |
+     * |-----|------------------------------|
+     * | 1   | `T`/`n`                      |
+     * | 2   | (`T` - t<small>1</small>) / (n - 1) |
+     * | 3   | (`T` - (t<small>1</small> + t<small>2</small>)) / (n - 2) |
+     * | ... | |
+     * | N   | (`T` - (t<small>1</small> + t<small>2</small> + ... + t<small>n-1</small>))) |
+     *
+     * ###Example
+     *
+     * Retry on a network problem and operation timed-out no more than 3 tries.
+     * Each try has own time duration constraint calculated as:
+     * - for the 1st try: 0,5/3 sec.
+     * - for the 2nd try: (0,5 - t<small>1</small>) / 2 >= 0,5/3 sec.
+     * - for the 3rd try: 0,5 - (t<small>1</small> + t<small>2</small>) >= 0,5/3 sec.
+     *
+     * @code
+    auto retry = failover::retry(errc::network, errc::timeout);
+    ozo::request[retry*3](pool, query, .5s, out, yield);
+     * @endcode
+     */
+    constexpr auto tries(int n) const {
+        if (n < 0) {
+            throw std::invalid_argument(
+                "ozo::failover::retry_strategy::tries() argument "
+                "should not be less than 0");
+        }
+        auto retval = *this;
+        retval.tries_ = n;
+        return retval;
+    }
+
+    /**
+     * @brief Sintactic sugar for `ozo::retry_strategy::tries()`
+     *
+     * @param n --- number of tries
+     * @return `retry_strategy` specialization object
+     */
+    constexpr auto operator * (int n) const { return tries(n); }
+
+    /**
+     * @brief number of operation tries setted with `ozo::retry_strategy::tries()`
+     *
+     * @return int --- number of operation tries
+     */
+    constexpr int get_tries() const { return tries_; }
+
+    /**
+     * @brief Retry conditions for the strategy
+     *
+     * @return ErrorConditions --- retry conditions setted for this strategy.
+     */
+    constexpr ErrorConditions get_conditions() const { return errcs_; }
+
+private:
+    int tries_ = 1;
+    ErrorConditions errcs_;
+};
+
+template <typename ErrorConditions>
+inline auto operator * (int n, retry_strategy<ErrorConditions> rs) {
+    return rs * n;
+}
+
+/**
+ * Retry on specified error conditions.
+ *
+ * @param ec --- variadic of error conditions to retry
+ * @return `ozo::failover::retry_strategy` specialization.
+ *
+ * ###Example
+ *
+ * Retry on a network problem and operation timed-out no more than 3 tries.
+ * Each try has own time constraint calculated from total operation time constraint.
+ * See `ozo::failover::retry_strategy::tries()` for time constraint details.
+ *
+ * @code
+auto retry = failover::retry(errc::network, errc::timeout)*3;
+ozo::request[retry](pool, query, .5s, out, yield);
+ * @endcode
+ *
+ * @sa `ozo::failover::retry_strategy`
+ * @ingroup group-failover-retry
+ */
+template <typename ...ErrorConditions>
+constexpr auto retry(ErrorConditions ...ec) {
+    return retry_strategy(detail::make_errcs_tuple(ec...));
+}
+
+} // namespace ozo::failover
+
+namespace ozo {
+
+template <typename ...Ts, typename Op>
+struct construct_initiator_impl<failover::retry_strategy<Ts...>, Op>
+: failover::construct_initiator_impl {};
+
+} // namespace ozo

--- a/include/ozo/failover/strategy.h
+++ b/include/ozo/failover/strategy.h
@@ -1,0 +1,389 @@
+#pragma once
+
+#include <ozo/type_traits.h>
+#include <ozo/asio.h>
+#include <ozo/deadline.h>
+#include <ozo/connection.h>
+
+#include <tuple>
+
+
+/**
+ * @defgroup group-failover Failover
+ * @brief Failover microframwork for database-related operations
+ */
+
+/**
+ * @defgroup group-failover-strategy Strategy interface
+ * @ingroup group-failover
+ * @brief Failover microframwork strategy extention interface
+ */
+
+
+#ifdef OZO_DOCUMENTATION
+namespace ozo {
+/**
+ * @brief FailoverStrategy concept
+ *
+ * Failover strategy defines interface for the failover framework extention. `FailoverStrategy`
+ * should be a factory for the first #FailoverTry.
+ *
+ * ### Failover Compatible Operation
+ *
+@code
+
+#include <boost/asio/spawn.hpp>
+
+struct complex_transaction_data {
+//...
+};
+
+template <typename Initiator>
+struct complex_transaction_op : base_async_operation <complex_transaction_op, Initiator> {
+    using base = typename complex_transaction_op::base;
+    using base::base;
+
+    template <typename P, typename TimeConstraint, typename CompletionToken>
+    decltype(auto) operator() (P&& provider, complex_transaction_data data, TimeConstraint t, CompletionToken&& token) const {
+        static_assert(ozo::ConnectionProvider<P>, "provider should be a ConnectionProvider");
+        static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
+        return ozo::async_initiate<CompletionToken, ozo::handler_signature<P>>(
+            // Initiator and token
+            get_operation_initiator(*this), token,
+            // ConnectionProvider, TimeConstraint, additional arguments
+            std::forward<P>(provider), ozo::deadline(t), std::move(data)
+        );
+    }
+};
+
+namespace detail {
+template <typename Handler, typename TimeConstraint>
+struct complex_transaction_impl {
+    complex_transaction_data data_;
+    TimeConstraint time_constraint_;
+    Handler handler_;
+
+    template <typename Connection>
+    constexpr void operator()(error_code ec, Connection&& conn) {
+        if (ec) {
+            return handler_(ec, std::forward<Connection>(conn));
+        }
+        boost::asio::spawn(ozo::get_executor(conn), [
+                data = std::move(data_),
+                time_constraint = std::move(time_constraint_),
+                handler = std::move(handler_)] (auto yield) mutable {
+            error_code ec;
+            ozo::rows_of<...> rows;
+            auto conn = ozo::request(conn, time_constraint_, "..."_SQL..., ozo::into(rows), yield[ec]);
+            if (!ec) {
+                conn = ozo::execute(conn, time_constraint_, "..."_SQL + handle_data(rows)..., yield[ec]);
+                if (!ec) {
+                    return ozo::commit(conn, std::move(handler_));
+                }
+            }
+            auto ex = boost::asio::get_associated_executor(handler_);
+            boost::asio::dispatch(ex, [ec, handler=std::move(handler_), conn = std::move(conn)]{
+                handler(ec, std::move(conn));
+            });
+        });
+    }
+
+    using executor_type = decltype(asio::get_associated_executor(handler_));
+
+    executor_type get_executor() const noexcept {
+        return asio::get_associated_executor(handler_);
+    }
+
+    using allocator_type = decltype(asio::get_associated_allocator(handler_));
+
+    allocator_type get_allocator() const noexcept {
+        return asio::get_associated_allocator(handler_);
+    }
+};
+
+struct initiate_complex_transaction {
+    template <typename Handler, typename P, typename Q, typename TimeConstraint>
+    constexpr void operator()(Handler&& h, P&& provider, TimeConstraint t, complex_transaction_data data) const {
+        ozo::begin(provider, t, complex_transaction_impl{std::move(data), t, std::forward<Handler>(h)});
+    }
+};
+} // namespace detail
+
+constexpr complex_transaction_op<detail::initiate_async_execute> complex_transaction;
+@endcode
+ * @ingroup group-failover-strategy
+ * @hideinitializer
+ */
+template <typename T>
+constexpr auto FailoverStrategy = std::false_type;
+
+/**
+ * @brief FailoverTry concept
+ *
+ * Failover try defines interface for a single operation execution try and possible
+ * next failover try.
+ *
+ * @ingroup group-failover-strategy
+ * @hideinitializer
+ */
+template <typename T>
+constexpr auto FailoverTry = std::false_type;
+}
+#endif
+
+namespace ozo::failover {
+
+namespace hana = boost::hana;
+
+/**
+ * @brief Basic operation context
+ *
+ * @tparam ConnectionProvider --- #ConnectionProvider type.
+ * @tparam TimeConstraint --- operation #TimeConstraint type.
+ * @tparam Args --- other operation arguments' type.
+ * @ingroup group-failover-strategy
+ */
+template <
+    typename ConnectionProvider,
+    typename TimeConstraint,
+    typename ...Args>
+struct basic_context {
+    static_assert(ozo::TimeConstraint<TimeConstraint>, "TimeConstraint should models ozo::TimeConstraint");
+    static_assert(ozo::ConnectionProvider<ConnectionProvider>, "ConnectionProvider should models ozo::ConnectionProvider");
+
+    std::decay_t<ConnectionProvider> provider; //!< #ConnectionProvider for an operation, typically deduced from operation's 1st argument.
+    TimeConstraint time_constraint; //!< #TimeConstraint for an operation, typically deduced from operation's 2nd argument.
+    hana::tuple<std::decay_t<Args>...> args; //!< Other arguments of an operation except #CompletionToken.
+
+    /**
+     * @brief Construct a new basic context object
+     *
+     * @param p --- #ConnectionProvider for an operation.
+     * @param t --- #TimeConstraint for an operation.
+     * @param args --- other arguments of an operation except #CompletionToken.
+     */
+    basic_context(ConnectionProvider p, TimeConstraint t, Args ...args)
+    : provider(std::forward<ConnectionProvider>(p)),
+      time_constraint(t),
+      args(std::forward<Args>(args)...) {}
+};
+
+template <typename FailoverStrategy, typename Operation>
+struct get_first_try_impl {
+    template <typename Allocator, typename ...Args>
+    static auto apply(const Operation& op, const FailoverStrategy& s, const Allocator& alloc, Args&& ...args) {
+        return s.get_first_try(op, alloc, std::forward<Args>(args)...);
+    }
+};
+
+/**
+ * @brief Get the first try object for an operation
+ *
+ * This function is a part of failover strategy interface. It creates the first try of operation
+ * execution context. The context data should be allocated via the specified allocator. This function
+ * would be called once during a failover operation execution. By default #FailoverStrategy should
+ * have `get_first_try(const Operation& op, const Allocator& alloc, Args&& ...args) const` member function.
+ *
+ * @param op --- operation for which the try object should be created.
+ * @param strategy --- strategy according to which the try object should be created.
+ * @param alloc --- allocator for try object.
+ * @param args --- operation arguments except #CompletionToken.
+ * @return #FailoverTry object.
+ *
+ * ###Customization Point
+ *
+ * This function may be customized for a #FailoverStrategy via specialization
+ * of `ozo::failover::get_first_try_impl`. E.g.:
+ * @code
+namespace ozo::failover {
+
+template <typename Operation>
+struct get_first_try_impl<my_strategy, Operation> {
+    template <typename Allocator, typename ...Args>
+    static auto apply(const Operation&, const my_strategy& s, const Allocator& alloc, Args&& ...args) {
+        return s.get_start_context<Operation>(alloc, std::forward<Args>(args)...);
+    }
+};
+
+} // namespace ozo::failover
+ * @endcode
+ * @ingroup group-failover-strategy
+ */
+template <typename FailoverStrategy, typename Operation, typename Allocator, typename ...Args>
+inline auto get_first_try(const Operation& op, const FailoverStrategy& strategy, const Allocator& alloc, Args&& ...args) {
+    return get_first_try_impl<FailoverStrategy, Operation>::apply(op, strategy, alloc, std::forward<Args>(args)...);
+}
+
+template <typename Try>
+struct get_try_context_impl {
+    static decltype(auto) apply(const Try& a_try) {
+        return a_try.get_context();
+    }
+};
+
+/**
+ * @brief Get operation context for the try
+ *
+ * By default #FailoverTry object should have `get_context() const` member function.
+ *
+ * @param a_try --- #FailoverTry object
+ * @return auto --- #HanaSequence with operation arguments.
+ *
+ * ###Customization Point
+ *
+ * This function may be customized for a #FailoverTry via specialization
+ * of `ozo::failover::get_try_context_impl`. E.g.:
+ * @code
+namespace ozo::failover {
+
+template <>
+struct get_try_context_impl<my_strategy_try> {
+    template <typename Allocator, typename ...Args>
+    static auto apply(const my_strategy_try& obj) {
+        return obj.ctx;
+    }
+};
+
+} // namespace ozo::failover
+ * @endcode
+ * @ingroup group-failover-strategy
+ */
+template <typename FailoverTry>
+inline auto get_try_context(const FailoverTry& a_try) {
+    auto res = detail::apply<get_try_context_impl>(unwrap(a_try));
+    static_assert(HanaSequence<decltype(res)>,
+        "get_try_context_impl::apply() should provide HanaSequence");
+    return res;
+}
+
+template <typename Try>
+struct get_next_try_impl {
+    template <typename Conn>
+    static auto apply(Try& a_try, error_code ec, Conn&& conn) {
+        return a_try.get_next_try(ec, conn);
+    }
+};
+
+/**
+ * @brief Get the next try object
+ *
+ * Return #FailoverTry for next failover try if it possible. By default it calls
+ * `a_try.get_next_try(ec, conn)`. This behavior customisable via `ozo::failover::get_next_try_impl`
+ * specialization.
+ *
+ * @param a_try --- current #FailoverTry object.
+ * @param ec --- current try error code.
+ * @param conn --- current #connection object.
+ * @return #FailoverTry --- if given error code and connection may be failovered with next try.
+ * @return null-state --- otherwise.
+ *
+ * ###Customization Point
+ *
+ * This function may be customized for a #FailoverTry via specialization
+ * of `ozo::failover::get_next_try_impl`. E.g.:
+ * @code
+namespace ozo::failover {
+
+template <>
+struct get_next_try_impl<my_strategy_try> {
+    template <typename Allocator, typename ...Args>
+    static std::optional<my_strategy_try> apply(const my_strategy_try& obj, error_code ec, Conn&& conn) {
+        if (ec != my_error_condition::recoverable) {
+            obj.log_error("can not recover error {0} with message {1}", ec, ozo::error_message(conn));
+            return std::nullopt;
+        }
+        obj.log_notice("recovering error {0} with message {1}", ec, ozo::error_message(conn));
+        return obj;
+    }
+};
+
+} // namespace ozo::failover
+ * @endcode
+ * @ingroup group-failover-strategy
+ */
+template <typename Try, typename Connection>
+inline auto get_next_try(Try& a_try, error_code ec, Connection&& conn) {
+    return detail::apply<get_next_try_impl>(unwrap(a_try), std::move(ec),
+        std::forward<Connection>(conn));
+}
+
+namespace detail {
+
+template <template<typename...> typename Template, typename Allocator, typename ...Ts>
+static auto allocate_shared(const Allocator& alloc, Ts&& ...vs) {
+    using type = decltype(Template{std::forward<Ts>(vs)...});
+    return std::allocate_shared<type>(alloc, std::forward<Ts>(vs)...);
+}
+
+template <typename Try, typename Operation, typename Handler>
+inline void initiate_operation(const Operation&, Try&&, Handler&&);
+
+template <typename Operation, typename Try, typename Handler>
+struct continuation {
+    Operation op_;
+    Try try_;
+    Handler handler_;
+
+    continuation(const Operation& op, Try a_try, Handler handler)
+    : op_(op), try_(std::move(a_try)), handler_(std::move(handler)) {}
+
+    template <typename Connection>
+    void operator() (error_code ec, Connection&& conn) {
+        static_assert(ozo::Connection<Connection>, "conn should model Connection concept");
+        if (ec) {
+            auto next_try = get_next_try(try_, std::move(ec), std::forward<Connection>(conn));
+            if (!is_null(next_try)) {
+                initiate_operation(op_, std::move(next_try), std::move(handler_));
+                return;
+            }
+        }
+        handler_(std::move(ec), std::forward<Connection>(conn));
+    }
+
+    using executor_type = decltype(asio::get_associated_executor(handler_));
+
+    executor_type get_executor() const {
+        return asio::get_associated_executor(handler_);
+    }
+
+    using allocator_type = decltype(asio::get_associated_allocator(handler_));
+
+    allocator_type get_allocator() const {
+        return asio::get_associated_allocator(handler_);
+    }
+};
+
+template <typename Try, typename Operation, typename Handler>
+inline void initiate_operation(const Operation& op, Try&& a_try, Handler&& handler) {
+    hana::unpack(get_try_context(a_try), [&](auto&& ...args) {
+        ozo::get_operation_initiator(op)(
+            continuation{op, std::forward<Try>(a_try), std::forward<Handler>(handler)},
+            std::forward<decltype(args)>(args)...
+        );
+    });
+}
+
+template <typename FailoverStrategy, typename Operation>
+struct operation_initiator {
+    FailoverStrategy strategy_;
+    Operation op_;
+
+    constexpr operation_initiator(FailoverStrategy strategy, const Operation& op)
+    : strategy_(std::move(strategy)), op_(op) {}
+
+    template <typename Handler, typename ...Args>
+    void operator() (Handler&& handler, Args&& ...args) const {
+        auto first_try = get_first_try(op_, strategy_, asio::get_associated_allocator(handler), std::forward<Args>(args)...);
+        initiate_operation(op_, std::move(first_try), std::forward<Handler>(handler));
+    }
+};
+
+} // namespace detail
+
+struct construct_initiator_impl {
+    template <typename FailoverStrategy, typename Op>
+    constexpr static auto apply(FailoverStrategy&& strategy, const Op& op) {
+        return detail::operation_initiator(std::forward<FailoverStrategy>(strategy), op);
+    }
+};
+} // namespace ozo::failover

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,6 +69,8 @@ set(SOURCES
     transaction_status.cpp
     impl/async_request.cpp
     io/size_of.cpp
+    failover/retry.cpp
+    failover/strategy.cpp
     main.cpp
 )
 
@@ -80,6 +82,7 @@ if(OZO_BUILD_PG_TESTS)
         integration/get_connection_integration.cpp
         integration/execute_integration.cpp
         integration/transaction_integration.cpp
+        integration/retry_integration.cpp
     )
     add_definitions(-DOZO_PG_TEST_CONNINFO="${OZO_PG_TEST_CONNINFO}")
 endif()

--- a/tests/failover/retry.cpp
+++ b/tests/failover/retry.cpp
@@ -1,0 +1,191 @@
+#include <ozo/failover/retry.h>
+
+#include "../test_error.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace {
+
+using namespace testing;
+using time_point = ozo::time_traits::time_point;
+using duration = ozo::time_traits::duration;
+using namespace std::chrono_literals;
+
+struct fake_connection_provider {};
+
+struct get_try_time_constraint : Test {
+    constexpr static auto deadline = time_point{} + 3s;
+    constexpr static auto now() {return time_point{};}
+};
+
+struct connection_mock {
+    MOCK_CONST_METHOD0(close_connection, void());
+    friend void close_connection(connection_mock* self) {
+        if(!self) {
+            throw std::invalid_argument("self should not be null");
+        }
+        self->close_connection();
+    };
+};
+
+} // namespace
+
+// To make fake_connection_provider conforming to ConnectionProvider
+// for test purposes
+namespace ozo::detail {
+template <typename T>
+struct connection_provider_supports_time_constraint<fake_connection_provider, T>{
+    using type = std::true_type;
+};
+template <typename T>
+struct connection_provider_supports_time_constraint<fake_connection_provider*, T>{
+    using type = std::true_type;
+};
+} // namespace ozo::detail
+
+namespace ozo {
+// Some cheats about connection_mock which is not a connection
+// at all.
+template <>
+struct is_connection<connection_mock*> : std::true_type {};
+
+template <>
+struct is_nullable<connection_mock*> : std::true_type {};
+
+} // namespace
+
+namespace {
+
+namespace hana = boost::hana;
+using namespace std::literals;
+
+TEST_F(get_try_time_constraint, should_return_none_for_none_time_constraint) {
+    EXPECT_EQ(ozo::none,
+        ozo::failover::detail::get_try_time_constraint(ozo::none, 1));
+    EXPECT_EQ(ozo::none,
+        ozo::failover::detail::get_try_time_constraint(ozo::none, -1));
+    EXPECT_EQ(ozo::none,
+        ozo::failover::detail::get_try_time_constraint(ozo::none, 0));
+}
+
+TEST_F(get_try_time_constraint, should_return_duration_divided_on_try_count_for_try_count_greter_than_zero) {
+    EXPECT_EQ(1s, ozo::failover::detail::get_try_time_constraint(3s, 3));
+}
+
+TEST_F(get_try_time_constraint, should_return_zero_duration_for_try_count_zero) {
+    EXPECT_EQ(duration{0}, ozo::failover::detail::get_try_time_constraint(3s, 0));
+}
+
+TEST_F(get_try_time_constraint, should_return_zero_duration_for_try_count_less_than_zero) {
+    EXPECT_EQ(duration{0}, ozo::failover::detail::get_try_time_constraint(3s, -1));
+}
+
+TEST_F(get_try_time_constraint, should_return_time_left_divided_on_try_count_for_try_count_greter_than_zero) {
+    EXPECT_EQ(1s, ozo::failover::detail::get_try_time_constraint(deadline, 3, now));
+}
+
+TEST_F(get_try_time_constraint, should_return_zero_time_left_for_try_count_zero) {
+    EXPECT_EQ(duration{0}, ozo::failover::detail::get_try_time_constraint(deadline, 0, now));
+}
+
+TEST_F(get_try_time_constraint, should_return_zero_time_left_for_try_count_less_than_zero) {
+    EXPECT_EQ(duration{0}, ozo::failover::detail::get_try_time_constraint(deadline, -1, now));
+}
+
+struct basic_try__get_next_try : Test {
+    connection_mock conn;
+    auto ctx() const {
+        return ozo::failover::basic_context(fake_connection_provider{}, ozo::none);
+    }
+    static constexpr connection_mock* null_conn = nullptr;
+};
+
+TEST_F(basic_try__get_next_try, should_return_next_try_for_any_error_if_certain_is_not_specified) {
+    auto basic_try = ozo::failover::basic_try(3, hana::make_tuple(), ctx());
+    EXPECT_TRUE(basic_try.get_next_try(ozo::tests::error::error, null_conn));
+    EXPECT_TRUE(basic_try.get_next_try(ozo::tests::error::another_error, null_conn));
+    EXPECT_TRUE(basic_try.get_next_try(ozo::tests::error::ok, null_conn));
+}
+
+TEST_F(basic_try__get_next_try, should_return_next_try_for_matching_error_if_certain_is_specified) {
+    auto basic_try = ozo::failover::basic_try(3, hana::make_tuple(ozo::tests::errc::error), ctx());
+    EXPECT_TRUE(basic_try.get_next_try(ozo::tests::error::another_error, null_conn));
+}
+
+TEST_F(basic_try__get_next_try, should_return_null_state_for_nonmatching_error_if_certain_is_specified) {
+    auto basic_try = ozo::failover::basic_try(3, hana::make_tuple(ozo::tests::errc::error), ctx());
+    EXPECT_FALSE(basic_try.get_next_try(ozo::tests::error::ok, null_conn));
+}
+
+TEST_F(basic_try__get_next_try, should_return_null_state_for_matching_error_and_no_tries_left) {
+    auto first_try = ozo::failover::basic_try(2, hana::make_tuple(), ctx());
+    auto next_try = first_try.get_next_try(ozo::tests::error::error, null_conn);
+    EXPECT_FALSE(next_try->get_next_try(ozo::tests::error::error, null_conn));
+}
+
+TEST_F(basic_try__get_next_try, should_close_connection_on_retry) {
+    auto basic_try = ozo::failover::basic_try(3, hana::make_tuple(), ctx());
+    EXPECT_CALL(conn, close_connection());
+    basic_try.get_next_try(ozo::tests::error::error, std::addressof(conn));
+}
+
+TEST_F(basic_try__get_next_try, should_close_connection_on_no_retry) {
+    auto basic_try = ozo::failover::basic_try(3, hana::make_tuple(ozo::tests::errc::error), ctx());
+    EXPECT_CALL(conn, close_connection());
+    basic_try.get_next_try(ozo::tests::error::ok, std::addressof(conn));
+}
+
+struct basic_try__get_context : Test {
+    fake_connection_provider provider;
+    constexpr static auto errcs = hana::make_tuple();
+};
+
+TEST_F(basic_try__get_context, should_return_provider_form_context) {
+    auto basic_try = ozo::failover::basic_try(3, errcs,
+        ozo::failover::basic_context(std::addressof(provider), ozo::none));
+    EXPECT_EQ(basic_try.get_context()[hana::size_c<0>], std::addressof(provider));
+}
+
+TEST_F(basic_try__get_context, should_return_additional_arguments_form_context) {
+    auto basic_try = ozo::failover::basic_try(3, errcs,
+        ozo::failover::basic_context(std::addressof(provider), ozo::none, 555, "strong"s));
+    EXPECT_EQ(basic_try.get_context()[hana::size_c<2>], 555);
+    EXPECT_EQ(basic_try.get_context()[hana::size_c<3>], "strong"s);
+}
+
+TEST_F(basic_try__get_context, should_return_claculated_time_out_form_context) {
+    auto basic_try = ozo::failover::basic_try(3, errcs,
+        ozo::failover::basic_context(std::addressof(provider), 3s));
+    EXPECT_EQ(basic_try.get_context()[hana::size_c<1>], 1s);
+}
+
+TEST(basic_try__tries_remain, should_return_tries_remain_count) {
+    auto basic_try = ozo::failover::basic_try(3, hana::make_tuple(),
+        ozo::failover::basic_context(fake_connection_provider{}, ozo::none));
+    EXPECT_EQ(basic_try.tries_remain(), 3);
+}
+
+TEST(basic_try__retry_conditions, should_return_retry_conditions) {
+    const auto conditions = hana::make_tuple(ozo::tests::errc::error, ozo::tests::error::ok);
+    auto basic_try = ozo::failover::basic_try(3, conditions,
+        ozo::failover::basic_context(fake_connection_provider{}, ozo::none));
+    EXPECT_EQ(basic_try.get_conditions(), conditions);
+}
+
+TEST(basic_try, should_throw_std__invalid_argument_if_n_tries_less_than_0) {
+    const auto ctx = ozo::failover::basic_context(fake_connection_provider{}, ozo::none);
+    EXPECT_THROW(ozo::failover::basic_try(-1, hana::make_tuple(), ctx), std::invalid_argument);
+}
+
+TEST(basic_try, should_construct_object_with_n_tries_equal_to_0) {
+    const auto ctx = ozo::failover::basic_context(fake_connection_provider{}, ozo::none);
+    EXPECT_NO_THROW(ozo::failover::basic_try(0, hana::make_tuple(), ctx));
+}
+
+TEST(basic_try, should_construct_object_with_n_tries_greater_than_0) {
+    const auto ctx = ozo::failover::basic_context(fake_connection_provider{}, ozo::none);
+    EXPECT_NO_THROW(ozo::failover::basic_try(1, hana::make_tuple(), ctx));
+}
+
+} // namespace

--- a/tests/failover/strategy.cpp
+++ b/tests/failover/strategy.cpp
@@ -1,0 +1,188 @@
+#include <ozo/failover/strategy.h>
+
+#include "../test_error.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace {
+struct connection_mock {};
+
+struct provider_mock {};
+
+struct try_mock {
+    MOCK_CONST_METHOD2(get_next_try, try_mock*(ozo::error_code, connection_mock*));
+    using context = boost::hana::tuple<provider_mock*, ozo::time_traits::duration, int, std::string>;
+    MOCK_CONST_METHOD0(get_context, context());
+};
+
+struct handler_mock {
+    struct wrapper {
+        handler_mock const* mock_ = nullptr;
+        void operator () (ozo::error_code ec, connection_mock* conn) const {
+            mock_->call(ec, conn);
+        };
+        bool operator == (const wrapper& rhs) const {
+            return mock_ == rhs.mock_;
+        }
+    };
+    MOCK_CONST_METHOD2(call, void(ozo::error_code, connection_mock*));
+    auto f() const { return wrapper{this}; }
+};
+
+struct operation {
+    using handler_type = ozo::failover::detail::continuation<operation, try_mock*, decltype(std::declval<handler_mock>().f())>;
+    struct initiator_mock {
+        MOCK_CONST_METHOD5(call, void(
+            handler_type,
+            provider_mock* provider,
+            ozo::time_traits::duration t,
+            int arg1,
+            std::string arg2
+        ));
+    };
+    initiator_mock * mock = nullptr;
+
+    struct initiator_type {
+        initiator_mock * mock = nullptr;
+        initiator_type(initiator_mock* mock) : mock(mock) {}
+
+        void operator() (handler_type h, provider_mock* provider, ozo::time_traits::duration t, int arg1, std::string arg2) {
+            if (!mock) {
+                throw std::invalid_argument("mock should not be nullptr");
+            }
+            mock->call(std::move(h), provider, t, arg1, arg2);
+        }
+    };
+
+    initiator_type get_initiator() const {
+        return {mock};
+    }
+
+    bool operator == (const operation& rhs) const {
+        return mock == rhs.mock;
+    }
+};
+
+
+
+} // namespace
+
+namespace ozo {
+// Some cheats about connection_mock which is not a connection
+// at all.
+template <>
+struct is_connection<connection_mock*> : std::true_type {};
+
+template <>
+struct is_nullable<connection_mock*> : std::true_type {};
+
+template <>
+struct is_nullable<try_mock*> : std::true_type {};
+
+template <>
+struct unwrap_impl<try_mock*> : ozo::detail::functional::dereference {};
+
+namespace failover::detail {
+
+template <typename ...Ts>
+inline bool operator == (const continuation<Ts...>& lhs, const continuation<Ts...>& rhs) {
+    return std::tie(lhs.op_, lhs.try_, lhs.handler_) == std::tie(rhs.op_, rhs.try_, rhs.handler_);
+}
+
+} // namespace failover::detail
+} // namespace ozo
+
+namespace {
+
+using namespace testing;
+using namespace std::literals;
+using namespace std::chrono_literals;
+
+struct continuation : Test {
+    handler_mock handler;
+    operation::initiator_mock initiator;
+    operation op{std::addressof(initiator)};
+    try_mock a_try;
+    connection_mock conn;
+    provider_mock provider;
+};
+
+TEST_F(continuation, should_call_handler_if_called_with_no_error) {
+    EXPECT_CALL(handler, call(ozo::error_code{}, std::addressof(conn)));
+
+    auto continuation = ozo::failover::detail::continuation{op, std::addressof(a_try), handler.f()};
+    continuation(ozo::error_code{}, std::addressof(conn));
+}
+
+TEST_F(continuation, should_call_handler_if_called_with_error_and_no_next_try) {
+    InSequence s;
+    EXPECT_CALL(a_try, get_next_try(ozo::error_code{ozo::tests::error::error}, std::addressof(conn)))
+        .WillOnce(Return(nullptr));
+    EXPECT_CALL(handler, call(ozo::error_code{ozo::tests::error::error}, std::addressof(conn)));
+
+    auto continuation = ozo::failover::detail::continuation{op, std::addressof(a_try), handler.f()};
+    continuation(ozo::error_code{ozo::tests::error::error}, std::addressof(conn));
+}
+
+TEST_F(continuation, should_initiate_operation_with_context_and_continuation_if_called_with_error_and_has_next_try) {
+    InSequence s;
+    EXPECT_CALL(a_try, get_next_try(ozo::error_code{ozo::tests::error::error}, std::addressof(conn)))
+        .WillOnce(Return(std::addressof(a_try)));
+    EXPECT_CALL(a_try, get_context())
+        .WillOnce(Return(boost::hana::make_tuple(std::addressof(provider), 3s, 42, "some string"s)));
+    EXPECT_CALL(initiator, call(
+        ozo::failover::detail::continuation{op, std::addressof(a_try), handler.f()},
+        std::addressof(provider), ozo::time_traits::duration{3s}, 42, "some string"s));
+
+    auto continuation = ozo::failover::detail::continuation{op, std::addressof(a_try), handler.f()};
+    continuation(ozo::error_code{ozo::tests::error::error}, std::addressof(conn));
+}
+
+struct strategy_mock {
+    MOCK_CONST_METHOD6(get_first_try, try_mock*(
+        const operation&,
+        const std::allocator<char>& ,
+        provider_mock* provider,
+        ozo::time_traits::duration t,
+        int arg1,
+        std::string arg2));
+};
+
+struct strategy_impl {
+    strategy_mock* mock_ = nullptr;
+    template <typename ...Ts>
+    auto get_first_try(Ts&&... vs) const {
+        return mock_->get_first_try(std::forward<Ts>(vs)...);
+    }
+};
+
+TEST(operation_initiator, should_call_get_first_try_and_initiate_operation_via_its_initiator) {
+    handler_mock handler;
+    strategy_mock strategy;
+    operation::initiator_mock initiator;
+    operation op{std::addressof(initiator)};
+    provider_mock provider;
+    try_mock a_try;
+
+    EXPECT_CALL(strategy, get_first_try(op, _,
+        std::addressof(provider),
+        ozo::time_traits::duration{3s},
+        42,
+        "some string"s))
+        .WillOnce(Return(std::addressof(a_try)));
+
+    EXPECT_CALL(a_try, get_context())
+        .WillOnce(Return(boost::hana::make_tuple(std::addressof(provider), 3s, 42, "some string"s)));
+
+    EXPECT_CALL(initiator, call(
+        ozo::failover::detail::continuation{op, std::addressof(a_try), handler.f()},
+        std::addressof(provider), ozo::time_traits::duration{3s}, 42, "some string"s));
+
+    ozo::failover::detail::operation_initiator(strategy_impl{std::addressof(strategy)}, op)(
+        handler.f(),
+        std::addressof(provider),
+        3s, 42, "some string"s);
+}
+
+} // namespace

--- a/tests/integration/retry_integration.cpp
+++ b/tests/integration/retry_integration.cpp
@@ -1,0 +1,115 @@
+#include <ozo/connection_info.h>
+#include <ozo/query_builder.h>
+#include <ozo/request.h>
+#include <ozo/shortcuts.h>
+#include <ozo/failover/retry.h>
+
+#include <boost/asio/spawn.hpp>
+#include <boost/range/adaptor/transformed.hpp>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace {
+template <
+    typename OidMap = ozo::empty_oid_map,
+    typename Statistics = ozo::no_statistics>
+struct connection_info_sequence {
+    using base_type = ozo::connection_info<OidMap, Statistics>;
+    using connection_type = typename base_type::connection_type;
+
+    std::vector<base_type> base_;
+    typename std::vector<base_type>::const_iterator i_;
+
+    static std::vector<base_type> make_connection_infos(std::vector<std::string> in) {
+        const auto infos = in | boost::adaptors::transformed([](std::string& info){
+            return base_type{std::move(info)};
+        });
+        return {infos.begin(), infos.end()};
+    }
+
+    connection_info_sequence(std::vector<std::string> conn_infos)
+    : base_(make_connection_infos(std::move(conn_infos))), i_(base_.cbegin()) {}
+
+    connection_info_sequence(const connection_info_sequence&) = delete;
+    connection_info_sequence(connection_info_sequence&&) = delete;
+
+    template <typename TimeConstraint, typename Handler>
+    void operator ()(ozo::io_context& io, TimeConstraint t, Handler&& handler) {
+        if (i_==base_.end()) {
+            handler(ozo::error::pq_connection_start_failed, connection_type{});
+        } else {
+            (*i_++)(io, t, std::forward<Handler>(handler));
+        }
+    }
+
+    auto operator [](ozo::io_context& io) & {
+        return ozo::connection_provider(*this, io);
+    }
+};
+
+#define ASSERT_REQUEST_OK(ec, conn)\
+    ASSERT_FALSE(ec) << ec.message() \
+        << "|" << ozo::error_message(conn) \
+        << "|" << (!ozo::is_null_recursive(conn) ? ozo::get_error_context(conn) : "") << std::endl
+
+
+namespace hana = boost::hana;
+
+using namespace testing;
+// using namespace ozo::tests;
+
+TEST(request, should_return_success_for_invalid_connection_info_retried_with_valid_connection_info) {
+    using namespace ozo::literals;
+    using namespace hana::literals;
+
+    ozo::io_context io;
+    connection_info_sequence<> conn_info({"invalid connection info", OZO_PG_TEST_CONNINFO});
+
+    std::vector<int> res;
+    ozo::request[ozo::failover::retry(ozo::errc::connection_error)*2](conn_info[io], "SELECT 1"_SQL + " + 1"_SQL, ozo::into(res),
+            [&](ozo::error_code ec, auto conn) {
+        ASSERT_REQUEST_OK(ec, conn);
+        EXPECT_EQ(res.front(), 2);
+    });
+
+    io.run();
+    EXPECT_EQ(conn_info.i_, conn_info.base_.end());
+}
+
+TEST(request, should_return_error_and_bad_connect_for_nonretryable_error) {
+    using namespace ozo::literals;
+    using namespace hana::literals;
+
+    ozo::io_context io;
+    connection_info_sequence<> conn_info({"invalid connection info", OZO_PG_TEST_CONNINFO});
+
+    std::vector<int> res;
+    ozo::request[ozo::failover::retry(ozo::errc::database_readonly)*2](conn_info[io], "SELECT 1"_SQL + " + 1"_SQL, ozo::into(res),
+            [&](ozo::error_code ec, [[maybe_unused]] auto conn) {
+        EXPECT_TRUE(ec);
+    });
+
+    io.run();
+    EXPECT_NE(conn_info.i_, conn_info.base_.begin());
+    EXPECT_NE(conn_info.i_, conn_info.base_.end());
+}
+
+TEST(request, should_return_error_and_bad_connect_for_invalid_connection_info_and_expired_tries) {
+    using namespace ozo::literals;
+    using namespace hana::literals;
+
+    ozo::io_context io;
+    connection_info_sequence<> conn_info({"invalid connection info", "invalid connection info"});
+
+    std::vector<int> res;
+    ozo::request[ozo::failover::retry()*2](conn_info[io], "SELECT 1"_SQL + " + 1"_SQL, ozo::into(res),
+            [&](ozo::error_code ec, [[maybe_unused]] auto conn) {
+        EXPECT_TRUE(ec);
+    });
+
+    io.run();
+    EXPECT_EQ(conn_info.i_, conn_info.base_.end());
+}
+
+} // namespace

--- a/tests/test_error.h
+++ b/tests/test_error.h
@@ -11,6 +11,7 @@ namespace ozo::tests::error {
 enum code {
     ok, // to do no use error code 0
     error, // error
+    another_error, // another error
 };
 
 namespace detail {
@@ -25,6 +26,8 @@ public:
                 return "no error";
             case error:
                 return "test error";
+            case another_error:
+                return "another error";
         }
         std::ostringstream error;
         error << "no message for value: " << value;
@@ -55,3 +58,62 @@ inline auto make_error_code(const code e) {
 }
 
 } // namespace ozo::tests::error
+
+namespace ozo::tests::errc {
+
+enum code {
+    ok, // to do no use error code 0
+    error, // error
+};
+
+namespace detail {
+
+class category : public error_category {
+public:
+    const char* name() const noexcept override { return "ozo::tests::error::detail::category"; }
+
+    std::string message(int value) const override {
+        switch (code(value)) {
+            case ok:
+                return "no error";
+            case error:
+                return "test error";
+        }
+        std::ostringstream error;
+        error << "no message for value: " << value;
+        return error.str();
+    }
+
+    bool equivalent( const boost::system::error_code& code, int condition ) const noexcept override {
+        if (condition == error) {
+            return code.category() == ozo::tests::error::get_category() &&
+                (code.value() == ozo::tests::error::error || code.value() == ozo::tests::error::another_error);
+        }
+        return condition == ok && code == ozo::tests::error::ok;
+    }
+};
+
+} // namespace detail
+
+inline const error_category& get_category() {
+    static detail::category instance;
+    return instance;
+}
+
+} // namespace ozo::tests::error
+
+namespace boost::system {
+
+template <>
+struct is_error_condition_enum<ozo::tests::errc::code> : std::true_type {};
+
+} // namespace boost::system
+
+namespace ozo::tests::errc {
+
+inline auto make_error_condition(const code e) {
+    return boost::system::error_condition(static_cast<int>(e), get_category());
+}
+
+} // namespace ozo::tests::error
+


### PR DESCRIPTION
Failover micro framework
===========

Introduce failover mechanism with retry strategy as a first implemented strategy.

RATIONALE
----------

Distributed environment is unstable, so we want to have recovery mechanisms. Failover micro-framework is created to provide such customisable and easy to use solution. Here we have two new concepts: *Strategy* and *Try*.

* **Strategy** is entity which determines how to try to recover an operation which failed. 
* **Try** is an entity which holds a context of an operation and decides should we try to recover a failed operation or give an error for a user.

EXTENSION
----------

The `ozo::fallback::retry` strategy is an example of the framework extension.

OPERATION SUPPORT FAILOVER
-----------------

* request
* execute
* get_connection
* begin

BASIC USAGE EXAMPLE
----------------

Operation with failover looks like this:

```c++
execute[fallback::retry(connection_error)*3](conn_info[io], query, 3s, yield);
```

see [retry_request.cpp](https://github.com/yandex/ozo/pull/129/files#diff-0faf5b07ab5932bd18487a1b85009ef6) for more details.