### PR TITLE
Remove get_io_context(Connection)

### DIFF
--- a/include/ozo/connection_info.h
+++ b/include/ozo/connection_info.h
@@ -62,7 +62,8 @@ public:
     template <typename TimeConstraint, typename Handler>
     void operator ()(io_context& io, TimeConstraint t, Handler&& handler) const {
         static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
-        impl::async_connect(conn_str, t, std::make_shared<connection>(io, statistics),
+        auto allocator = asio::get_associated_allocator(handler);
+        impl::async_connect(conn_str, t, std::allocate_shared<connection>(allocator, io, statistics),
             std::forward<Handler>(handler));
     }
 

--- a/include/ozo/detail/deadline.h
+++ b/include/ozo/detail/deadline.h
@@ -9,13 +9,13 @@
 
 namespace ozo::detail {
 
-template <typename IoContext, typename Continuation>
+template <typename Executor, typename Continuation>
 class deadline_handler {
 public:
     template <typename TimeConstraint, typename TimerHandler>
-    deadline_handler(IoContext& io, TimeConstraint t, Continuation handler, TimerHandler on_deadline)
-    : timer_(ozo::detail::get_operation_timer(io, t)), handler_(std::move(handler)),
-            executor_(ozo::detail::make_strand_executor(io.get_executor())) {
+    deadline_handler(const Executor& ex, TimeConstraint t, Continuation handler, TimerHandler on_deadline)
+    : timer_(ozo::detail::get_operation_timer(ex, t)), handler_(std::move(handler)),
+            executor_(ozo::detail::make_strand_executor(ex)) {
         timer_.async_wait(wrapper<TimerHandler>{std::move(on_deadline), get_executor()});
     }
 
@@ -25,15 +25,15 @@ public:
         asio::dispatch(ozo::detail::bind(std::move(handler_), std::move(ec), std::forward<Args>(args)...));
     }
 
-    using executor_type = ozo::detail::strand<typename IoContext::executor_type>;
+    using timer_type = typename ozo::detail::operation_timer<Executor>::type;
+
+    using executor_type = ozo::detail::strand<Executor>;
 
     executor_type get_executor() const noexcept { return executor_;}
 
     using allocator_type = asio::associated_allocator_t<Continuation>;
 
     allocator_type get_allocator() const noexcept { return asio::get_associated_allocator(handler_);}
-
-    using timer_type = typename ozo::detail::operation_timer<IoContext>::type;
 
 private:
     template <typename Target>

--- a/include/ozo/impl/cancel.h
+++ b/include/ozo/impl/cancel.h
@@ -89,7 +89,7 @@ struct initiate_async_cancel {
         shared_handler_t shared_handler(std::allocator_arg, allocator, std::forward<CompletionHandler>(h));
         asio::post(cancel_op{
             std::forward<Handle>(cancel_handle),
-            detail::deadline_handler(io, t, shared_handler, on_cancel_op_timer{shared_handler})
+            detail::deadline_handler(io.get_executor(), t, shared_handler, on_cancel_op_timer{shared_handler})
         });
     }
 

--- a/include/ozo/impl/connection_pool.h
+++ b/include/ozo/impl/connection_pool.h
@@ -112,7 +112,7 @@ struct pooled_connection_wrapper {
 
         auto conn = std::allocate_shared<connection>(get_allocator(), std::forward<Handle>(handle));
         if (connection_good(conn)) {
-            ec = rebind_io_context(conn, io_);
+            ec = bind_executor(conn, io_.get_executor());
             return handler_(std::move(ec), std::move(conn));
         }
 

--- a/tests/connection_pool.cpp
+++ b/tests/connection_pool.cpp
@@ -229,7 +229,7 @@ TEST_F(pooled_connection_wrapper, should_invoke_handler_if_passed_connection_is_
 
     EXPECT_CALL(handle_mock, value()).WillRepeatedly(ReturnRef(conn));
     EXPECT_CALL(handle_mock, empty()).WillRepeatedly(Return(false));
-    EXPECT_CALL(connection_mock, rebind_io_context()).WillRepeatedly(Return(ozo::error_code{}));
+    EXPECT_CALL(connection_mock, bind_executor()).WillRepeatedly(Return(ozo::error_code{}));
 
     EXPECT_CALL(callback_mock, call(_, _)).WillOnce(Return());
 

--- a/tests/detail/deadline.cpp
+++ b/tests/detail/deadline.cpp
@@ -6,34 +6,6 @@
 
 namespace {
 
-struct io_context_mock : ozo::tests::execution_context {
-    ozo::tests::steady_timer_gmock* timer_;
-    io_context_mock(ozo::tests::executor_mock& executor,
-        ozo::tests::strand_executor_service_mock& strand_service,
-        ozo::tests::steady_timer_gmock& timer
-    ) : ozo::tests::execution_context(executor, strand_service), timer_(std::addressof(timer)) {}
-    MOCK_METHOD1(get_operation_timer, void(ozo::time_traits::time_point));
-};
-
-} // namespace
-
-namespace ozo::detail {
-
-template <>
-struct operation_timer<io_context_mock> {
-    using type = ozo::tests::steady_timer;
-
-    template <typename TimeConstraint>
-    static type get(io_context_mock& io, TimeConstraint t) {
-        io.get_operation_timer(t);
-        return type{io.timer_};
-    }
-};
-
-} // namespace ozo::detail
-
-namespace {
-
 using namespace testing;
 using namespace std::literals;
 
@@ -45,12 +17,13 @@ struct deadline_handler : Test {
     ozo::tests::executor_gmock strand;
     ozo::tests::strand_executor_service_gmock strand_service;
     ozo::tests::steady_timer_gmock timer;
-    io_context_mock io{executor, strand_service, timer};
+    ozo::tests::steady_timer_service_mock timer_service;
+    ozo::tests::execution_context io{executor, strand_service, timer_service};
     StrictMock<ozo::tests::callback_gmock<>> on_deadline;
     StrictMock<ozo::tests::callback_gmock<>> continuation;
 
     deadline_handler() {
-        EXPECT_CALL(io, get_operation_timer(_));
+        EXPECT_CALL(timer_service, timer(An<time_point>())).WillRepeatedly(ReturnRef(timer));
         EXPECT_CALL(strand_service, get_executor()).WillOnce(ReturnRef(strand));
     }
 };
@@ -64,14 +37,14 @@ TEST_F(deadline_handler, should_call_timeout_handler_on_timeout) {
     EXPECT_CALL(on_deadline_executor, dispatch(_)).WillOnce(InvokeArgument<0>());
     EXPECT_CALL(on_deadline, call(_));
     using ozo::tests::wrap;
-    ozo::detail::deadline_handler(io, ozo::time_traits::time_point{}, wrap(continuation), wrap(on_deadline));
+    ozo::detail::deadline_handler(io.get_executor(), time_point{}, wrap(continuation), wrap(on_deadline));
 }
 
 TEST_F(deadline_handler, should_not_call_timeout_handler_on_timer_cancel) {
     EXPECT_CALL(timer, async_wait(_)).WillOnce(InvokeArgument<0>(boost::asio::error::operation_aborted));
     EXPECT_CALL(strand, post(_)).WillOnce(InvokeArgument<0>());
     using ozo::tests::wrap;
-    ozo::detail::deadline_handler(io, ozo::time_traits::time_point{}, wrap(continuation), wrap(on_deadline));
+    ozo::detail::deadline_handler(io.get_executor(), time_point{}, wrap(continuation), wrap(on_deadline));
 }
 
 TEST_F(deadline_handler, should_cancel_timer_and_call_continuation) {
@@ -83,7 +56,7 @@ TEST_F(deadline_handler, should_cancel_timer_and_call_continuation) {
     EXPECT_CALL(continuation_executor, dispatch(_)).WillOnce(InvokeArgument<0>());
     EXPECT_CALL(continuation, call(_));
     using ozo::tests::wrap;
-    auto h = ozo::detail::deadline_handler(io, ozo::time_traits::time_point{}, wrap(continuation), wrap(on_deadline));
+    auto h = ozo::detail::deadline_handler(io.get_executor(), time_point{}, wrap(continuation), wrap(on_deadline));
     h(ozo::error_code{});
 }
 

--- a/tests/impl/request_oid_map.cpp
+++ b/tests/impl/request_oid_map.cpp
@@ -64,10 +64,6 @@ struct connection {
     friend const OidMap& get_connection_oid_map(const connection& self) {
         return self.oid_map;
     }
-    friend void get_connection_socket(connection&) {}
-    friend void get_connection_socket(const connection&) {}
-    friend void get_connection_handle(connection&) {}
-    friend void get_connection_handle(const connection&) {}
     friend std::string& get_connection_error_context(connection& self) {
         return self.error_context;
     }
@@ -78,6 +74,14 @@ struct connection {
     friend void get_connection_timer(const connection&) {}
 };
 
+}
+
+namespace ozo {
+template <class OidMap>
+struct is_connection<::connection<OidMap>> : std::true_type {};
+} // namespace ozo
+
+namespace {
 TEST(request_oid_map_op, should_call_handler_with_oid_request_failed_error_when_oid_map_length_differs_from_result_length) {
     StrictMock<callback_gmock<connection<>>> cb_mock {};
     auto operation = ozo::impl::request_oid_map_op{wrap(cb_mock)};

--- a/tests/transaction_status.cpp
+++ b/tests/transaction_status.cpp
@@ -12,7 +12,7 @@ struct get_transaction_status : testing::Test {
         using namespace ozo::tests;
         return std::make_shared<connection<>>(connection<>{
             std::make_unique<native_handle>(native_handle::good),
-            {}, {}, nullptr, "", {}
+            {}, {}, nullptr, "", {}, nullptr
         });
     }
 };


### PR DESCRIPTION
Move to connection-bound executor

Boost 1.70 version of `boost::asio::posix_descriptor` does not provide `get_io_context()` method anymore. It does not provide `io_context` via `get_executor().context()` either. This methods have been used as getters for connection-bound `io_context`. To avoid problems in the future, it has been decided to move to the connection-bound executor and remove direct usage of  `io_context` from all the library interfaces except connection provider bindings. There is a reference on `io_context` object inside connection implementation but all the accessors have been removed from the interfaces to avoid usage of deprecated `get_io_context()` methods of `boost::asio` entities.