### PR TITLE
Change API functions implementation to functional object

### DIFF
--- a/include/ozo/execute.h
+++ b/include/ozo/execute.h
@@ -4,6 +4,7 @@
 
 namespace ozo {
 
+#ifdef OZO_DOCUMENTATION
 /**
  * @brief Executes query but does not return a result
  * @ingroup group-requests-functions
@@ -13,27 +14,52 @@ namespace ozo {
  *
  * @param provider --- #ConnectionProvider object
  * @param query --- #Query to execute
- * @param token --- any valid of #CompletionToken.
+ * @param timeout --- request timeout
+ * @param token --- operation #CompletionToken.
  * @return depends on #CompletionToken.
  */
-template <typename P, typename Q, typename CompletionToken, typename = Require<ConnectionProvider<P>>>
-inline auto execute(P&& provider, Q&& query, const time_traits::duration& timeout, CompletionToken&& token) {
-    using signature_t = void (error_code, connection_type<P>);
-    async_completion<CompletionToken, signature_t> init(token);
+template <typename P, typename Q, typename CompletionToken>
+decltype(auto) execute(P&& provider, Q&& query, const time_traits::duration& timeout, CompletionToken&& token);
 
-    impl::async_execute(std::forward<P>(provider), std::forward<Q>(query), timeout, init.completion_handler);
+/**
+ * @brief Executes query but does not return a result
+ * @ingroup group-requests-functions
+ *
+ * This function is same as `ozo::request()` function except it does not return any result.
+ * It suitable to use with `UPDATE` `INSERT` statements, or invoking procedures without result.
+ *
+ * @param provider --- #ConnectionProvider object
+ * @param query --- #Query to execute
+ * @param token --- operation #CompletionToken.
+ * @return depends on #CompletionToken.
+ */
+template <typename P, typename Q, typename CompletionToken>
+decltype(auto) execute(P&& provider, Q&& query, CompletionToken&& token);
+#else
+struct execute_op {
+    template <typename P, typename Q, typename CompletionToken>
+    decltype(auto) operator() (P&& provider, Q&& query, const time_traits::duration& timeout, CompletionToken&& token) const {
+        static_assert(ConnectionProvider<P>, "provider should be a ConnectionProvider");
+        using signature_t = void (error_code, connection_type<P>);
+        async_completion<CompletionToken, signature_t> init(token);
 
-    return init.result.get();
-}
+        impl::async_execute(std::forward<P>(provider), std::forward<Q>(query), timeout, init.completion_handler);
 
-template <typename P, typename Q, typename CompletionToken, typename = Require<ConnectionProvider<P>>>
-inline auto execute(P&& provider, Q&& query, CompletionToken&& token) {
-    return execute(
-        std::forward<P>(provider),
-        std::forward<Q>(query),
-        time_traits::duration::max(),
-        std::forward<CompletionToken>(token)
-    );
-}
+        return init.result.get();
+    }
 
+    template <typename P, typename Q, typename CompletionToken>
+    decltype(auto) operator() (P&& provider, Q&& query, CompletionToken&& token) const {
+        static_assert(ConnectionProvider<P>, "provider should be a ConnectionProvider");
+        return (*this)(
+            std::forward<P>(provider),
+            std::forward<Q>(query),
+            time_traits::duration::max(),
+            std::forward<CompletionToken>(token)
+        );
+    }
+};
+
+constexpr execute_op execute;
+#endif
 } // namespace ozo


### PR DESCRIPTION
Thus make it possible to identify operation. 
Since it is not possible to pass template function as an object, this is needed for the future failover framework to point operation for failover.