### PR TITLE
Implement support for timestamps

### DIFF
--- a/include/ozo/detail/epoch.h
+++ b/include/ozo/detail/epoch.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <chrono>
+
+namespace ozo::detail {
+
+// pg epoch is 2000-01-01 00:00:00, which is 30 years (10957 days)
+// after the unix epoch (1970-01-01 00:00:00, the default value for a time_point)
+// c++20: static constexpr const auto epoch = std::chrono::system_clock::time_point{} + std::chrono::years{ 30 };
+static constexpr const auto epoch = std::chrono::system_clock::time_point{} + std::chrono::hours{ 24 } * 10957;
+
+}

--- a/include/ozo/ext/std.h
+++ b/include/ozo/ext/std.h
@@ -19,3 +19,4 @@
 #include <ozo/ext/std/vector.h>
 #include <ozo/ext/std/weak_ptr.h>
 #include <ozo/ext/std/array.h>
+#include <ozo/ext/std/time_point.h>

--- a/include/ozo/ext/std/time_point.h
+++ b/include/ozo/ext/std/time_point.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <ozo/pg/definitions.h>
+#include <ozo/detail/epoch.h>
+#include <ozo/io/send.h>
+#include <ozo/io/recv.h>
+
+#include <chrono>
+#include <iostream>
+
+
+namespace ozo {
+
+
+/**
+ * @defgroup group-ext-std-chrono-system-clock-time-point std::chrono::system_clock::time_point
+ * @ingroup group-ext-std
+ * @brief [std::chrono::system_clock::time_point](https://en.cppreference.com/w/cpp/chrono/time_point) support
+ *
+ *@code
+#include <ozo/ext/std/time_point.h>
+ *@endcode
+ *
+ * `std::chrono::system_clock::time_point` is defined as a point in time.
+ */
+
+template <>
+struct send_impl<std::chrono::system_clock::time_point> {
+    template <typename M>
+    static ostream& apply(ostream& out, const oid_map_t<M>&, const std::chrono::system_clock::time_point& in) {
+        int64_t value = std::chrono::duration_cast<std::chrono::microseconds>(in - detail::epoch).count();
+        return impl::write(out, value);
+    }
+};
+
+template <>
+struct recv_impl<std::chrono::system_clock::time_point> {
+    template <typename M>
+    static istream& apply(istream& in, size_type, const oid_map_t<M>&, std::chrono::system_clock::time_point& out) {
+        int64_t value;
+        impl::read(in, value);
+        out = detail::epoch + std::chrono::microseconds{ value };
+        return in;
+    }
+};
+
+}
+
+OZO_PG_BIND_TYPE(std::chrono::system_clock::time_point, "timestamp")

--- a/include/ozo/pg/types.h
+++ b/include/ozo/pg/types.h
@@ -19,3 +19,4 @@
 #include <ozo/pg/types/oid.h>
 #include <ozo/pg/types/text.h>
 #include <ozo/pg/types/uuid.h>
+#include <ozo/pg/types/timestamp.h>

--- a/include/ozo/pg/types/timestamp.h
+++ b/include/ozo/pg/types/timestamp.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <ozo/ext/std/time_point.h>
+
+namespace ozo::pg {
+using timestamp = std::chrono::system_clock::time_point;
+} // namespace ozo:pg

--- a/tests/binary_deserialization.cpp
+++ b/tests/binary_deserialization.cpp
@@ -759,4 +759,21 @@ TEST_F(recv, should_convert_UUIDOID_to_uuid) {
     EXPECT_EQ(result, uuid);
 }
 
+TEST_F(recv, should_convert_TIMESTAMPOID_to_time_point) {
+    const char bytes[] = {
+        char(0xFF), char(0xFC), char(0xA2), char(0xFE),
+        char(0xC4), char(0xC8), char(0x20), char(0x00),
+    };
+
+    EXPECT_CALL(mock, field_type(_)).WillRepeatedly(Return(1114));
+    EXPECT_CALL(mock, get_value(_, _)).WillRepeatedly(Return(bytes));
+    EXPECT_CALL(mock, get_length(_, _)).WillRepeatedly(Return(16));
+    EXPECT_CALL(mock, get_isnull(_, _)).WillRepeatedly(Return(false));
+
+    std::chrono::system_clock::time_point result{};
+    std::chrono::system_clock::time_point expected{};
+    ozo::recv(value, oid_map, result);
+    EXPECT_EQ(result, expected);
+}
+
 } // namespace

--- a/tests/binary_serialization.cpp
+++ b/tests/binary_serialization.cpp
@@ -189,4 +189,13 @@ TEST_F(send, with_boost_uuid_should_store_it_as_is) {
     }));
 }
 
+TEST_F(send, with_std_chrono_time_point_should_store_as_microseconds) {
+    const std::chrono::system_clock::time_point time_point{};
+    ozo::send(os, oid_map, time_point);
+    EXPECT_EQ(buffer, std::vector<char>({
+        char(0xFF), char(0xFC), char(0xA2), char(0xFE),
+        char(0xC4), char(0xC8), char(0x20), char(0x00),
+    }));
+}
+
 } // namespace

--- a/tests/integration/result_integration.cpp
+++ b/tests/integration/result_integration.cpp
@@ -44,6 +44,17 @@ TEST(result, should_convert_into_tuple_integer_and_text) {
     EXPECT_EQ(std::get<1>(r[0]), "2");
 }
 
+TEST(result, should_convert_into_tuple_time_point_and_text) {
+    auto result = execute_query("select '2000-01-01 00:00:00'::timestamp, '2';");
+    auto oid_map = ozo::empty_oid_map();
+    std::vector<std::tuple<std::chrono::system_clock::time_point, std::string>> r;
+    ozo::recv_result(result, oid_map, std::back_inserter(r));
+
+    ASSERT_EQ(r.size(), 1u);
+    EXPECT_EQ(std::get<0>(r[0]), ozo::detail::epoch);
+    EXPECT_EQ(std::get<1>(r[0]), "2");
+}
+
 TEST(result, should_convert_into_tuple_float_and_text) {
     auto result = execute_query("select 42.13::float4, 'text';");
     auto oid_map = ozo::empty_oid_map();


### PR DESCRIPTION
This PR will implement support for querying PG `timestamp without time zone` to an `std::chrono::system_clock::time_point`.

There are some things I don't exactly like, I'd be happy to hear any input on this:

* `std::chrono::system_clock::time_point` default constructor does not guarantee it is initialized to the UNIX epoch. The standard does suggest that _almost_ any implementation does this, and from c++20 it _is_ guaranteed. This means that the epoch I initialize could potentially be wrong. I don't know of any systems where this is the case, though.

* The magic number of days to add is also not the nicest way of doing it. Again, c++20 to the rescue, since that one has `std::chrono::years{ 30 }`, which we unfortunately can't use yet.