### PR TITLE
Fix unwrap_type falure because of ADL

### DIFF
--- a/include/ozo/core/unwrap.h
+++ b/include/ozo/core/unwrap.h
@@ -93,7 +93,7 @@ struct get_unwrapped_type {
 #ifdef OZO_DOCUMENTATION
     using type = <unwrapped type>; //!< Unwrapped type
 #else
-    using type = std::decay_t<decltype(unwrap(std::declval<T>()))>;
+    using type = std::decay_t<decltype(ozo::unwrap(std::declval<T>()))>;
 #endif
 };
 

--- a/tests/type_traits.cpp
+++ b/tests/type_traits.cpp
@@ -85,6 +85,19 @@ TEST(is_null_recursive, should_return_false_for_non_nullable_type) {
     EXPECT_FALSE(ozo::is_null_recursive(int()));
 }
 
+namespace test_unwrap_local {
+struct test_type {};
+
+void unwrap(test_type){}
+}
+
+TEST(unwrap_type, should_unwrap_type_with_no_adl) {
+    using type = test_unwrap_local::test_type;
+    unwrap(type{});
+    const bool is_same = std::is_same_v<ozo::unwrap_type<type>, type>;
+    EXPECT_TRUE(is_same);
+}
+
 TEST(unwrap, should_unwrap_type) {
     boost::optional<int> n(7);
     EXPECT_EQ(ozo::unwrap(n), 7);


### PR DESCRIPTION
If type to be unwrapped has unwrap() function in its own namespace
it may affect the ozo::unwrap_type via ADL.