### PR TITLE
Time constraints

### DIFF
--- a/benchmarks/ozo_benchmark.cpp
+++ b/benchmarks/ozo_benchmark.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[]) {
     for (int i = 0; i < 8; ++i) {
         asio::spawn(io, [&] (auto yield) {
             try {
-                auto connection = ozo::get_connection(ozo::make_connector(connection_info, io), yield);
+                auto connection = ozo::get_connection(connection_info[io], yield);
                 benchmark.start();
                 while (true) {
                     ozo::result result;

--- a/examples/connection_pool.cpp
+++ b/examples/connection_pool.cpp
@@ -43,15 +43,13 @@ int main(int argc, char **argv) {
 
         //! [Creating Connection Provider]
 
-        // The next step is bind asio::io_context with ConnectionSource to setup executor for all
-        // callbacks. Default connection is a ConnectionProvider. If there is some problem with network
-        // or database we don't want to wait indefinitely, so we establish connect timeout. If there is
-        // no available connection in the connection pool we also want to wait within finite time duration.
-        ozo::connection_pool_timeouts timeouts;
-        timeouts.connect = std::chrono::seconds(1);
-        timeouts.queue = std::chrono::seconds(1);
-
-        const auto connector = ozo::make_connector(connection_pool, io, timeouts);
+        // The next step is bind io_context with ConnectionSource to setup executor for all
+        // callbacks. This line is for the exposition and education purpose only.
+        // The best practice is to use simple inline call like
+        //
+        //     ozo::request(connection_pool[io], query, ozo::deadline(1s), ozo::into(res), yield);
+        //
+        const auto connector = connection_pool[io];
         //! [Creating Connection Provider]
 
         // Request result is always set of rows. Client should take care of output object lifetime.
@@ -61,14 +59,14 @@ int main(int argc, char **argv) {
         // Also we setup request timeout and reference for error code to avoid throwing exceptions.
         // Function returns connection which can be used as ConnectionProvider for futher requests or to
         // get additional inforation about error through error context.
-        const std::chrono::seconds request_timeout(1);
         boost::system::error_code ec;
         // This allows to use _SQL literals
         using namespace ozo::literals;
+        using namespace std::chrono_literals;
         const auto connection = ozo::request(
             connector,
             "SELECT pg_backend_pid()"_SQL,
-            request_timeout,
+            ozo::deadline(1s),
             ozo::into(result),
             yield[ec]
         );

--- a/include/ozo/connection_info.h
+++ b/include/ozo/connection_info.h
@@ -12,12 +12,11 @@ namespace ozo {
 /**
  * @brief Connection information
  *
- * @ingroup group-connection-types
- *
  * This type is a basic #ConnectionSource implementation. This source allows to establish connection
  * via [connection string](https://www.postgresql.org/docs/9.4/static/libpq-connect.html#LIBPQ-CONNSTRING) specified.
- * @tparam OidMap --- oids map type which defines user types are used within this connection.
+ * @tparam OidMap --- OidMap type which defines custom types should be used within this connection.
  * @tparam Statistics --- statistics type which defines statistics is collected for this connection.
+ * @ingroup group-connection-types
  */
 template <
     typename OidMap = empty_oid_map,
@@ -34,16 +33,17 @@ public:
      *
      * Type is used to model #ConnectionSource
      */
-   using connection_type = std::shared_ptr<connection>;
+    using connection_type = std::shared_ptr<connection>;
 
     /**
      * @brief Construct a new connection information object
      *
      * @param conn_str --- connection string which is being used to create connection to a database.
      * For details of how to make string see [official libpq documentation](https://www.postgresql.org/docs/9.4/static/libpq-connect.html#LIBPQ-CONNSTRING)
+     * @param OidMap --- #OidMap for custom types support.
      * @param statistics --- statistics are being used for connections.
      */
-    connection_info(std::string conn_str, Statistics statistics = Statistics{})
+    connection_info(std::string conn_str, const OidMap& = OidMap{}, Statistics statistics = Statistics{})
             : conn_str(std::move(conn_str)), statistics(std::move(statistics)) {
     }
 
@@ -52,22 +52,58 @@ public:
      *
      * In case of success --- the handler will be invoked as operation succeeded.
      * In case of connection fail --- the handler will be invoked as operation failed.
+     * This operation has a time constrain and would be interrupted if the time
+     * constrain expired by cancelling IO on a #Connection's socket.
      *
      * @param io --- `io_context` for the connection IO.
+     * @param t --- #TimeConstraint for the operation.
      * @param handler --- #Handler.
-     * @param timeouts --- connection time-out.
      */
-    template <typename Handler>
-    void operator ()(io_context& io, Handler&& handler,
-            time_traits::duration timeout = time_traits::duration::max()) const {
-        impl::async_connect(
-            conn_str,
-            timeout,
-            std::make_shared<connection>(io, statistics),
-            std::forward<Handler>(handler)
-        );
+    template <typename TimeConstraint, typename Handler>
+    void operator ()(io_context& io, TimeConstraint t, Handler&& handler) const {
+        static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
+        impl::async_connect(conn_str, t, std::make_shared<connection>(io, statistics),
+            std::forward<Handler>(handler));
+    }
+
+    auto operator [](io_context& io) const & {
+        return connection_provider(*this, io);
+    }
+
+    auto operator [](io_context& io) && {
+        return connection_provider(std::move(*this), io);
     }
 };
+
+//[[DEPRECATED]] for backward compatibility only
+template <typename ...Ts>
+auto make_connector(const connection_info<Ts...>& source, io_context& io, time_traits::duration timeout) {
+    return bind_get_connection_timeout(source[io], timeout);
+}
+
+//[[DEPRECATED]] for backward compatibility only
+template <typename ...Ts>
+auto make_connector(connection_info<Ts...>& source, io_context& io, time_traits::duration timeout) {
+    return bind_get_connection_timeout(source[io], timeout);
+}
+
+//[[DEPRECATED]] for backward compatibility only
+template <typename ...Ts>
+auto make_connector(connection_info<Ts...>&& source, io_context& io, time_traits::duration timeout) {
+    return bind_get_connection_timeout(source[io], timeout);
+}
+
+//[[DEPRECATED]] for backward compatibility only
+template <typename ...Ts>
+auto make_connector(const connection_info<Ts...>& source, io_context& io) { return source[io];}
+
+//[[DEPRECATED]] for backward compatibility only
+template <typename ...Ts>
+auto make_connector(connection_info<Ts...>& source, io_context& io) { return source[io];}
+
+//[[DEPRECATED]] for backward compatibility only
+template <typename ...Ts>
+auto make_connector(connection_info<Ts...>&& source, io_context& io) { return source[io];}
 
 /**
  * @brief Constructs `ozo::connection_info` #ConnectionSource.
@@ -80,11 +116,11 @@ public:
  * @return `ozo::connection_info` specialization.
  */
 template <typename OidMap = empty_oid_map, typename Statistics = no_statistics>
-inline auto make_connection_info(std::string conn_str, const OidMap& = OidMap{},
+inline auto make_connection_info(std::string conn_str, const OidMap& oid_map = OidMap{},
         Statistics statistics = Statistics{}) {
-    return connection_info<OidMap, Statistics>{std::move(conn_str), statistics};
+    return connection_info{std::move(conn_str), oid_map, statistics};
 }
 
-static_assert(ConnectionProvider<connector<connection_info<>>>, "is not a ConnectionProvider");
+static_assert(ConnectionProvider<decltype(std::declval<connection_info<>>()[std::declval<io_context&>()])>, "is not a ConnectionProvider");
 
 } // namespace ozo

--- a/include/ozo/core/concept.h
+++ b/include/ozo/core/concept.h
@@ -373,6 +373,21 @@ struct is_emplaceable<T, std::void_t<decltype(std::declval<T&>().emplace())>> : 
 template <typename T>
 constexpr auto Emplaceable = is_emplaceable<std::decay_t<T>>::value;
 
+template <typename T>
+struct is_time_constrain : std::false_type {};
+
+/**
+ * @brief Time constrain concept
+ *
+ * `TimeConstraint` is a type which provides information about time restrictions for an operation.
+ * Currently supported constrains:
+ * * `std::chrono::duration` --- operation time-out duration,
+ * * `std::chrono::time_point` --- operation deadline time point,
+ * * `ozo::none` --- operation is not restricted in time.
+ */
+template <typename T>
+constexpr auto TimeConstraint = is_time_constrain<std::decay_t<T>>::value;
+
 /**
  * @brief Completion token concept
  *

--- a/include/ozo/core/none.h
+++ b/include/ozo/core/none.h
@@ -18,6 +18,9 @@ struct none_t {
     static constexpr void apply (Args&& ...) noexcept {}
 };
 
+template <>
+struct is_time_constrain<none_t> : std::true_type {};
+
 template <typename T>
 using is_none = std::is_same<T, none_t>;
 

--- a/include/ozo/deadline.h
+++ b/include/ozo/deadline.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include <ozo/core/none.h>
+#include <ozo/time_traits.h>
+
+namespace ozo {
+/**
+ * @brief Dealdine calculation
+ *
+ * Calculate deadline from time point. Literally returns it's argument.
+ *
+ * @param t --- time point of a deadline
+ * @return it's argument
+ * @ingroup group-core-functions
+ */
+inline constexpr time_traits::time_point deadline(time_traits::time_point t) noexcept {
+    return t;
+}
+
+/**
+ * @brief Dealdine calculation
+ *
+ * Calculates deadline time point in a given duration from a given time point.
+ * The result value range is [now, time_traits::time_point::max()].
+ * Literally: `now  + after`.
+ *
+ * @param after --- duration to a deadline time point
+ * @param now --- start time point for the duration
+ * @return calculated deadline time point
+ * @ingroup group-core-functions
+ */
+inline constexpr time_traits::time_point deadline(
+        time_traits::duration after, time_traits::time_point now) noexcept {
+    if (after < time_traits::duration(0)) {
+        return now;
+    }
+    return after > time_traits::time_point::max() - now ?
+            time_traits::time_point::max() : now + after;
+}
+
+/**
+ * @brief Dealdine calculation
+ *
+ * Calculates deadline time point in a given duration from now.
+ * The result value is limited by time_traits::time_point::max().
+ * Literally: `time_traits::now() + after`.
+ *
+ * @param after --- duration to a deadline time point
+ * @return calculated deadline time point
+ * @ingroup group-core-functions
+ */
+inline time_traits::time_point deadline(time_traits::duration after) noexcept {
+    return deadline(after, time_traits::now()) ;
+}
+
+/**
+ * @brief Dealdine calculation
+ *
+ * Calculates deadline from `ozo::none_t`.
+ *
+ * @param none_t
+ * @return `ozo::none`
+ * @ingroup group-core-functions
+ */
+inline constexpr auto deadline(none_t) noexcept { return none;}
+
+/**
+ * @brief Time left to deadline
+ *
+ * Calculates time left form given `now` time point to a given deadline time point `t`.
+ *
+ * @param t --- deadline time point
+ * @param now --- time point to calculate duration from
+ * @return time left to the time point which is more or equal to a zero.
+ * @ingroup group-core-functions
+ */
+inline constexpr time_traits::duration time_left(
+        time_traits::time_point t, time_traits::time_point now) noexcept {
+    return t > now ? t - now : time_traits::duration(0);
+}
+
+/**
+ * @brief Time left to deadline
+ *
+ * Calculates time left to a given deadline time point.
+ *
+ * @param t --- deadline time point
+ * @return time left to the time point which is more or equal to a zero.
+ * @ingroup group-core-functions
+ */
+inline time_traits::duration time_left(time_traits::time_point t) noexcept {
+    return time_left(t, time_traits::now());
+}
+
+/**
+ * @brief Deadline is expired
+ *
+ * Indicates if a given dedline is expired for a given time point. Deadline is expired then time
+ * left duration to the deadline is 0.
+ *
+ * @param t --- deadline time point
+ * @return true --- deadline has been expired
+ * @return false --- there is time left to deadline
+ * @ingroup group-core-functions
+ */
+inline bool expired(time_traits::time_point t, time_traits::time_point now) noexcept {
+    return time_left(t, now) == time_traits::duration(0);
+}
+
+/**
+ * @brief Deadline is expired
+ *
+ * Indicates if a given dedline is expired. Deadline is expired then time
+ * left duration to the deadline is 0.
+ *
+ * @param t --- deadline time point
+ * @return true --- deadline has been expired
+ * @return false --- there is time left to deadline
+ * @ingroup group-core-functions
+ */
+inline bool expired(time_traits::time_point t) noexcept {
+    return expired(t, time_traits::now());
+}
+
+} // namespace ozo

--- a/include/ozo/detail/cancel_timer_handler.h
+++ b/include/ozo/detail/cancel_timer_handler.h
@@ -2,6 +2,8 @@
 
 #include <ozo/asio.h>
 #include <ozo/error.h>
+#include <ozo/time_traits.h>
+#include <ozo/core/none.h>
 
 namespace ozo::detail {
 
@@ -29,5 +31,27 @@ struct cancel_timer_handler {
         return asio::get_associated_allocator(handler);
     }
 };
+
+template <typename T>
+struct bind_cancel_timer_impl {
+    template <typename Handler>
+    constexpr static decltype(auto) apply(Handler&& h) {
+        return cancel_timer_handler(std::forward<Handler>(h));
+    }
+};
+
+template <>
+struct bind_cancel_timer_impl<ozo::none_t> {
+    template <typename Handler>
+    constexpr static decltype(auto) apply(Handler&& h) {
+        return std::forward<Handler>(h);
+    }
+};
+
+template <typename TimeConstraint, typename Handler>
+inline constexpr decltype(auto) bind_cancel_timer(Handler&& h) {
+    static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
+    return bind_cancel_timer_impl<TimeConstraint>::apply(std::forward<Handler>(h));
+}
 
 } // namespace ozo::detail

--- a/include/ozo/execute.h
+++ b/include/ozo/execute.h
@@ -6,57 +6,58 @@ namespace ozo {
 
 #ifdef OZO_DOCUMENTATION
 /**
- * @brief Executes query but does not return a result
- * @ingroup group-requests-functions
+ * @brief Executes query with no result data expected
  *
- * This function is same as `ozo::request()` function except it does not return any result.
+ * This function is same as `ozo::request()` function except it does not provide any result data.
  * It suitable to use with `UPDATE` `INSERT` statements, or invoking procedures without result.
+ *
+ * @note The function does not particitate in ADL since could be implemented via functional object.
  *
  * @param provider --- #ConnectionProvider object
  * @param query --- #Query to execute
- * @param timeout --- request timeout
+ * @param time_constraint --- request #TimeConstraint; this time constrain <b>includes</b> time for getting connection from provider.
  * @param token --- operation #CompletionToken.
- * @return depends on #CompletionToken.
+ * @return deduced from #CompletionToken.
+ * @ingroup group-requests-functions
  */
-template <typename P, typename Q, typename CompletionToken>
-decltype(auto) execute(P&& provider, Q&& query, const time_traits::duration& timeout, CompletionToken&& token);
+template <typename ConnectionProvider, typename Query, typename TimeConstraint, typename CompletionToken>
+decltype(auto) execute(ConnectionProvider&& provider, Query&& query, TimeConstraint time_constraint, CompletionToken&& token);
 
 /**
- * @brief Executes query but does not return a result
- * @ingroup group-requests-functions
+ * @brief Executes query with no result data expected
  *
- * This function is same as `ozo::request()` function except it does not return any result.
- * It suitable to use with `UPDATE` `INSERT` statements, or invoking procedures without result.
+ * This function is time constrain free shortcut to `ozo::execute()` function.
+ * Its call is equal to `ozo::execute(provider, query, ozo::none, token)` call.
+ *
+ * @note The function does not particitate in ADL since could be implemented via functional object.
  *
  * @param provider --- #ConnectionProvider object
  * @param query --- #Query to execute
  * @param token --- operation #CompletionToken.
- * @return depends on #CompletionToken.
+ * @return deduced from #CompletionToken.
+ * @ingroup group-requests-functions
  */
 template <typename P, typename Q, typename CompletionToken>
 decltype(auto) execute(P&& provider, Q&& query, CompletionToken&& token);
 #else
 struct execute_op {
-    template <typename P, typename Q, typename CompletionToken>
-    decltype(auto) operator() (P&& provider, Q&& query, const time_traits::duration& timeout, CompletionToken&& token) const {
+    template <typename P, typename Q, typename TimeConstraint, typename CompletionToken>
+    decltype(auto) operator() (P&& provider, Q&& query, TimeConstraint t, CompletionToken&& token) const {
         static_assert(ConnectionProvider<P>, "provider should be a ConnectionProvider");
+        static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
         using signature_t = void (error_code, connection_type<P>);
         async_completion<CompletionToken, signature_t> init(token);
 
-        impl::async_execute(std::forward<P>(provider), std::forward<Q>(query), timeout, init.completion_handler);
+        impl::async_execute(std::forward<P>(provider), std::forward<Q>(query),
+            t, init.completion_handler);
 
         return init.result.get();
     }
 
     template <typename P, typename Q, typename CompletionToken>
     decltype(auto) operator() (P&& provider, Q&& query, CompletionToken&& token) const {
-        static_assert(ConnectionProvider<P>, "provider should be a ConnectionProvider");
-        return (*this)(
-            std::forward<P>(provider),
-            std::forward<Q>(query),
-            time_traits::duration::max(),
-            std::forward<CompletionToken>(token)
-        );
+        return (*this)(std::forward<P>(provider), std::forward<Q>(query), none,
+            std::forward<CompletionToken>(token));
     }
 };
 

--- a/include/ozo/impl/async_connect.h
+++ b/include/ozo/impl/async_connect.h
@@ -58,7 +58,8 @@ template <typename Context>
 struct async_connect_op {
     Context context;
 
-    void perform(const std::string& conninfo, const time_traits::duration& timeout) {
+    template <typename TimeConstraint>
+    void perform(const std::string& conninfo, const TimeConstraint& time_constrain) {
         if (error_code ec = start_connection(get_connection(context), conninfo)) {
             return done(ec);
         }
@@ -71,7 +72,7 @@ struct async_connect_op {
             return done(ec);
         }
 
-        detail::set_io_timeout(get_connection(context), get_handler(context), timeout);
+        detail::set_io_timeout(get_connection(context), get_handler(context), time_constrain);
 
         return write_poll(get_connection(context), *this);
     }
@@ -172,20 +173,21 @@ constexpr decltype(auto) make_request_oid_map_handler(Handler&& handler, Require
     return std::forward<Handler>(handler);
 }
 
-template <typename ConnectionT, typename Handler>
-inline Require<Connection<ConnectionT>> async_connect(std::string conninfo, const time_traits::duration& timeout,
-        ConnectionT&& connection, Handler&& handler) {
+template <typename C, typename TimeConstraint, typename Handler>
+inline void async_connect(std::string conninfo, const TimeConstraint& time_constrain,
+        C&& connection, Handler&& handler) {
+    static_assert(Connection<C>, "C should model Connection concept");
     auto strand = ozo::detail::make_strand_executor(get_executor(connection));
     make_async_connect_op(
         make_connect_operation_context(
-            std::forward<ConnectionT>(connection),
-            make_request_oid_map_handler<ConnectionT>(
-                asio::bind_executor(strand, detail::cancel_timer_handler(
+            std::forward<C>(connection),
+            make_request_oid_map_handler<C>(
+                asio::bind_executor(strand, detail::bind_cancel_timer<std::decay_t<TimeConstraint>>(
                     detail::post_handler(std::forward<Handler>(handler))
                 ))
             )
         )
-    ).perform(conninfo, timeout);
+    ).perform(conninfo, time_constrain);
 }
 
 } // namespace impl

--- a/include/ozo/impl/async_end_transaction.h
+++ b/include/ozo/impl/async_end_transaction.h
@@ -10,10 +10,11 @@ template <typename Handler>
 struct async_end_transaction_op {
     Handler handler;
 
-    template <typename T, typename Query>
-    void perform(T&& provider, Query&& query, const time_traits::duration& timeout) {
+    template <typename T, typename Query, typename TimeConstraint>
+    void perform(T&& provider, Query&& query, TimeConstraint t) {
         static_assert(Connection<T>, "T is not a Connection");
-        async_execute(std::forward<T>(provider), std::forward<Query>(query), timeout, std::move(*this));
+        static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
+        async_execute(std::forward<T>(provider), std::forward<Query>(query), t, std::move(*this));
     }
 
     template <typename Connection>
@@ -35,11 +36,11 @@ auto make_async_end_transaction_op(Handler&& handler) {
     return async_end_transaction_op<std::decay_t<Handler>> {std::forward<Handler>(handler)};
 }
 
-template <typename T, typename Query, typename Handler>
+template <typename T, typename Query, typename TimeConstraint, typename Handler>
 Require<ConnectionProvider<T>> async_end_transaction(T&& provider, Query&& query,
-        const time_traits::duration& timeout, Handler&& handler) {
+        TimeConstraint t, Handler&& handler) {
     make_async_end_transaction_op(std::forward<Handler>(handler))
-        .perform(std::forward<T>(provider), std::forward<Query>(query), timeout);
+        .perform(std::forward<T>(provider), std::forward<Query>(query), t);
 }
 
 } // namespace ozo::impl

--- a/include/ozo/impl/async_execute.h
+++ b/include/ozo/impl/async_execute.h
@@ -2,24 +2,22 @@
 
 #include <ozo/core/none.h>
 #include <ozo/impl/async_request.h>
-#include <ozo/time_traits.h>
 
-namespace ozo {
-namespace impl {
+namespace ozo::impl {
 
-template <typename P, typename Q, typename Handler>
-inline void async_execute(P&& provider, Q&& query, const time_traits::duration& timeout, Handler&& handler) {
+template <typename P, typename Q, typename TimeConstraint, typename Handler>
+inline void async_execute(P&& provider, Q&& query, TimeConstraint t, Handler&& handler) {
     static_assert(ConnectionProvider<P>, "is not a ConnectionProvider");
     static_assert(Query<Q> || QueryBuilder<Q>, "is neither Query nor QueryBuilder");
-    async_get_connection(std::forward<P>(provider),
+    static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
+    async_get_connection(std::forward<P>(provider), deadline(t),
         async_request_op {
             std::forward<Q>(query),
-            timeout,
+            deadline(t),
             none,
             std::forward<Handler>(handler)
         }
     );
 }
 
-} // namespace impl
-} // namespace ozo
+} // namespace ozo::impl

--- a/include/ozo/impl/async_start_transaction.h
+++ b/include/ozo/impl/async_start_transaction.h
@@ -10,10 +10,12 @@ template <typename Handler>
 struct async_start_transaction_op {
     Handler handler;
 
-    template <typename T, typename Query>
-    void perform(T&& provider, Query&& query, const time_traits::duration& timeout) {
+    template <typename T, typename Query, typename TimeConstraint>
+    void perform(T&& provider, Query&& query, TimeConstraint t) {
         static_assert(ConnectionProvider<T>, "T is not a ConnectionProvider");
-        async_execute(std::forward<T>(provider), std::forward<Query>(query), timeout, std::move(*this));
+        static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
+        async_execute(std::forward<T>(provider), std::forward<Query>(query),
+            t, std::move(*this));
     }
 
     template <typename Connection>
@@ -33,11 +35,11 @@ auto make_async_start_transaction_op(Handler&& handler) {
     return async_start_transaction_op<std::decay_t<Handler>> {std::forward<Handler>(handler)};
 }
 
-template <typename T, typename Query, typename Handler>
+template <typename T, typename Query, typename TimeConstraint, typename Handler>
 Require<ConnectionProvider<T>> async_start_transaction(T&& provider, Query&& query,
-        const time_traits::duration& timeout, Handler&& handler) {
+        TimeConstraint t, Handler&& handler) {
     make_async_start_transaction_op(std::forward<Handler>(handler))
-        .perform(std::forward<T>(provider), std::forward<Query>(query), timeout);
+        .perform(std::forward<T>(provider), std::forward<Query>(query), t);
 }
 
 } // namespace ozo::impl

--- a/include/ozo/impl/end_transaction.h
+++ b/include/ozo/impl/end_transaction.h
@@ -4,9 +4,9 @@
 
 namespace ozo::impl {
 
-template <typename T, typename Query, typename CompletionToken>
+template <typename T, typename Query, typename TimeConstrain, typename CompletionToken>
 auto end_transaction(transaction<T>&& transaction, Query&& query,
-        const time_traits::duration& timeout, CompletionToken&& token) {
+        TimeConstrain t, CompletionToken&& token) {
     using signature = void (error_code, T);
 
     async_completion<CompletionToken, signature> init(token);
@@ -14,7 +14,7 @@ auto end_transaction(transaction<T>&& transaction, Query&& query,
     async_end_transaction(
         std::move(transaction),
         std::forward<Query>(query),
-        timeout,
+        t,
         init.completion_handler
     );
 

--- a/include/ozo/impl/start_transaction.h
+++ b/include/ozo/impl/start_transaction.h
@@ -4,10 +4,10 @@
 
 namespace ozo::impl {
 
-template <typename T, typename Query, typename CompletionToken,
-          typename = Require<ConnectionProvider<T>>>
+template <typename T, typename Query, typename TimeConstrain,
+        typename CompletionToken, typename = Require<ConnectionProvider<T>>>
 auto start_transaction(T&& provider, Query&& query,
-        const time_traits::duration& timeout, CompletionToken&& token) {
+        TimeConstrain t, CompletionToken&& token) {
     using signature = void (error_code, transaction<connection_type<T>>);
 
     async_completion<CompletionToken, signature> init(token);
@@ -15,7 +15,7 @@ auto start_transaction(T&& provider, Query&& query,
     async_start_transaction(
         std::forward<T>(provider),
         std::forward<Query>(query),
-        timeout,
+        t,
         init.completion_handler
     );
 

--- a/include/ozo/request.h
+++ b/include/ozo/request.h
@@ -5,33 +5,45 @@
 namespace ozo {
 #ifdef OZO_DOCUMENTATION
 /**
- * @brief Send request to a database and provides query result (time-out version).
- * @ingroup group-requests-functions
+ * @brief Request query from a database
  *
  * The function sends request to a database and provides result via out parameter. The function can
- * be called as any of Boost.Asio asynchronous function with #CompletionToken.
+ * be called as any of Boost.Asio asynchronous function with #CompletionToken. The request would be
+ * cancelled if time constrain is reached while performing.
  *
- * ###Basic usage
+ * @note The function does not particitate in ADL since could be implemented via functional object.
+ *
+ * @param provider --- #ConnectionProvider to get connection from.
+ * @param query --- #Query or `ozo::query_builder` object to request from a database.
+ * @param time_constraint --- request #TimeConstraint; this time constrain <b>includes</b> time for getting connection from provider.
+ * @param out --- output object like Iterator, #InsertIterator or `ozo::result`.
+ * @param token --- operation #CompletionToken.
+ * @return deduced from #CompletionToken.
+ *
+ * ###Example
  *
  * @code
 #include <ozo/request.h>
 #include <ozo/connection_info.h>
 #include <ozo/shortcuts.h>
 #include <boost/asio.hpp>
+
 int main() {
     boost::asio::io_context io;
     ozo::rows_of<std::int64_t, std::optional<std::string>> rows;
-    ozo::connection_info<> conn_info("host=... port=...");
+    auto conn_info = ozo::connection_info("host=... port=...");
 
     using namespace ozo::literals;
+    using namespace std::chrono_literals;
     const auto query = "SELECT id, name FROM users_info WHERE amount>="_SQL + std::int64_t(25);
 
-    ozo::request(ozo::make_connector(conn_info, io, 500ms), query, 100ms, ozo::into(rows),
+    ozo::request(conn_info[io], query, 500ms, ozo::into(rows),
             [&](ozo::error_code ec, auto conn) {
         if (ec) {
-            std::cerr << ec.message()
-                      << " | " << error_message(conn)
-                      << " | " << get_error_context(conn);
+            std::cerr << ec.message() << " | " << error_message(conn);
+            if (!is_null_recursive(conn)) {
+                std::cerr << " | " << get_error_context(conn);
+            }
             return;
         };
         assert(ozo::connection_good(conn));
@@ -44,55 +56,50 @@ int main() {
     io.run();
 }
  * @endcode
- * @param provider --- #ConnectionProvider to get connection from.
- * @param query --- #Query or `ozo::query_builder` object to send to a database.
- * @param timeout --- request timeout.
- * @param out --- output object like Iterator, #InsertIterator or `ozo::result`.
- * @param token --- operation #CompletionToken.
- * @return depends on #CompletionToken.
+ * @ingroup group-requests-functions
  */
-template <typename P, typename Q, typename Out, typename CompletionToken>
-decltype(auto) request (P&& provider, Q&& query, const time_traits::duration& timeout, Out out, CompletionToken&& token);
+template <typename ConnectionProvider, typename Query, typename TimeConstraint, typename Out, typename CompletionToken>
+decltype(auto) request (ConnectionProvider&& provider, Query&& query, TimeConstraint time_constraint, Out out, CompletionToken&& token);
 
 /**
- * @brief Send request to a database and provides query result.
- * @ingroup group-requests-functions
+ * @brief Request query from a database
  *
- * This is time-out free version of the `ozo::request`.
+ * This function is time constrain free shortcut to `ozo::request()` function.
+ * Its call is equal to `ozo::request(provider, query, ozo::none, out, token)` call.
+ *
+ * @note The function does not particitate in ADL since could be implemented via functional object.
+ *
  * @param provider --- #ConnectionProvider to get connection from.
- * @param query --- #Query or `ozo::query_builder` object to send to a database.
+ * @param query --- #Query or `ozo::query_builder` object to request from a database.
  * @param out --- output object like Iterator, #InsertIterator or `ozo::result`.
  * @param token --- operation #CompletionToken.
- * @return depends on #CompletionToken.
+ * @return deduced from #CompletionToken.
+ * @ingroup group-requests-functions
  */
-template <typename P, typename Q, typename Out, typename CompletionToken>
-decltype(auto) request (P&& provider, Q&& query, Out out, CompletionToken&& token);
+template <typename ConnectionProvider, typename Query, typename Out, typename CompletionToken>
+decltype(auto) request (ConnectionProvider&& provider, Query&& query, Out out, CompletionToken&& token);
 
 #else
 
 struct request_op {
-    template <typename P, typename Q, typename Out, typename CompletionToken>
-    decltype(auto) operator() (P&& provider, Q&& query, const time_traits::duration& timeout, Out out, CompletionToken&& token) const {
+    template <typename P, typename Q, typename TimeConstraint, typename Out, typename CompletionToken>
+    decltype(auto) operator() (P&& provider, Q&& query, TimeConstraint t,
+            Out out, CompletionToken&& token) const {
         static_assert(ConnectionProvider<P>, "provider should be a ConnectionProvider");
+        static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
         using signature_t = void (error_code, connection_type<P>);
         async_completion<CompletionToken, signature_t> init(token);
 
-        impl::async_request(std::forward<P>(provider), std::forward<Q>(query), timeout, std::move(out),
-                init.completion_handler);
+        impl::async_request(std::forward<P>(provider), std::forward<Q>(query),
+                t, std::move(out), init.completion_handler);
 
         return init.result.get();
     }
 
     template <typename P, typename Q, typename Out, typename CompletionToken>
     decltype(auto) operator()(P&& provider, Q&& query, Out out, CompletionToken&& token) const {
-        static_assert(ConnectionProvider<P>, "provider should be a ConnectionProvider");
-        return (*this)(
-            std::forward<P>(provider),
-            std::forward<Q>(query),
-            time_traits::duration::max(),
-            std::move(out),
-            std::forward<CompletionToken>(token)
-        );
+        return (*this)(std::forward<P>(provider), std::forward<Q>(query), none, std::move(out),
+            std::forward<CompletionToken>(token));
     }
 };
 

--- a/include/ozo/shortcuts.h
+++ b/include/ozo/shortcuts.h
@@ -29,7 +29,7 @@ const auto query =
 ozo::rows_of<std::int64_t, std::string> rows;
 //           ------------  ===========
 
-ozo::request(ozo::make_connector(io, conn_info), query, ozo::into(rows), boost::asio::use_future);
+ozo::request(conn_info[io], query, ozo::into(rows), boost::asio::use_future);
 @endcode
  * @tparam Ts --- types of columns in result
  */
@@ -55,7 +55,7 @@ const auto query =
 ozo::lrows_of<std::int64_t, std::string> rows;
 //            ------------  ===========
 
-ozo::request(ozo::make_connector(io, conn_info), query, ozo::into(rows), boost::asio::use_future);
+ozo::request(conn_info[io], query, ozo::into(rows), boost::asio::use_future);
 @endcode
  * @tparam Ts --- types of columns in result
  */
@@ -77,7 +77,7 @@ const auto query = "SELECT id, name FROM users_info WHERE amount>="_SQL + std::i
 
 ozo::rows_of<std::int64_t, std::string> rows;
 
-ozo::request(ozo::make_connector(io, conn_info), query, ozo::into(rows), boost::asio::use_future);
+ozo::request(conn_info[io], query, ozo::into(rows), boost::asio::use_future);
 @endcode
  * @param v --- container for rows
  */
@@ -99,7 +99,7 @@ const auto query = "SELECT id, name FROM users_info WHERE amount>="_SQL + std::i
 
 ozo::result res;
 
-ozo::request(ozo::make_connector(io, conn_info), query, ozo::into(res), boost::asio::use_future);
+ozo::request(conn_info[io], query, ozo::into(res), boost::asio::use_future);
 @endcode
  * @param v --- `ozo::basic_result` object for rows.
  */

--- a/include/ozo/time_traits.h
+++ b/include/ozo/time_traits.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <ozo/core/concept.h>
 #include <chrono>
 
 namespace ozo {
@@ -20,5 +21,11 @@ struct time_traits {
         return std::chrono::steady_clock::now();
     }
 };
+
+template <typename ...Ts>
+struct is_time_constrain<std::chrono::duration<Ts...>> : std::true_type {};
+
+template <typename ...Ts>
+struct is_time_constrain<std::chrono::time_point<Ts...>> : std::true_type {};
 
 } // namespace ozo

--- a/include/ozo/transaction.h
+++ b/include/ozo/transaction.h
@@ -6,14 +6,15 @@
 namespace ozo {
 
 struct begin_op {
-    template <typename T, typename CompletionToken>
-    auto operator() (T&& provider, const time_traits::duration& timeout, CompletionToken&& token) const {
+    template <typename T, typename TimeConstraint, typename CompletionToken>
+    auto operator() (T&& provider, TimeConstraint t, CompletionToken&& token) const {
         static_assert(ConnectionProvider<T>, "provider should be a ConnectionProvider");
+        static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
         using namespace ozo::literals;
         return impl::start_transaction(
             std::forward<T>(provider),
             "BEGIN"_SQL,
-            timeout,
+            t,
             std::forward<CompletionToken>(token)
         );
     }
@@ -22,7 +23,7 @@ struct begin_op {
     auto operator() (T&& provider, CompletionToken&& token) const {
         return (*this)(
             std::forward<T>(provider),
-            time_traits::duration::max(),
+            none,
             std::forward<CompletionToken>(token)
         );
     }
@@ -31,13 +32,14 @@ struct begin_op {
 constexpr begin_op begin;
 
 struct commit_op {
-    template <typename T, typename CompletionToken>
-    auto operator() (impl::transaction<T>&& transaction, const time_traits::duration& timeout, CompletionToken&& token) const {
+    template <typename T, typename TimeConstraint, typename CompletionToken>
+    auto operator() (impl::transaction<T>&& transaction, TimeConstraint t, CompletionToken&& token) const {
+        static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
         using namespace ozo::literals;
         return impl::end_transaction(
             std::move(transaction),
             "COMMIT"_SQL,
-            timeout,
+            t,
             std::forward<CompletionToken>(token)
         );
     }
@@ -46,7 +48,7 @@ struct commit_op {
     auto operator() (impl::transaction<T>&& transaction, CompletionToken&& token) const {
         return (*this)(
             std::move(transaction),
-            time_traits::duration::max(),
+            none,
             std::forward<CompletionToken>(token)
         );
     }
@@ -55,13 +57,14 @@ struct commit_op {
 constexpr commit_op commit;
 
 struct rollback_op {
-    template <typename T, typename CompletionToken>
-    auto operator() (impl::transaction<T>&& transaction, const time_traits::duration& timeout, CompletionToken&& token) const {
+    template <typename T, typename TimeConstraint, typename CompletionToken>
+    auto operator() (impl::transaction<T>&& transaction, TimeConstraint t, CompletionToken&& token) const {
+        static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
         using namespace ozo::literals;
         return impl::end_transaction(
             std::move(transaction),
             "ROLLBACK"_SQL,
-            timeout,
+            t,
             std::forward<CompletionToken>(token)
         );
     }
@@ -70,7 +73,7 @@ struct rollback_op {
     auto operator() (impl::transaction<T>&& transaction, CompletionToken&& token) const {
         return (*this)(
             std::move(transaction),
-            time_traits::duration::max(),
+            none,
             std::forward<CompletionToken>(token)
         );
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,8 @@ set(SOURCES
     impl/async_get_result.cpp
     detail/base36.cpp
     detail/functional.cpp
+    detail/cancel_timer_handler.cpp
+    detail/timeout_handler.cpp
     impl/request_oid_map.cpp
     impl/request_oid_map_handler.cpp
     impl/async_start_transaction.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ set(SOURCES
     concept.cpp
     result.cpp
     none.cpp
+    deadline.cpp
     impl/async_send_query_params.cpp
     impl/async_get_result.cpp
     detail/base36.cpp

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -203,7 +203,7 @@ TEST_F(async_get_connection, should_pass_through_the_connection_to_handler) {
     EXPECT_CALL(callback_executor, dispatch(_)).WillOnce(InvokeArgument<0>());
     EXPECT_CALL(cb_mock, call(error_code{}, conn)).WillOnce(Return());
 
-    ozo::async_get_connection(conn, wrap(cb_mock));
+    ozo::async_get_connection(conn, ozo::none, wrap(cb_mock));
 }
 
 TEST_F(async_get_connection, should_reset_connection_error_context) {
@@ -212,7 +212,7 @@ TEST_F(async_get_connection, should_reset_connection_error_context) {
 
     EXPECT_CALL(executor, dispatch(_)).WillOnce(InvokeArgument<0>());
 
-    ozo::async_get_connection(conn, [](error_code, auto conn) {
+    ozo::async_get_connection(conn, ozo::none, [](error_code, auto conn) {
         EXPECT_TRUE(conn->error_context_.empty());
     });
 }

--- a/tests/deadline.cpp
+++ b/tests/deadline.cpp
@@ -1,0 +1,59 @@
+#include <ozo/deadline.h>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace {
+
+using namespace testing;
+using namespace std::literals;
+
+using time_point = ozo::time_traits::time_point;
+using duration = ozo::time_traits::duration;
+
+TEST(deadline, should_return_its_argument_for_time_point_type) {
+    EXPECT_EQ(ozo::deadline(time_point{}), time_point{});
+}
+
+TEST(deadline, should_return_none_for_ozo_none_t_type) {
+    EXPECT_EQ(ozo::deadline(ozo::none_t{}), ozo::none);
+}
+
+TEST(deadline, should_return_proper_time_point_for_time_point_and_duration) {
+    EXPECT_EQ(ozo::deadline(1s, time_point{}), time_point{} + 1s);
+}
+
+TEST(deadline, should_return_time_point_max_on_saturation) {
+    EXPECT_EQ(ozo::deadline(duration::max(), time_point{} + 1s),
+        time_point::max());
+}
+
+TEST(deadline, should_return_time_point_argument_on_negative_duration) {
+    EXPECT_EQ(ozo::deadline(-1s, time_point{}), time_point{});
+}
+
+TEST(time_left, should_return_duration_for_time_point_less_than_deadline) {
+    EXPECT_EQ(ozo::time_left(time_point{} + 1s, time_point{}), 1s);
+}
+
+TEST(time_left, should_return_zero_for_time_point_equal_to_deadline) {
+    EXPECT_EQ(ozo::time_left(time_point{}, time_point{}), duration(0));
+}
+
+TEST(time_left, should_return_zero_for_time_point_greater_than_deadline) {
+    EXPECT_EQ(ozo::time_left(time_point{}, time_point{} + 1s), duration(0));
+}
+
+TEST(expired, should_return_false_for_time_point_less_than_deadline) {
+    EXPECT_FALSE(ozo::expired(time_point{} + 1s, time_point{}));
+}
+
+TEST(expired, should_return_true_for_time_point_equal_to_deadline) {
+    EXPECT_TRUE(ozo::expired(time_point{}, time_point{}));
+}
+
+TEST(expired, should_return_true_for_time_point_greater_than_deadline) {
+    EXPECT_TRUE(ozo::expired(time_point{}, time_point{} + 1s));
+}
+
+} // namespace

--- a/tests/detail/cancel_timer_handler.cpp
+++ b/tests/detail/cancel_timer_handler.cpp
@@ -1,0 +1,37 @@
+#include <ozo/detail/cancel_timer_handler.h>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace {
+
+using namespace testing;
+using namespace std::literals;
+
+using time_point = ozo::time_traits::time_point;
+using duration = ozo::time_traits::duration;
+
+struct test_handler {
+    template <typename ...Ts>
+    void operator() (Ts&&...) const {}
+};
+
+TEST(bind_cancel_timer, should_forward_handler_for_ozo_none_t) {
+    EXPECT_TRUE((std::is_same_v<
+        decltype(ozo::detail::bind_cancel_timer<ozo::none_t>(test_handler{})),
+        test_handler&&>));
+}
+
+TEST(bind_cancel_timer, should_wrap_handler_for_ozo_time_traits_duration) {
+    EXPECT_TRUE((std::is_same_v<
+        decltype(ozo::detail::bind_cancel_timer<ozo::time_traits::duration>(test_handler{})),
+        ozo::detail::cancel_timer_handler<test_handler>>));
+}
+
+TEST(bind_cancel_timer, should_wrap_handler_for_ozo_time_traits_time_point) {
+    EXPECT_TRUE((std::is_same_v<
+        decltype(ozo::detail::bind_cancel_timer<ozo::time_traits::time_point>(test_handler{})),
+        ozo::detail::cancel_timer_handler<test_handler>>));
+}
+
+} // namespace

--- a/tests/detail/timeout_handler.cpp
+++ b/tests/detail/timeout_handler.cpp
@@ -1,0 +1,46 @@
+#include <ozo/detail/timeout_handler.h>
+#include "../test_asio.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace {
+
+using namespace testing;
+using namespace std::literals;
+
+using time_point = ozo::time_traits::time_point;
+using duration = ozo::time_traits::duration;
+
+struct test_handler {
+    template <typename ...Ts>
+    void operator() (Ts&&...) const {}
+};
+
+struct connection {
+    ozo::tests::steady_timer_gmock timer;
+    ozo::tests::stream_descriptor_gmock socket;
+    friend auto& get_timer(connection& c) { return c.timer; }
+    friend auto& get_socket(connection& c) { return c.socket; }
+};
+
+TEST(set_io_timeout, should_do_nothing_for_ozo_none) {
+    connection c;
+    ozo::detail::set_io_timeout(c, test_handler{}, ozo::none);
+}
+
+TEST(set_io_timeout, should_set_timer_for_duration_and_async_wait) {
+    connection c;
+    EXPECT_CALL(c.timer, expires_after(duration(1s))).WillOnce(Return(0));
+    EXPECT_CALL(c.timer, async_wait(_)).WillOnce(Return());
+    ozo::detail::set_io_timeout(c, test_handler{}, duration(1s));
+}
+
+TEST(set_io_timeout, should_set_timer_for_time_point_and_async_wait) {
+    connection c;
+    EXPECT_CALL(c.timer, expires_at(time_point{})).WillOnce(Return(0));
+    EXPECT_CALL(c.timer, async_wait(_)).WillOnce(Return());
+    ozo::detail::set_io_timeout(c, test_handler{}, time_point{});
+}
+
+} // namespace

--- a/tests/integration/request_integration.cpp
+++ b/tests/integration/request_integration.cpp
@@ -228,7 +228,6 @@ TEST(request, should_call_handler_with_error_for_zero_timeout) {
         EXPECT_FALSE(called.test_and_set());
         EXPECT_EQ(ec, boost::system::error_condition(boost::system::errc::operation_canceled));
         EXPECT_FALSE(ozo::connection_bad(conn));
-        EXPECT_EQ(ozo::get_error_context(conn), "error while get request result");
     });
 
     io.run();

--- a/tests/test_asio.h
+++ b/tests/test_asio.h
@@ -163,12 +163,14 @@ struct stream_descriptor {
 struct steady_timer_mock {
     virtual ~steady_timer_mock() = default;
     virtual std::size_t expires_after(const asio::steady_timer::duration& expiry_time) = 0;
+    virtual std::size_t expires_at(const asio::steady_timer::time_point&) = 0;
     virtual void async_wait(std::function<void(error_code)> handler) = 0;
     virtual std::size_t cancel() = 0;
 };
 
 struct steady_timer_gmock : steady_timer_mock {
     MOCK_METHOD1(expires_after, std::size_t (const asio::steady_timer::duration&));
+    MOCK_METHOD1(expires_at, std::size_t (const asio::steady_timer::time_point&));
     MOCK_METHOD1(async_wait, void (std::function<void(error_code)>));
     MOCK_METHOD0(cancel, std::size_t ());
 };
@@ -178,6 +180,10 @@ struct steady_timer {
 
     std::size_t expires_after(const asio::steady_timer::duration& expiry_time) {
         return impl->expires_after(expiry_time);
+    }
+
+    std::size_t expires_at(const asio::steady_timer::time_point& at) {
+        return impl->expires_at(at);
     }
 
     template <typename Handler>


### PR DESCRIPTION
Add time constrants support for API
==========================

Now operations can be called with different time constraints. This PR is a basis for the upcoming failover framework feature.

**ATTENTION!** this commit breaks `ConnectionProvider` and `ConnectionSource` customisation interfaces, so user should implement new versions, see *DEPRECATION & INCOMPATIBILITY* section for more details. Users who do not use such customisation points *should not be affected*.

MOTIVATION
------------

Previous time-out interfaces were sophisticated and not convenient. Only time-outs were allowed. Deadlines implementation was a tricky thing for a user. Timer always set up mandatory, the only option was an infinite time-out. New interface allows to do not set up timer via `ozo::none` and allow user to make own custom implementation of timed-out operations.

Just compare old interface vs. new one:

Old:

```c++
ozo::request(ozo::make_connector(source, io, conn_timeout), query, op_timeout, ozo::into(out), token);
```

New:

```c++
auto timeout = conn_timeout + op_timeout;
ozo::request(source[io], query, timeout, ozo::into(out), token);
```

Deadline propagation:

```c++
const auto deadline = ozo::deadline(operation_budget);
//...
auto conn = ozo::request(source[io], query_one, deadline, ozo::into(out), yield);
//...
ozo::request(source, query_two, deadline, ozo::into(out), yield);
```

DEPRECATION & INCOMPATIBILITY
-------------

All the deprecated entities are commented as *[[DEPRECATED]]* and after some time will be marked via `[[deprecated]]` attribute. Thus after such change `-Werror` user builds will be broken in case of deprecated entities usage.

* `ozo::connector` - has been completely removed, this change can break backward compatibility for ConnectionSource customization, but its support costs too much. User should migrate on new interfaces.
* No more support for `ozo::async_get_connection(Provider, Handler)`. Use three argument version with TimeConstraint `ozo::async_get_connection(Provider, TimeConstraint, Handler)`.  Thus `ConnectionSource` should have `void operator()(io_context&, TimeConstraint, Handler&&)` instead of `void operator()(io_context&, Handler&&)`.
* `ozo::make_connector` - deprecated and will be removed after internal projects have been moved on a new interface, time constraints for `ozo::get_connection()` could be made via `ozo::bind_get_connection_timeout` class or explicit `ozo::get_connection()` with a desirable time constraint.
* `ozo::connection_pool_timeouts` - deprecated, since `queue` member would be ignored, rationale is that this time constrain should be equal to `connect` member, thus it can be expressed via single time constrain.