### PR TITLE
Extend failover strategy with initiate_next_try()

### DIFF
--- a/include/ozo/core/options.h
+++ b/include/ozo/core/options.h
@@ -131,7 +131,7 @@ public:
      *
      * @param v --- default options
      */
-    options_factory_base(Options v) : v_(std::move(v)) {
+    constexpr options_factory_base(Options v) : v_(std::move(v)) {
         static_assert(decltype(hana::is_a<hana::map_tag>(v))::value, "Options should be boost::hana::map");
     }
 
@@ -281,7 +281,7 @@ public:
      *
      * @param options --- `boost::hana::map` with default options, default value is empty map.
      */
-    options_factory(Options options = Options{}) : base(std::move(options)) {
+    constexpr options_factory(Options options = Options{}) : base(std::move(options)) {
         options_factory(decltype(hana::is_a<hana::map_tag>(options))::value, "Options should be boost::hana::map");
     }
 };

--- a/include/ozo/failover/retry.h
+++ b/include/ozo/failover/retry.h
@@ -190,7 +190,7 @@ public:
      *
      * @param options --- `boost::hana::map` of `ozo::failover::retry_options` and values.
      */
-    retry_strategy(Options options = Options{}) : base(std::move(options)) {
+    constexpr retry_strategy(Options options = Options{}) : base(std::move(options)) {
         static_assert(decltype(hana::is_a<hana::map_tag>(options))::value, "Options should be boost::hana::map");
     }
 

--- a/include/ozo/failover/role_based.h
+++ b/include/ozo/failover/role_based.h
@@ -569,7 +569,7 @@ public:
      *
      * @param options --- `boost::hana::map` of `ozo::failover::role_based_options` and values.
      */
-    role_based_strategy(Options options = Options{}) : base(std::move(options)) {
+    constexpr role_based_strategy(Options options = Options{}) : base(std::move(options)) {
         static_assert(decltype(hana::is_a<hana::map_tag>(options))::value, "Options should be boost::hana::map");
     }
 


### PR DESCRIPTION
This mechanism supports static polymorphism of tries depended on error conditions.
Unlike `ozo::failover::get_next_try()` it allows to use different types of
try-objects for different error conditions.

Function implementation should call initiator in case of operation with given error
condition may be recovered by try-object is given to initiator. Or should not call
initiator in case of an unrecoverable error condition.