### PR TITLE
Deprecate old interfaces

### DIFF
--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -163,24 +163,8 @@ constexpr detail::result_of<get_connection_socket_impl, T> get_connection_socket
 }
 #endif
 
-#if BOOST_VERSION < 107000
-template <typename T, typename = hana::when<true>>
-struct get_connection_executor_impl {
-    template <typename Conn>
-    constexpr static auto apply(Conn&& c) -> decltype(get_connection_socket(c).get_executor()) {
-        return get_connection_socket(c).get_executor();
-    }
-};
-#else
 template <typename T, typename = hana::when<true>>
 struct get_connection_executor_impl;
-#endif
-
-template <typename T, typename = std::void_t<>>
-struct get_connection_timer_impl;
-
-template <typename T>
-asio::steady_timer& get_connection_timer(T&&);
 
 template <typename T>
 struct get_connection_executor_impl<T,

--- a/include/ozo/connection_info.h
+++ b/include/ozo/connection_info.h
@@ -78,33 +78,33 @@ public:
 
 //[[DEPRECATED]] for backward compatibility only
 template <typename ...Ts>
-auto make_connector(const connection_info<Ts...>& source, io_context& io, time_traits::duration timeout) {
+[[deprecated]] auto make_connector(const connection_info<Ts...>& source, io_context& io, time_traits::duration timeout) {
     return bind_get_connection_timeout(source[io], timeout);
 }
 
 //[[DEPRECATED]] for backward compatibility only
 template <typename ...Ts>
-auto make_connector(connection_info<Ts...>& source, io_context& io, time_traits::duration timeout) {
+[[deprecated]] auto make_connector(connection_info<Ts...>& source, io_context& io, time_traits::duration timeout) {
     return bind_get_connection_timeout(source[io], timeout);
 }
 
 //[[DEPRECATED]] for backward compatibility only
 template <typename ...Ts>
-auto make_connector(connection_info<Ts...>&& source, io_context& io, time_traits::duration timeout) {
+[[deprecated]] auto make_connector(connection_info<Ts...>&& source, io_context& io, time_traits::duration timeout) {
     return bind_get_connection_timeout(source[io], timeout);
 }
 
 //[[DEPRECATED]] for backward compatibility only
 template <typename ...Ts>
-auto make_connector(const connection_info<Ts...>& source, io_context& io) { return source[io];}
+[[deprecated]] auto make_connector(const connection_info<Ts...>& source, io_context& io) { return source[io];}
 
 //[[DEPRECATED]] for backward compatibility only
 template <typename ...Ts>
-auto make_connector(connection_info<Ts...>& source, io_context& io) { return source[io];}
+[[deprecated]] auto make_connector(connection_info<Ts...>& source, io_context& io) { return source[io];}
 
 //[[DEPRECATED]] for backward compatibility only
 template <typename ...Ts>
-auto make_connector(connection_info<Ts...>&& source, io_context& io) { return source[io];}
+[[deprecated]] auto make_connector(connection_info<Ts...>&& source, io_context& io) { return source[io];}
 
 /**
  * @brief Constructs `ozo::connection_info` #ConnectionSource.

--- a/include/ozo/connection_pool.h
+++ b/include/ozo/connection_pool.h
@@ -28,7 +28,7 @@ struct connection_pool_config {
  * Time restrictions to get connection from the `ozo::connection_pool`
  * @note This type is deprecated, use time constrained version of ozo::get_connection() or ozo::dedline for operations.
  */
-struct [[deprecated]] connection_pool_timeouts {
+struct /*[[deprecated]]*/ connection_pool_timeouts {
     time_traits::duration connect = std::chrono::seconds(10); //!< maximum time interval to establish to or wait for free connection with DBMS
     time_traits::duration queue = std::chrono::seconds(10); //!< [[IGNORED]]
 };

--- a/include/ozo/connection_pool.h
+++ b/include/ozo/connection_pool.h
@@ -28,7 +28,7 @@ struct connection_pool_config {
  * Time restrictions to get connection from the `ozo::connection_pool`
  * @note This type is deprecated, use time constrained version of ozo::get_connection() or ozo::dedline for operations.
  */
-struct connection_pool_timeouts {
+struct [[deprecated]] connection_pool_timeouts {
     time_traits::duration connect = std::chrono::seconds(10); //!< maximum time interval to establish to or wait for free connection with DBMS
     time_traits::duration queue = std::chrono::seconds(10); //!< [[IGNORED]]
 };

--- a/include/ozo/connection_pool.h
+++ b/include/ozo/connection_pool.h
@@ -141,13 +141,13 @@ private:
 
 //[[DEPRECATED]] for backward compatibility only
 template <typename ...Ts>
-auto make_connector(connection_pool<Ts...>& source, io_context& io, const connection_pool_timeouts& timeouts) {
+[[deprecated]] auto make_connector(connection_pool<Ts...>& source, io_context& io, const connection_pool_timeouts& timeouts) {
     return bind_get_connection_timeout(source[io], timeouts.connect);
 }
 
 //[[DEPRECATED]] for backward compatibility only
 template <typename ...Ts>
-auto make_connector(connection_pool<Ts...>& source, io_context& io) {
+[[deprecated]] auto make_connector(connection_pool<Ts...>& source, io_context& io) {
     return source[io];
 }
 

--- a/tests/connection_info.cpp
+++ b/tests/connection_info.cpp
@@ -9,7 +9,7 @@ TEST(connection_info, should_return_error_and_bad_connect_for_invalid_connection
     ozo::io_context io;
     ozo::connection_info<> conn_info("invalid connection info");
 
-    ozo::get_connection(ozo::make_connector(conn_info, io), [](ozo::error_code ec, auto conn){
+    ozo::get_connection(conn_info[io], [](ozo::error_code ec, auto conn){
         EXPECT_TRUE(ec);
         EXPECT_TRUE(!ozo::error_message(conn).empty());
         EXPECT_TRUE(ozo::connection_bad(conn));

--- a/tests/integration/execute_integration.cpp
+++ b/tests/integration/execute_integration.cpp
@@ -14,7 +14,7 @@ TEST(execute, should_perform_operation_without_result) {
     ozo::io_context io;
     ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
 
-    ozo::execute(ozo::make_connector(conn_info, io), "BEGIN"_SQL,
+    ozo::execute(conn_info[io], "BEGIN"_SQL,
         [&](ozo::error_code ec, auto conn) {
             ASSERT_FALSE(ec) << ec.message() << " | " << error_message(conn) << " | " << get_error_context(conn);
             EXPECT_FALSE(ozo::connection_bad(conn));

--- a/tests/integration/get_connection_integration.cpp
+++ b/tests/integration/get_connection_integration.cpp
@@ -11,7 +11,7 @@ TEST(get_connection, should_return_timeout_error_for_zero_connect_timeout) {
     const std::chrono::seconds timeout(0);
 
     std::atomic_flag called {};
-    ozo::get_connection(ozo::make_connector(conn_info, io, timeout), [&] (ozo::error_code ec, auto conn) {
+    ozo::get_connection(conn_info[io], timeout, [&] (ozo::error_code ec, auto conn) {
         EXPECT_FALSE(called.test_and_set());
         EXPECT_EQ(ec, boost::system::error_condition(boost::system::errc::operation_canceled));
         EXPECT_FALSE(ozo::connection_bad(conn));
@@ -27,7 +27,7 @@ TEST(get_connection, should_return_connection_for_max_connect_timeout) {
     const auto timeout = ozo::time_traits::duration::max();
 
     std::atomic_flag called {};
-    ozo::get_connection(ozo::make_connector(conn_info, io, timeout), [&] (ozo::error_code ec, auto conn) {
+    ozo::get_connection(conn_info[io], timeout, [&] (ozo::error_code ec, auto conn) {
         EXPECT_FALSE(called.test_and_set());
         EXPECT_FALSE(ec);
         EXPECT_FALSE(ozo::connection_bad(conn));

--- a/tests/integration/transaction_integration.cpp
+++ b/tests/integration/transaction_integration.cpp
@@ -22,7 +22,7 @@ TEST(transaction, create_schema_in_transaction_and_commit_then_table_should_exis
     ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
 
     asio::spawn(io, [&] (asio::yield_context yield) {
-        auto transaction = ozo::begin(ozo::make_connector(conn_info, io), yield);
+        auto transaction = ozo::begin(conn_info[io], yield);
         ASSERT_TRUE(transaction);
         ozo::result result;
         ozo::request(transaction, "DROP SCHEMA IF EXISTS ozo_test CASCADE;"_SQL, std::ref(result), yield);
@@ -41,7 +41,7 @@ TEST(transaction, create_schema_in_transaction_and_rollback_then_table_should_no
     ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
 
     asio::spawn(io, [&] (asio::yield_context yield) {
-        auto transaction = ozo::begin(ozo::make_connector(conn_info, io), yield);
+        auto transaction = ozo::begin(conn_info[io], yield);
         ozo::result result;
         ozo::request(transaction, "DROP SCHEMA IF EXISTS ozo_test CASCADE;"_SQL, std::ref(result), yield);
         ozo::request(transaction, "CREATE SCHEMA ozo_test;"_SQL, std::ref(result), yield);


### PR DESCRIPTION
Deprecate old interfaces for ConnectionProvider via `[[deprecated]]` attribute.