### PR TITLE
Extend retry strategy

### DIFF
--- a/include/ozo/detail/make_copyable.h
+++ b/include/ozo/detail/make_copyable.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <ozo/asio.h>
+
+#include <utility>
+#include <type_traits>
+
+namespace ozo::detail {
+
+/**
+ * @brief Wrapper to make Handler object copyable
+ *
+ * Sometimes asynchronous API does make a copy of completion handlers
+ * (e.g. at that moment resource_pool does). In this case to do not obligate
+ * user to use only copyable completion handlers it is better to provide
+ * convenient wrapper for make a completion handler copyable.
+ *
+ * @tparam Handler
+ */
+template <typename Handler>
+struct make_copyable {
+    using target_type = std::decay_t<Handler>;
+    using type = std::conditional_t<std::is_copy_constructible_v<target_type>,
+                    target_type,
+                    make_copyable>;
+
+    using executor_type = typename asio::associated_executor<target_type>::type;
+
+    executor_type get_executor() const noexcept {
+        return asio::get_associated_executor(*handler_);
+    }
+
+    using allocator_type = typename asio::associated_allocator<target_type>::type;
+
+    allocator_type get_allocator() const noexcept {
+        return asio::get_associated_allocator(*handler_);
+    }
+
+    make_copyable(Handler&& handler) {
+        auto allocator = asio::get_associated_allocator(handler);
+        handler_ = std::allocate_shared<target_type>(allocator, std::move(handler));
+    }
+
+    template <typename ...Args>
+    auto operator()(Args&& ...args) & {
+        return static_cast<target_type&>(*this)(std::forward<Args>(args)...);
+    }
+
+    template <typename ...Args>
+    auto operator()(Args&& ...args) const & {
+        return static_cast<const target_type&>(*this)(std::forward<Args>(args)...);
+    }
+
+    template <typename ...Args>
+    auto operator()(Args&& ...args) && {
+        return static_cast<target_type&&>(static_cast<make_copyable&&>(*this))(std::forward<Args>(args)...);
+    }
+
+    operator const target_type& () const & { return *handler_;}
+
+    operator target_type& () & { return *handler_;}
+
+    operator target_type&& () && { return static_cast<target_type&&>(*handler_);}
+
+    std::shared_ptr<target_type> handler_;
+};
+
+template <typename Handler>
+using make_copyable_t = typename make_copyable<Handler>::type;
+
+} // namespace ozo::detail

--- a/include/ozo/impl/connection_pool.h
+++ b/include/ozo/impl/connection_pool.h
@@ -5,6 +5,7 @@
 #include <yamail/resource_pool/async/pool.hpp>
 #include <ozo/asio.h>
 #include <ozo/ext/std/shared_ptr.h>
+#include <ozo/detail/make_copyable.h>
 
 namespace ozo::impl {
 
@@ -68,7 +69,7 @@ template <typename IoContext, typename Source, typename Handler, typename TimeCo
 struct pooled_connection_wrapper {
     IoContext& io_;
     Source source_;
-    Handler handler_;
+    detail::make_copyable_t<Handler> handler_;
     TimeConstraint time_constrain_;
 
     using connection = pooled_connection<Source>;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ set(SOURCES
     detail/functional.cpp
     detail/cancel_timer_handler.cpp
     detail/timeout_handler.cpp
+    detail/make_copyable.cpp
     impl/request_oid_map.cpp
     impl/request_oid_map_handler.cpp
     impl/async_start_transaction.cpp

--- a/tests/connection_pool.cpp
+++ b/tests/connection_pool.cpp
@@ -193,6 +193,17 @@ struct pooled_connection_wrapper : Test {
 
 using ozo::error_code;
 
+TEST_F(pooled_connection_wrapper, should_be_copyable_with_non_copyable_handler_for_resource_pool_compatibility) {
+    auto h = ozo::impl::wrap_pooled_connection_handler(
+            io,
+            connection_source{&provider_mock},
+            ozo::none,
+            [&, attr = std::unique_ptr<int>()](error_code ec, auto& conn) mutable { callback_mock.call(ec, conn); }
+        );
+
+    EXPECT_TRUE(std::is_copy_constructible_v<decltype(h)>);
+}
+
 TEST_F(pooled_connection_wrapper, should_invoke_handler_with_error_if_error_is_passed) {
     auto h = ozo::impl::wrap_pooled_connection_handler(
             io,

--- a/tests/detail/make_copyable.cpp
+++ b/tests/detail/make_copyable.cpp
@@ -1,0 +1,69 @@
+#include "test_asio.h"
+
+#include <ozo/detail/make_copyable.h>
+
+#include <boost/asio/post.hpp>
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+namespace {
+
+using namespace testing;
+using namespace ozo::tests;
+
+namespace asio = boost::asio;
+
+struct make_copyable : Test {
+    StrictMock<executor_gmock> executor;
+    StrictMock<callback_gmock<int>> cb_mock {};
+    ozo::tests::execution_context io{executor};
+};
+
+struct handler_mock {
+    MOCK_METHOD2(call_ref, void(ozo::error_code, int));
+    MOCK_METHOD2(call_rval_ref, void(ozo::error_code, int));
+    MOCK_CONST_METHOD2(call_const_ref, void(ozo::error_code, int));
+};
+
+struct handler_obj {
+    handler_mock& mock_;
+
+    void operator()(ozo::error_code ec, int v) & { mock_.call_ref(ec, v); }
+    void operator()(ozo::error_code ec, int v) && { mock_.call_rval_ref(ec, v); }
+    void operator()(ozo::error_code ec, int v) const & { mock_.call_const_ref(ec, v); }
+};
+
+TEST_F(make_copyable, should_provide_handler_executor) {
+    EXPECT_CALL(cb_mock, get_executor()).WillOnce(Return(io.get_executor()));
+
+    EXPECT_EQ(ozo::detail::make_copyable(wrap(cb_mock)).get_executor(), io.get_executor());
+}
+
+TEST_F(make_copyable, should_call_wrapped_handler) {
+    handler_mock mock;
+    auto obj = ozo::detail::make_copyable(handler_obj{mock});
+
+    EXPECT_CALL(mock, call_ref(ozo::error_code{}, 42));
+    static_cast<decltype(obj)&>(obj)(ozo::error_code{}, 42);
+
+    EXPECT_CALL(mock, call_const_ref(ozo::error_code{}, 42));
+    static_cast<const decltype(obj)&>(obj)(ozo::error_code{}, 42);
+
+    EXPECT_CALL(mock, call_rval_ref(ozo::error_code{}, 42));
+    static_cast<decltype(obj)&&>(obj)(ozo::error_code{}, 42);
+}
+
+TEST(make_copyable_t, should_forward_copyable_handler) {
+    struct copyable {};
+    EXPECT_TRUE((std::is_same_v<ozo::detail::make_copyable_t<copyable>, copyable>));
+}
+
+TEST(make_copyable_t, should_wrap_non_copyable_handler) {
+    struct non_copyable {
+        std::unique_ptr<int> v_;
+    };
+    EXPECT_TRUE((std::is_same_v<ozo::detail::make_copyable_t<non_copyable>, ozo::detail::make_copyable<non_copyable>>));
+}
+
+} // namespace

--- a/tests/failover/retry.cpp
+++ b/tests/failover/retry.cpp
@@ -2,6 +2,9 @@
 
 #include "../test_error.h"
 
+#include <boost/hana/equal.hpp>
+#include <boost/hana/not_equal.hpp>
+
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -93,46 +96,126 @@ TEST_F(get_try_time_constraint, should_return_zero_time_left_for_try_count_less_
     EXPECT_EQ(duration{0}, ozo::failover::detail::get_try_time_constraint(deadline, -1, now));
 }
 
+template <typename Errcs, typename Ctx>
+static auto make_basic_try(int n_tries, Errcs errcs, Ctx ctx) {
+    using op = ozo::failover::retry_options;
+    auto options = hana::make_map(
+        hana::make_pair(op::tries, n_tries),
+        hana::make_pair(op::conditions, errcs)
+    );
+    return ozo::failover::basic_try(std::move(options), std::move(ctx));
+}
+
 struct basic_try__get_next_try : Test {
     connection_mock conn;
+    struct handler_mock {
+        MOCK_METHOD2(call, void(ozo::error_code, connection_mock*));
+        void operator() (ozo::error_code ec, connection_mock* conn) { call(ec, conn); }
+    };
     auto ctx() const {
         return ozo::failover::basic_context(fake_connection_provider{}, ozo::none);
     }
     static constexpr connection_mock* null_conn = nullptr;
+    handler_mock handler;
 };
 
 TEST_F(basic_try__get_next_try, should_return_next_try_for_any_error_if_certain_is_not_specified) {
-    auto basic_try = ozo::failover::basic_try(3, hana::make_tuple(), ctx());
-    EXPECT_TRUE(basic_try.get_next_try(ozo::tests::error::error, null_conn));
-    EXPECT_TRUE(basic_try.get_next_try(ozo::tests::error::another_error, null_conn));
-    EXPECT_TRUE(basic_try.get_next_try(ozo::tests::error::ok, null_conn));
+    const auto basic_try = [&] { return make_basic_try(3, hana::make_tuple(), ctx());};
+    EXPECT_TRUE(basic_try().get_next_try(ozo::tests::error::error, null_conn));
+    EXPECT_TRUE(basic_try().get_next_try(ozo::tests::error::another_error, null_conn));
+    EXPECT_TRUE(basic_try().get_next_try(ozo::tests::error::ok, null_conn));
 }
 
 TEST_F(basic_try__get_next_try, should_return_next_try_for_matching_error_if_certain_is_specified) {
-    auto basic_try = ozo::failover::basic_try(3, hana::make_tuple(ozo::tests::errc::error), ctx());
+    auto basic_try = make_basic_try(3, hana::make_tuple(ozo::tests::errc::error), ctx());
     EXPECT_TRUE(basic_try.get_next_try(ozo::tests::error::another_error, null_conn));
 }
 
+TEST_F(basic_try__get_next_try, should_call_on_retry_handler_for_retry) {
+    using op = ozo::failover::retry_options;
+    auto options = hana::make_map(
+        hana::make_pair(op::tries, 3),
+        hana::make_pair(op::on_retry, [&](ozo::error_code ec, auto& conn) mutable {handler(ec, conn);})
+    );
+    auto basic_try =  ozo::failover::basic_try(std::move(options), ctx());
+    EXPECT_CALL(handler, call(ozo::error_code{ozo::tests::error::another_error}, null_conn));
+    basic_try.get_next_try(ozo::tests::error::another_error, null_conn);
+}
+
+TEST_F(basic_try__get_next_try, should_not_call_on_retry_handler_if_no_retry_may_be) {
+    using op = ozo::failover::retry_options;
+    auto options = hana::make_map(
+        hana::make_pair(op::tries, 0),
+        hana::make_pair(op::on_retry, [&](ozo::error_code ec, auto& conn) mutable {handler(ec, conn);})
+    );
+    auto basic_try = ozo::failover::basic_try(std::move(options), ctx());
+    basic_try.get_next_try(ozo::tests::error::another_error, null_conn);
+}
+
 TEST_F(basic_try__get_next_try, should_return_null_state_for_nonmatching_error_if_certain_is_specified) {
-    auto basic_try = ozo::failover::basic_try(3, hana::make_tuple(ozo::tests::errc::error), ctx());
+    auto basic_try = make_basic_try(3, hana::make_tuple(ozo::tests::errc::error), ctx());
     EXPECT_FALSE(basic_try.get_next_try(ozo::tests::error::ok, null_conn));
 }
 
 TEST_F(basic_try__get_next_try, should_return_null_state_for_matching_error_and_no_tries_left) {
-    auto first_try = ozo::failover::basic_try(2, hana::make_tuple(), ctx());
+    auto first_try = make_basic_try(2, hana::make_tuple(), ctx());
     auto next_try = first_try.get_next_try(ozo::tests::error::error, null_conn);
     EXPECT_FALSE(next_try->get_next_try(ozo::tests::error::error, null_conn));
 }
 
-TEST_F(basic_try__get_next_try, should_close_connection_on_retry) {
-    auto basic_try = ozo::failover::basic_try(3, hana::make_tuple(), ctx());
+TEST_F(basic_try__get_next_try, should_close_connection_on_retry_if_option_is_omitted) {
+    auto basic_try = make_basic_try(3, hana::make_tuple(), ctx());
     EXPECT_CALL(conn, close_connection());
     basic_try.get_next_try(ozo::tests::error::error, std::addressof(conn));
 }
 
-TEST_F(basic_try__get_next_try, should_close_connection_on_no_retry) {
-    auto basic_try = ozo::failover::basic_try(3, hana::make_tuple(ozo::tests::errc::error), ctx());
+TEST_F(basic_try__get_next_try, should_close_connection_on_retry_if_option_is_true) {
+    using op = ozo::failover::retry_options;
+    auto options = hana::make_map(
+        hana::make_pair(op::tries, 3),
+        hana::make_pair(op::close_connection, true)
+    );
+    auto basic_try =  ozo::failover::basic_try(std::move(options), ctx());
     EXPECT_CALL(conn, close_connection());
+    basic_try.get_next_try(ozo::tests::error::error, std::addressof(conn));
+}
+
+TEST_F(basic_try__get_next_try, should_not_close_connection_on_retry_if_option_is_false) {
+    using op = ozo::failover::retry_options;
+    auto options = hana::make_map(
+        hana::make_pair(op::tries, 3),
+        hana::make_pair(op::close_connection, false)
+    );
+    auto basic_try =  ozo::failover::basic_try(std::move(options), ctx());
+    basic_try.get_next_try(ozo::tests::error::error, std::addressof(conn));
+}
+
+TEST_F(basic_try__get_next_try, should_close_connection_on_no_retry_if_option_is_omitted) {
+    auto basic_try = make_basic_try(3, hana::make_tuple(ozo::tests::errc::error), ctx());
+    EXPECT_CALL(conn, close_connection());
+    basic_try.get_next_try(ozo::tests::error::ok, std::addressof(conn));
+}
+
+TEST_F(basic_try__get_next_try, should_close_connection_on_no_retry_if_option_is_true) {
+    using op = ozo::failover::retry_options;
+    auto options = hana::make_map(
+        hana::make_pair(op::tries, 3),
+        hana::make_pair(op::conditions, hana::make_tuple(ozo::tests::errc::error)),
+        hana::make_pair(op::close_connection, true)
+    );
+    auto basic_try =  ozo::failover::basic_try(std::move(options), ctx());
+    EXPECT_CALL(conn, close_connection());
+    basic_try.get_next_try(ozo::tests::error::ok, std::addressof(conn));
+}
+
+TEST_F(basic_try__get_next_try, should_not_close_connection_on_no_retry_if_option_is_false) {
+    using op = ozo::failover::retry_options;
+    auto options = hana::make_map(
+        hana::make_pair(op::tries, 3),
+        hana::make_pair(op::conditions, hana::make_tuple(ozo::tests::errc::error)),
+        hana::make_pair(op::close_connection, false)
+    );
+    auto basic_try =  ozo::failover::basic_try(std::move(options), ctx());
     basic_try.get_next_try(ozo::tests::error::ok, std::addressof(conn));
 }
 
@@ -142,50 +225,47 @@ struct basic_try__get_context : Test {
 };
 
 TEST_F(basic_try__get_context, should_return_provider_form_context) {
-    auto basic_try = ozo::failover::basic_try(3, errcs,
+    auto basic_try = make_basic_try(3, errcs,
         ozo::failover::basic_context(std::addressof(provider), ozo::none));
     EXPECT_EQ(basic_try.get_context()[hana::size_c<0>], std::addressof(provider));
 }
 
 TEST_F(basic_try__get_context, should_return_additional_arguments_form_context) {
-    auto basic_try = ozo::failover::basic_try(3, errcs,
+    auto basic_try = make_basic_try(3, errcs,
         ozo::failover::basic_context(std::addressof(provider), ozo::none, 555, "strong"s));
     EXPECT_EQ(basic_try.get_context()[hana::size_c<2>], 555);
     EXPECT_EQ(basic_try.get_context()[hana::size_c<3>], "strong"s);
 }
 
 TEST_F(basic_try__get_context, should_return_claculated_time_out_form_context) {
-    auto basic_try = ozo::failover::basic_try(3, errcs,
+    auto basic_try = make_basic_try(3, errcs,
         ozo::failover::basic_context(std::addressof(provider), 3s));
     EXPECT_EQ(basic_try.get_context()[hana::size_c<1>], 1s);
 }
 
 TEST(basic_try__tries_remain, should_return_tries_remain_count) {
-    auto basic_try = ozo::failover::basic_try(3, hana::make_tuple(),
+    auto basic_try = make_basic_try(3, hana::make_tuple(),
         ozo::failover::basic_context(fake_connection_provider{}, ozo::none));
     EXPECT_EQ(basic_try.tries_remain(), 3);
 }
 
+template <typename Sequence>
+static std::string to_string(const Sequence& v) {
+    std::ostringstream s;
+    boost::hana::fold(v, "("sv, [&s](std::string_view delim, const auto& item) {
+            s << delim << item;
+            return ", "sv;
+        });
+    s << ")";
+    return s.str();
+}
+
 TEST(basic_try__retry_conditions, should_return_retry_conditions) {
     const auto conditions = hana::make_tuple(ozo::tests::errc::error, ozo::tests::error::ok);
-    auto basic_try = ozo::failover::basic_try(3, conditions,
+    auto basic_try = make_basic_try(3, conditions,
         ozo::failover::basic_context(fake_connection_provider{}, ozo::none));
-    EXPECT_EQ(basic_try.get_conditions(), conditions);
-}
-
-TEST(basic_try, should_throw_std__invalid_argument_if_n_tries_less_than_0) {
-    const auto ctx = ozo::failover::basic_context(fake_connection_provider{}, ozo::none);
-    EXPECT_THROW(ozo::failover::basic_try(-1, hana::make_tuple(), ctx), std::invalid_argument);
-}
-
-TEST(basic_try, should_construct_object_with_n_tries_equal_to_0) {
-    const auto ctx = ozo::failover::basic_context(fake_connection_provider{}, ozo::none);
-    EXPECT_NO_THROW(ozo::failover::basic_try(0, hana::make_tuple(), ctx));
-}
-
-TEST(basic_try, should_construct_object_with_n_tries_greater_than_0) {
-    const auto ctx = ozo::failover::basic_context(fake_connection_provider{}, ozo::none);
-    EXPECT_NO_THROW(ozo::failover::basic_try(1, hana::make_tuple(), ctx));
+    EXPECT_EQ(basic_try.get_conditions(), conditions)
+        << to_string(basic_try.get_conditions()) << "!=" << to_string(conditions);
 }
 
 } // namespace


### PR DESCRIPTION
RATIONALE
----------
Often it is needed to log information about retries. To implement this feature the options mechanism for retry strategy has been introduced. Options mechanism allows easy to extend functionality without paying for options are not used.

Option may be set up with strategy method set() like this:

```c++
auto retry = retry().set(on_retry, [](error_code ec, auto& conn) {
    std::cout << ec.message();
});
```