### PR TITLE
Boost 1.70 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "contrib/resource_pool"]
 	path = contrib/resource_pool
 	url = https://github.com/elsid/resource_pool.git
+	branch = master

--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ published and distributed by YANDEX LLC as the owner:
 Dmitrii Potepalov <potepalovd@yandex-team.ru>
 Roman Siromakha <elsid@yandex-team.ru>
 Sergei Khandrikov <thed636@yandex-team.ru>
+Jonas Stoehr <jonass@jsje.de>

--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -434,7 +434,7 @@ inline decltype(auto) get_socket(T&& conn) noexcept {
 template <typename T>
 inline decltype(auto) get_io_context(T& conn) noexcept {
     static_assert(Connection<T>, "T must be a Connection");
-    return get_socket(conn).get_io_context();
+    return get_socket(conn).get_executor().context();
 }
 
 /**

--- a/tests/test_asio.h
+++ b/tests/test_asio.h
@@ -59,6 +59,9 @@ struct execution_context : asio::execution_context {
         executor_type(executor_mock& impl, execution_context& context)
         : impl_(&impl), context_(&context){}
 
+        explicit executor_type(execution_context& context)
+        : context_(&context){}
+
         execution_context& context() const noexcept {
             return *context_;
         }
@@ -69,17 +72,26 @@ struct execution_context : asio::execution_context {
 
         template <typename Function>
         void dispatch(Function&& f, std::allocator<void>) const {
+            assert_has_impl();
             return impl_->dispatch(wrap_shared(std::forward<Function>(f)));
         }
 
         template <typename Function>
         void post(Function&& f, std::allocator<void>) const {
+            assert_has_impl();
             return impl_->post(wrap_shared(std::forward<Function>(f)));
         }
 
         template <typename Function>
         void defer(Function&& f, std::allocator<void>) const {
+            assert_has_impl();
             return impl_->defer(wrap_shared(std::forward<Function>(f)));
+        }
+
+        void assert_has_impl() const {
+            if (!impl_) {
+                throw std::logic_error("ozo::testing::execution_context::executor_type::assert_impl() no executor mock");
+            }
         }
 
         friend bool operator ==(const executor_type& lhs, const executor_type& rhs) {
@@ -100,7 +112,8 @@ struct execution_context : asio::execution_context {
 
     executor_type get_executor() {
         if (!executor_) {
-            throw std::logic_error("ozo::testing::execution_context::get_executor() bad executor mock");
+            // Contstruct with empty implementation, as get_io_context depends on an executor being present
+            return executor_type{*this};
         }
         return {*executor_, *this};
     }


### PR DESCRIPTION
Fixups for Boost 1.70 (which are downwards compatible to boost 1.67):
* updated `resourece_pool` (likely has to be re-based back to the ancestor repository)
* use `get_executor().context()` instead of deprecated/removed `get_io_context()`
* fix `test_asio.h` to always have an executor to make io context retrieval work

Fixes #134 