### PR TITLE
Allow customization of transaction initiation statement

### DIFF
--- a/include/ozo/asio.h
+++ b/include/ozo/asio.h
@@ -201,7 +201,7 @@ constexpr execute_op<impl::initiate_async_execute> execute;
  * @endcode
  * @ingroup group-core-types
  */
-template <template<typename...> typename Operation, typename Initiator>
+template <typename Operation, typename Initiator>
 struct base_async_operation {
     using initiator_type = Initiator;
     using base = base_async_operation;
@@ -211,14 +211,10 @@ struct base_async_operation {
 
     constexpr initiator_type get_initiator() const { return initiator_;}
 
-    template <typename OtherInitiator>
-    constexpr static auto rebind_initiator(const OtherInitiator& other) {
-        return Operation<OtherInitiator>{other};
-    }
-
     template <typename InitiatorFactory>
     constexpr auto operator[] (InitiatorFactory&& f) const {
-        return rebind_initiator(construct_initiator(std::forward<InitiatorFactory>(f), *this));
+        const auto& op = static_cast<const Operation&>(*this);
+        return op.rebind_initiator(construct_initiator(std::forward<InitiatorFactory>(f), *this));
     }
 };
 

--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -978,7 +978,7 @@ template <typename T, typename CompletionToken>
 decltype(auto) get_connection(T&& provider, CompletionToken&& token);
 #else
 template <typename Initiator>
-struct get_connection_op : base_async_operation <get_connection_op, Initiator> {
+struct get_connection_op : base_async_operation <get_connection_op<Initiator>, Initiator> {
     using base = typename get_connection_op::base;
     using base::base;
 
@@ -994,6 +994,11 @@ struct get_connection_op : base_async_operation <get_connection_op, Initiator> {
     template <typename T, typename CompletionToken>
     decltype(auto) operator() (T&& provider, CompletionToken&& token) const {
         return (*this)(std::forward<T>(provider), none, std::forward<CompletionToken>(token));
+    }
+
+    template <typename OtherInitiator>
+    constexpr static auto rebind_initiator(const OtherInitiator& other) {
+        return get_connection_op<OtherInitiator>{other};
     }
 };
 

--- a/include/ozo/core/options.h
+++ b/include/ozo/core/options.h
@@ -4,8 +4,11 @@
 #include <boost/hana/tuple.hpp>
 #include <boost/hana/fold.hpp>
 #include <boost/hana/concat.hpp>
+#include <boost/hana/map.hpp>
 
 namespace ozo {
+
+namespace hana = boost::hana;
 
 /**
  * @brief Option class
@@ -33,8 +36,6 @@ struct option : hana::type<Key> {
         return hana::make_pair(*this, std::forward<T>(v));
     }
 };
-
-namespace hana = boost::hana;
 
 /**
  * @brief Get the option object from Hana.Map

--- a/include/ozo/detail/begin_statement_builder.h
+++ b/include/ozo/detail/begin_statement_builder.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <boost/hana/find.hpp>
+#include <boost/hana/filter.hpp>
+#include <boost/hana/fold.hpp>
+#include <boost/hana/not_equal.hpp>
+#include <boost/hana/optional.hpp>
+#include <boost/hana/plus.hpp>
+#include <boost/hana/string.hpp>
+#include <boost/hana/tuple.hpp>
+#include <ozo/core/none.h>
+#include <ozo/core/options.h>
+#include <ozo/query_builder.h>
+#include <ozo/transaction_options.h>
+#include <type_traits>
+
+namespace ozo::detail {
+
+namespace hana = boost::hana;
+
+struct begin_statement_builder {
+    using opt = transaction_options;
+
+    template <typename Level>
+    constexpr static auto to_string(decltype(opt::isolation_level), Level level) {
+        [[maybe_unused]] const auto prefix = BOOST_HANA_STRING(" ISOLATION LEVEL ");
+        const auto sql_levels = hana::make_map(
+            hana::make_pair(isolation_level::serializable, BOOST_HANA_STRING("SERIALIZABLE")),
+            hana::make_pair(isolation_level::repeatable_read, BOOST_HANA_STRING("REPEATABLE READ")),
+            hana::make_pair(isolation_level::read_committed, BOOST_HANA_STRING("READ COMMITTED")),
+            hana::make_pair(isolation_level::read_uncommitted, BOOST_HANA_STRING("READ UNCOMMITTED"))
+        );
+
+        if constexpr (const auto sql = hana::find(sql_levels, level); sql != hana::nothing) {
+            return prefix + *sql;
+        } else {
+            static_assert(std::is_void_v<Level>, "unexpected transaction level");
+        }
+    }
+
+    template <typename Mode>
+    constexpr static auto to_string(decltype(opt::mode), Mode mode) {
+        const auto sql_modes = hana::make_map(
+            hana::make_pair(transaction_mode::read_write, BOOST_HANA_STRING(" READ WRITE")),
+            hana::make_pair(transaction_mode::read_only, BOOST_HANA_STRING(" READ ONLY"))
+        );
+
+        if constexpr (const auto sql = hana::find(sql_modes, mode); sql != hana::nothing) {
+            return *sql;
+        } else {
+            static_assert(std::is_void_v<Mode>, "unknown transaction mode");
+        }
+    }
+
+    template <typename Deferrable>
+    constexpr static auto to_string(decltype(opt::deferrability), Deferrable) {
+        if constexpr (Deferrable::value) {
+            return BOOST_HANA_STRING(" DEFERRABLE");
+        } else {
+            return BOOST_HANA_STRING(" NOT DEFERRABLE");
+        }
+    }
+
+    template <typename Options>
+    constexpr static auto build(Options const& options) {
+        constexpr auto supported_options = hana::make_tuple(opt::isolation_level, opt::mode, opt::deferrability);
+        constexpr auto query_prefix = BOOST_HANA_STRING("BEGIN");
+
+        const auto real_options = hana::filter(hana::filter(supported_options, hana::partial(hana::contains, options)),
+                                               ([&](const auto& v) { return std::negation<is_none<std::decay_t<decltype(options[v])>>>{}; }));
+        const auto strings = hana::transform(real_options, [&](const auto& v) { return to_string(v, options[v]); });
+        return make_query(hana::fold(strings, query_prefix, hana::plus));
+    }
+};
+
+} // ozo::detail

--- a/include/ozo/execute.h
+++ b/include/ozo/execute.h
@@ -42,7 +42,7 @@ decltype(auto) execute(P&& provider, Q&& query, CompletionToken&& token);
 #else
 
 template <typename Initiator>
-struct execute_op : base_async_operation <execute_op, Initiator> {
+struct execute_op : base_async_operation <execute_op<Initiator>, Initiator> {
     using base = typename execute_op::base;
     using base::base;
 
@@ -58,6 +58,11 @@ struct execute_op : base_async_operation <execute_op, Initiator> {
     decltype(auto) operator() (P&& provider, Q&& query, CompletionToken&& token) const {
         return (*this)(std::forward<P>(provider), std::forward<Q>(query), none,
             std::forward<CompletionToken>(token));
+    }
+
+    template <typename OtherInitiator>
+    constexpr static auto rebind_initiator(const OtherInitiator& other) {
+        return execute_op<OtherInitiator>{other};
     }
 };
 

--- a/include/ozo/impl/async_end_transaction.h
+++ b/include/ozo/impl/async_end_transaction.h
@@ -17,8 +17,8 @@ struct async_end_transaction_op {
         async_execute(std::forward<T>(provider), std::forward<Query>(query), t, std::move(*this));
     }
 
-    template <typename Connection>
-    void operator ()(error_code ec, impl::transaction<Connection> transaction) {
+    template <typename Connection, typename Options>
+    void operator ()(error_code ec, impl::transaction<Connection, Options> transaction) {
         Connection connection;
         transaction.take_connection(connection);
         asio::dispatch(

--- a/include/ozo/impl/async_start_transaction.h
+++ b/include/ozo/impl/async_start_transaction.h
@@ -6,9 +6,10 @@
 
 namespace ozo::impl {
 
-template <typename Handler>
+template <typename Handler, typename Options>
 struct async_start_transaction_op {
     Handler handler;
+    Options options;
 
     template <typename T, typename Query, typename TimeConstraint>
     void perform(T&& provider, Query&& query, TimeConstraint t) {
@@ -24,21 +25,21 @@ struct async_start_transaction_op {
             detail::bind(
                 std::move(handler),
                 std::move(ec),
-                make_transaction(std::forward<Connection>(connection))
+                make_transaction(std::forward<Connection>(connection), std::move(options))
             )
         );
     }
 };
 
-template <typename Handler>
-auto make_async_start_transaction_op(Handler&& handler) {
-    return async_start_transaction_op<std::decay_t<Handler>> {std::forward<Handler>(handler)};
+template <typename Handler, typename Options>
+auto make_async_start_transaction_op(Handler&& handler, Options&& options) {
+    return async_start_transaction_op<std::decay_t<Handler>, std::decay_t<Options>> {std::forward<Handler>(handler), std::forward<Options>(options)};
 }
 
-template <typename T, typename Query, typename TimeConstraint, typename Handler>
-Require<ConnectionProvider<T>> async_start_transaction(T&& provider, Query&& query,
+template <typename T, typename Options, typename Query, typename TimeConstraint, typename Handler>
+Require<ConnectionProvider<T>> async_start_transaction(T&& provider, Options&& options, Query&& query,
         TimeConstraint t, Handler&& handler) {
-    make_async_start_transaction_op(std::forward<Handler>(handler))
+    make_async_start_transaction_op(std::forward<Handler>(handler), std::forward<Options>(options))
         .perform(std::forward<T>(provider), std::forward<Query>(query), t);
 }
 

--- a/include/ozo/request.h
+++ b/include/ozo/request.h
@@ -82,7 +82,7 @@ decltype(auto) request (ConnectionProvider&& provider, Query&& query, Out out, C
 #else
 
 template <typename Initiator>
-struct request_op : base_async_operation <request_op, Initiator> {
+struct request_op : base_async_operation <request_op<Initiator>, Initiator> {
     using base = typename request_op::base;
     using base::base;
 
@@ -99,6 +99,11 @@ struct request_op : base_async_operation <request_op, Initiator> {
     decltype(auto) operator()(P&& provider, Q&& query, Out out, CompletionToken&& token) const {
         return (*this)(std::forward<P>(provider), std::forward<Q>(query), none, std::move(out),
             std::forward<CompletionToken>(token));
+    }
+
+    template <typename OtherInitiator>
+    constexpr static auto rebind_initiator(const OtherInitiator& other) {
+        return request_op<OtherInitiator>{other};
     }
 };
 

--- a/include/ozo/transaction.h
+++ b/include/ozo/transaction.h
@@ -1,22 +1,28 @@
 #pragma once
 
+#include <ozo/core/options.h>
+#include <ozo/detail/begin_statement_builder.h>
 #include <ozo/impl/async_start_transaction.h>
 #include <ozo/impl/async_end_transaction.h>
+#include <ozo/transaction_status.h>
 
 namespace ozo {
 
-template <typename Initiator>
-struct begin_op : base_async_operation <begin_op, Initiator> {
+template <typename Initiator, typename Options = decltype(make_options())>
+struct begin_op : base_async_operation <begin_op<Initiator, Options>, Initiator> {
     using base = typename begin_op::base;
-    using base::base;
+    Options options_;
+
+    constexpr explicit begin_op(Initiator initiator = {}, Options options = {}) : base(initiator), options_(options) {}
+
     template <typename T, typename TimeConstraint, typename CompletionToken>
     auto operator() (T&& provider, TimeConstraint t, CompletionToken&& token) const {
         static_assert(ConnectionProvider<T>, "provider should be a ConnectionProvider");
         static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
         using namespace ozo::literals;
-        return async_initiate<CompletionToken, handler_signature<impl::transaction<connection_type<T>>>>(
+        return async_initiate<CompletionToken, handler_signature<impl::transaction<connection_type<T>, Options>>>(
             get_operation_initiator(*this), token,
-            std::forward<T>(provider), "BEGIN"_SQL, t);
+            std::forward<T>(provider), options_, detail::begin_statement_builder::build(options_), t);
     }
 
     template <typename T, typename CompletionToken>
@@ -27,13 +33,23 @@ struct begin_op : base_async_operation <begin_op, Initiator> {
             std::forward<CompletionToken>(token)
         );
     }
+
+    template <typename OtherOptions>
+    auto with_transaction_options(const OtherOptions& options) const {
+        return begin_op<Initiator, OtherOptions>{get_operation_initiator(*this), options};
+    }
+
+    template <typename OtherInitiator>
+    constexpr auto rebind_initiator(const OtherInitiator& other) const {
+        return begin_op<OtherInitiator, Options>{other, options_};
+    }
 };
 
 constexpr begin_op<impl::initiate_async_start_transaction> begin;
 
 struct commit_op {
-    template <typename T, typename TimeConstraint, typename CompletionToken>
-    auto operator() (impl::transaction<T>&& transaction, TimeConstraint t, CompletionToken&& token) const {
+    template <typename T, typename Options, typename TimeConstraint, typename CompletionToken>
+    auto operator() (impl::transaction<T, Options>&& transaction, TimeConstraint t, CompletionToken&& token) const {
         static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
         using namespace ozo::literals;
         return async_initiate<CompletionToken, handler_signature<T>>(
@@ -41,8 +57,8 @@ struct commit_op {
             std::move(transaction), "COMMIT"_SQL, t);
     }
 
-    template <typename T, typename CompletionToken>
-    auto operator() (impl::transaction<T>&& transaction, CompletionToken&& token) const {
+    template <typename... Ts, typename CompletionToken>
+    auto operator() (impl::transaction<Ts...>&& transaction, CompletionToken&& token) const {
         return (*this)(
             std::move(transaction),
             none,
@@ -54,8 +70,8 @@ struct commit_op {
 constexpr commit_op commit;
 
 struct rollback_op {
-    template <typename T, typename TimeConstraint, typename CompletionToken>
-    auto operator() (impl::transaction<T>&& transaction, TimeConstraint t, CompletionToken&& token) const {
+    template <typename T, typename Options, typename TimeConstraint, typename CompletionToken>
+    auto operator() (impl::transaction<T, Options>&& transaction, TimeConstraint t, CompletionToken&& token) const {
         static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
         using namespace ozo::literals;
         return async_initiate<CompletionToken, handler_signature<T>>(
@@ -63,8 +79,8 @@ struct rollback_op {
             std::move(transaction), "ROLLBACK"_SQL, t);
     }
 
-    template <typename T, typename CompletionToken>
-    auto operator() (impl::transaction<T>&& transaction, CompletionToken&& token) const {
+    template <typename... Ts, typename CompletionToken>
+    auto operator() (impl::transaction<Ts...>&& transaction, CompletionToken&& token) const {
         return (*this)(
             std::move(transaction),
             none,
@@ -74,5 +90,54 @@ struct rollback_op {
 };
 
 constexpr rollback_op rollback;
+
+/**
+ * @ingroup group-connection-functions
+ * @brief Retrieve's a transactions isolation level
+ *
+ * The isolation level can either be an instance of one of the child types of ozo::isolation_level or
+ * `ozo::none` if no level was explicitly set.
+ *
+ * @param transaction transaction to get the isolation level from
+ * @return sub type of ozo::isolation_level --- if the transaction isolation level has been set
+ * @return ozo::none --- if no isolation level has been set
+ */
+template<typename... Ts>
+constexpr auto get_transaction_isolation_level(const impl::transaction<Ts...>& transaction) {
+    return get_option(transaction.options(), transaction_options::isolation_level, none);
+}
+
+/**
+ * @ingroup group-connection-functions
+ * @brief Retrieve's a transactions transaction mode
+ *
+ * The mode can either be an instance of one of the child types of ozo::transaction_mode or
+ * ozo::none if mode was set explicitly set.
+ *
+ * @param transaction transaction to get the transaction mode from
+ * @return sub type of ozo::transaction_mode --- if the transaction mode has been set
+ * @return ozo::none --- if no transaction mode has been specified
+ */
+template<typename... Ts>
+constexpr auto get_transaction_mode(const impl::transaction<Ts...>& transaction) {
+    return get_option(transaction.options(), transaction_options::mode, none);
+}
+
+/**
+ * @ingroup group-connection-functions
+ * @brief Retrieve's a transactions deferrability
+ *
+ * Deferrability is usually indicated using an instance of ozo::deferrable_mode, but can also
+ * be any other type with a compile-time static ::value convertible to bool.
+ * `ozo::none` indicates no explicit deferrability was set.
+ *
+ * @param transaction transaction to get the deferrability from
+ * @return ozo::deferrable_mode (or any bool-convertible std::integral_constant) --- if the deferrability has been set
+ * @return ozo::none --- if no deferrability has been set
+ */
+template<typename... Ts>
+constexpr auto get_transaction_deferrability(const impl::transaction<Ts...>& transaction) {
+    return get_option(transaction.options(), transaction_options::deferrability, none);
+}
 
 } // namespace ozo

--- a/include/ozo/transaction_options.h
+++ b/include/ozo/transaction_options.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <boost/hana/optional.hpp>
+#include <boost/hana/type.hpp>
+#include <ozo/core/none.h>
+#include <ozo/core/options.h>
+#include <type_traits>
+
+namespace ozo {
+
+namespace hana = boost::hana;
+
+/**
+ * @ingroup group-connection-types
+ * @brief 'type enum' for transaction isolation levels supported by PostgreSQL
+ *
+ * See the official documentation [on transaction isolation](https://www.postgresql.org/docs/11/transaction-iso.html) and
+ * [transaction initiation](https://www.postgresql.org/docs/11/sql-set-transaction.html) for more information on guarantees every level makes
+ * and how these options affect transaction behaviour.
+ */
+struct isolation_level {
+    constexpr static hana::type<class serializable_tag> serializable{}; //!< SERIALIZABLE isolation level
+    constexpr static hana::type<class repeatable_tag> repeatable_read{}; //!< REPEATABLE READ isolation level
+    constexpr static hana::type<class read_committed_tag> read_committed{}; //!< READ COMMITTED isolation level
+    constexpr static hana::type<class read_uncommitted> read_uncommitted{}; //!< READ UNCOMMITTED isolation level (treated like READ COMMITTED by PostgreSQL)
+};
+
+/**
+ * @ingroup group-connection-types
+ * @brief 'type enum' for transaction modes supported by PostgreSQL
+ *
+ * See the official documentation on [transaction initiation](https://www.postgresql.org/docs/11/sql-set-transaction.html)
+ * for more information on how these options affect transaction behaviour.
+ */
+struct transaction_mode {
+    constexpr static hana::type<class read_write_tag> read_write{}; //!< READ WRITE transaction mode
+    constexpr static hana::type<class read_only_tag> read_only{}; //!< READ ONLY transaction mode
+};
+
+/**
+ * @ingroup group-connection-types
+ * @brief transaction deferrability indicator
+ * @tparam V integral constant indicating the deferrability
+ *
+ * See the official documentation on [transaction initiation](https://www.postgresql.org/docs/11/sql-set-transaction.html)
+ * for more information on how these options affect transaction behaviour.
+ */
+template <typename V>
+struct deferrable_mode : V {
+    using base = V;
+
+    constexpr auto operator!() const noexcept {
+        return deferrable_mode<typename std::negation<V>::type>{};
+    }
+};
+
+constexpr deferrable_mode<std::true_type> deferrable;
+
+/**
+ * @ingroup group-connection-types
+ * @brief options for transactions
+ *
+ * This options can be used with ozo::begin
+ */
+struct transaction_options {
+    constexpr static option<class isolation_level_tag> isolation_level{}; //!< Transaction isolation level, see ozo::isolation_level
+    constexpr static option<class mode_tag> mode{}; //!< Transaction mode, see ozo::transaction_mode
+    constexpr static option<class deferrability_tag> deferrability{}; //!< Transaction deferrability, see ozo::deferrable_mode
+};
+
+} // ozo

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ set(SOURCES
     impl/async_send_query_params.cpp
     impl/async_get_result.cpp
     detail/base36.cpp
+    detail/begin_statement_builder.cpp
     detail/functional.cpp
     detail/timeout_handler.cpp
     detail/make_copyable.cpp

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -177,8 +177,8 @@ struct connection {
         provider->mock_->request_oid_map();
     }
 
-    template <typename Q, typename Handler>
-    friend void async_execute(ozo::impl::transaction<std::shared_ptr<connection>>&& transaction, Q&&,
+    template <typename Q, typename Options, typename Handler>
+    friend void async_execute(ozo::impl::transaction<std::shared_ptr<connection>, Options>&& transaction, Q&&,
             const ozo::time_traits::duration&, Handler&&) {
         std::shared_ptr<connection> connection;
         transaction.take_connection(connection);

--- a/tests/detail/begin_statement_builder.cpp
+++ b/tests/detail/begin_statement_builder.cpp
@@ -1,0 +1,200 @@
+#include <ozo/detail/begin_statement_builder.h>
+#include <ozo/query_builder.h>
+
+#include <gtest/gtest.h>
+
+namespace {
+
+namespace hana = boost::hana;
+
+TEST(begin_statement_builder, should_build_query_according_to_options) {
+    using namespace ozo;
+    using namespace ozo::detail;
+    using namespace hana::literals;
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::serializable,
+                                                                   transaction_options::mode = transaction_mode::read_write,
+                                                                   transaction_options::deferrability = deferrable))),
+              "BEGIN ISOLATION LEVEL SERIALIZABLE READ WRITE DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::serializable,
+                                                                   transaction_options::mode = transaction_mode::read_write,
+                                                                   transaction_options::deferrability = !deferrable))),
+              "BEGIN ISOLATION LEVEL SERIALIZABLE READ WRITE NOT DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::serializable,
+                                                                   transaction_options::mode = transaction_mode::read_write))),
+              "BEGIN ISOLATION LEVEL SERIALIZABLE READ WRITE"_s);
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::serializable,
+                                                                   transaction_options::mode = transaction_mode::read_only,
+                                                                   transaction_options::deferrability = deferrable))),
+              "BEGIN ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::serializable,
+                                                                   transaction_options::mode = transaction_mode::read_only,
+                                                                   transaction_options::deferrability = !deferrable))),
+              "BEGIN ISOLATION LEVEL SERIALIZABLE READ ONLY NOT DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::serializable,
+                                                                   transaction_options::mode = transaction_mode::read_only))),
+              "BEGIN ISOLATION LEVEL SERIALIZABLE READ ONLY"_s);
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::serializable,
+                                                                   transaction_options::deferrability = deferrable))),
+              "BEGIN ISOLATION LEVEL SERIALIZABLE DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::serializable,
+                                                                   transaction_options::deferrability = !deferrable))),
+              "BEGIN ISOLATION LEVEL SERIALIZABLE NOT DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::serializable))),
+              "BEGIN ISOLATION LEVEL SERIALIZABLE"_s);
+
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::repeatable_read,
+                                                                   transaction_options::mode = transaction_mode::read_write,
+                                                                   transaction_options::deferrability = deferrable))),
+              "BEGIN ISOLATION LEVEL REPEATABLE READ READ WRITE DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::repeatable_read,
+                                                                   transaction_options::mode = transaction_mode::read_write,
+                                                                   transaction_options::deferrability = !deferrable))),
+              "BEGIN ISOLATION LEVEL REPEATABLE READ READ WRITE NOT DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::repeatable_read,
+                                                                   transaction_options::mode = transaction_mode::read_write))),
+              "BEGIN ISOLATION LEVEL REPEATABLE READ READ WRITE"_s);
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::repeatable_read,
+                                                                   transaction_options::mode = transaction_mode::read_only,
+                                                                   transaction_options::deferrability = deferrable))),
+              "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::repeatable_read,
+                                                                   transaction_options::mode = transaction_mode::read_only,
+                                                                   transaction_options::deferrability = !deferrable))),
+              "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY NOT DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::repeatable_read,
+                                                                   transaction_options::mode = transaction_mode::read_only))),
+              "BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY"_s);
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::repeatable_read,
+                                                                   transaction_options::deferrability = deferrable))),
+              "BEGIN ISOLATION LEVEL REPEATABLE READ DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::repeatable_read,
+                                                                   transaction_options::deferrability = !deferrable))),
+              "BEGIN ISOLATION LEVEL REPEATABLE READ NOT DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::repeatable_read))),
+              "BEGIN ISOLATION LEVEL REPEATABLE READ"_s);
+
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_committed,
+                                                                   transaction_options::mode = transaction_mode::read_write,
+                                                                   transaction_options::deferrability = deferrable))),
+              "BEGIN ISOLATION LEVEL READ COMMITTED READ WRITE DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_committed,
+                                                                   transaction_options::mode = transaction_mode::read_write,
+                                                                   transaction_options::deferrability = !deferrable))),
+              "BEGIN ISOLATION LEVEL READ COMMITTED READ WRITE NOT DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_committed,
+                                                                   transaction_options::mode = transaction_mode::read_write))),
+              "BEGIN ISOLATION LEVEL READ COMMITTED READ WRITE"_s);
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_committed,
+                                                                   transaction_options::mode = transaction_mode::read_only,
+                                                                   transaction_options::deferrability = deferrable))),
+              "BEGIN ISOLATION LEVEL READ COMMITTED READ ONLY DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_committed,
+                                                                   transaction_options::mode = transaction_mode::read_only,
+                                                                   transaction_options::deferrability = !deferrable))),
+              "BEGIN ISOLATION LEVEL READ COMMITTED READ ONLY NOT DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_committed,
+                                                                   transaction_options::mode = transaction_mode::read_only))),
+              "BEGIN ISOLATION LEVEL READ COMMITTED READ ONLY"_s);
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_committed,
+                                                                   transaction_options::deferrability = deferrable))),
+              "BEGIN ISOLATION LEVEL READ COMMITTED DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_committed,
+                                                                   transaction_options::deferrability = !deferrable))),
+              "BEGIN ISOLATION LEVEL READ COMMITTED NOT DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_committed))),
+              "BEGIN ISOLATION LEVEL READ COMMITTED"_s);
+
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_uncommitted,
+                                                                   transaction_options::mode = transaction_mode::read_write,
+                                                                   transaction_options::deferrability = deferrable))),
+              "BEGIN ISOLATION LEVEL READ UNCOMMITTED READ WRITE DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_uncommitted,
+                                                                   transaction_options::mode = transaction_mode::read_write,
+                                                                   transaction_options::deferrability = !deferrable))),
+              "BEGIN ISOLATION LEVEL READ UNCOMMITTED READ WRITE NOT DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_uncommitted,
+                                                                   transaction_options::mode = transaction_mode::read_write))),
+              "BEGIN ISOLATION LEVEL READ UNCOMMITTED READ WRITE"_s);
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_uncommitted,
+                                                                   transaction_options::mode = transaction_mode::read_only,
+                                                                   transaction_options::deferrability = deferrable))),
+              "BEGIN ISOLATION LEVEL READ UNCOMMITTED READ ONLY DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_uncommitted,
+                                                                   transaction_options::mode = transaction_mode::read_only,
+                                                                   transaction_options::deferrability = !deferrable))),
+              "BEGIN ISOLATION LEVEL READ UNCOMMITTED READ ONLY NOT DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_uncommitted,
+                                                                   transaction_options::mode = transaction_mode::read_only))),
+              "BEGIN ISOLATION LEVEL READ UNCOMMITTED READ ONLY"_s);
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_uncommitted,
+                                                                   transaction_options::deferrability = deferrable))),
+              "BEGIN ISOLATION LEVEL READ UNCOMMITTED DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_uncommitted,
+                                                                   transaction_options::deferrability = !deferrable))),
+              "BEGIN ISOLATION LEVEL READ UNCOMMITTED NOT DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = isolation_level::read_uncommitted))),
+              "BEGIN ISOLATION LEVEL READ UNCOMMITTED"_s);
+
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::mode = transaction_mode::read_write,
+                                                                   transaction_options::deferrability = deferrable))),
+              "BEGIN READ WRITE DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::mode = transaction_mode::read_write,
+                                                                   transaction_options::deferrability = !deferrable))),
+              "BEGIN READ WRITE NOT DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::mode = transaction_mode::read_write))),
+              "BEGIN READ WRITE"_s);
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::mode = transaction_mode::read_only,
+                                                                   transaction_options::deferrability = deferrable))),
+              "BEGIN READ ONLY DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::mode = transaction_mode::read_only,
+                                                                   transaction_options::deferrability = !deferrable))),
+              "BEGIN READ ONLY NOT DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::mode = transaction_mode::read_only))),
+              "BEGIN READ ONLY"_s);
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::deferrability = deferrable))),
+              "BEGIN DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::deferrability = !deferrable))),
+              "BEGIN NOT DEFERRABLE"_s);
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options())),
+              "BEGIN"_s);
+}
+
+TEST(begin_statement_builder, should_treat_none_like_non_existent_parameters) {
+    using namespace ozo;
+    using namespace ozo::detail;
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::isolation_level = ozo::none))),
+              get_text(begin_statement_builder::build(make_options())));
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::deferrability = ozo::none,
+                                                                   transaction_options::mode = transaction_mode::read_only))),
+              get_text(begin_statement_builder::build(make_options(transaction_options::mode = transaction_mode::read_only))));
+}
+
+TEST(begin_statement_builder, should_allow_integral_constants_for_deferrability) {
+    using namespace ozo;
+    using namespace ozo::detail;
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::deferrability = deferrable))),
+              get_text(begin_statement_builder::build(make_options(transaction_options::deferrability = std::true_type{}))));
+
+    EXPECT_EQ(get_text(begin_statement_builder::build(make_options(transaction_options::deferrability = !deferrable))),
+              get_text(begin_statement_builder::build(make_options(transaction_options::deferrability = std::false_type{}))));
+}
+
+} // namespace

--- a/tests/impl/async_end_transaction.cpp
+++ b/tests/impl/async_end_transaction.cpp
@@ -1,5 +1,6 @@
 #include "connection_mock.h"
 
+#include <ozo/core/options.h>
 #include <ozo/impl/async_end_transaction.h>
 
 #include <gtest/gtest.h>
@@ -23,13 +24,14 @@ struct async_end_transaction : Test {
     StrictMock<stream_descriptor_gmock> socket {};
     io_context io {executor, strand_service};
     decltype(make_connection(connection, io, socket)) conn = make_connection(connection, io, socket);
+    decltype(ozo::make_options()) options = ozo::make_options();
     time_traits::duration timeout {42};
 };
 
 TEST_F(async_end_transaction, should_call_async_execute) {
     *conn->handle_ = native_handle::good;
 
-    auto transaction = ozo::impl::transaction<decltype(conn)>(std::move(conn));
+    auto transaction = ozo::impl::transaction<decltype(conn), decltype(options)>(std::move(conn), options);
 
     const InSequence s;
 

--- a/tests/impl/async_start_transaction.cpp
+++ b/tests/impl/async_start_transaction.cpp
@@ -1,5 +1,6 @@
 #include "connection_mock.h"
 
+#include <ozo/core/options.h>
 #include <ozo/impl/async_start_transaction.h>
 
 #include <gtest/gtest.h>
@@ -14,9 +15,10 @@ using ozo::error_code;
 using ozo::time_traits;
 
 struct async_start_transaction : Test {
+    decltype(ozo::make_options()) options = ozo::make_options();
     StrictMock<connection_gmock> connection {};
     StrictMock<executor_gmock> callback_executor{};
-    StrictMock<callback_gmock<ozo::impl::transaction<connection_ptr<>>>> callback {};
+    StrictMock<callback_gmock<ozo::impl::transaction<connection_ptr<>, decltype(options)>>> callback {};
     StrictMock<executor_gmock> executor {};
     StrictMock<executor_gmock> strand {};
     StrictMock<strand_executor_service_gmock> strand_service {};
@@ -31,7 +33,7 @@ TEST_F(async_start_transaction, should_call_async_execute) {
 
     EXPECT_CALL(connection, async_execute()).WillOnce(Return());
 
-    ozo::impl::async_start_transaction(conn, fake_query {}, timeout, wrap(callback));
+    ozo::impl::async_start_transaction(conn, options, fake_query {}, timeout, wrap(callback));
 }
 
 } // namespace

--- a/tests/impl/transaction.cpp
+++ b/tests/impl/transaction.cpp
@@ -1,5 +1,6 @@
 #include "connection_mock.h"
 
+#include <ozo/core/options.h>
 #include <ozo/impl/transaction.h>
 
 #include <gtest/gtest.h>
@@ -17,53 +18,54 @@ struct impl_transaction : Test {
     StrictMock<stream_descriptor_gmock> socket {};
     io_context io {executor, strand_service};
     decltype(make_connection(connection, io, socket)) conn = make_connection(connection, io, socket);
+    decltype(ozo::make_options()) options = ozo::make_options();
 };
 
 TEST_F(impl_transaction, should_be_able_to_construct_default) {
-    ozo::impl::transaction<decltype(conn)> t;
+    ozo::impl::transaction<decltype(conn), decltype(options)> t;
 }
 
 TEST_F(impl_transaction, when_destruct_last_copy_with_connection_should_close_connection) {
     EXPECT_CALL(socket, close(_)).WillOnce(Return());
 
-    ozo::impl::make_transaction(std::move(conn));
+    ozo::impl::make_transaction(std::move(conn), options);
 }
 
 TEST_F(impl_transaction, when_destruct_last_copy_without_connection_should_not_close_connection) {
     EXPECT_CALL(socket, close(_)).Times(0);
 
-    ozo::impl::make_transaction(std::move(conn)).take_connection(conn);
+    ozo::impl::make_transaction(std::move(conn), options).take_connection(conn);
 }
 
 TEST_F(impl_transaction, should_be_able_to_convert_to_bool) {
-    ozo::impl::transaction<decltype(conn)> t;
+    ozo::impl::transaction<decltype(conn), decltype(options)> t;
     EXPECT_FALSE(static_cast<bool>(t));
 }
 
 TEST_F(impl_transaction, has_connection_when_constructed_with) {
     EXPECT_CALL(socket, close(_)).WillOnce(Return());
 
-    EXPECT_TRUE(ozo::impl::make_transaction(std::move(conn)).has_connection());
+    EXPECT_TRUE(ozo::impl::make_transaction(std::move(conn), options).has_connection());
 }
 
 TEST_F(impl_transaction, transaction_with_initialized_connection_is_not_null) {
     EXPECT_CALL(socket, close(_)).WillOnce(Return());
 
-    EXPECT_FALSE(is_null(ozo::impl::make_transaction(std::move(conn))));
+    EXPECT_FALSE(is_null(ozo::impl::make_transaction(std::move(conn), options)));
 }
 
 TEST_F(impl_transaction, transaction_without_connection_is_null) {
-    ozo::impl::transaction<decltype(conn)> transaction;
+    ozo::impl::transaction<decltype(conn), decltype(options)> transaction;
     EXPECT_TRUE(is_null(transaction));
 }
 
 TEST_F(impl_transaction, transaction_without_null_state_connection_is_null) {
-    ozo::impl::transaction<decltype(conn)> transaction(nullptr);
+    ozo::impl::transaction<decltype(conn), decltype(options)> transaction(nullptr, options);
     EXPECT_TRUE(is_null(transaction));
 }
 
 TEST_F(impl_transaction, transaction_become_null_after_take_connection) {
-    auto transaction = ozo::impl::make_transaction(std::move(conn));
+    auto transaction = ozo::impl::make_transaction(std::move(conn), options);
 
     transaction.take_connection(conn);
 

--- a/tests/integration/transaction_integration.cpp
+++ b/tests/integration/transaction_integration.cpp
@@ -54,4 +54,146 @@ TEST(transaction, create_schema_in_transaction_and_rollback_then_table_should_no
     io.run();
 }
 
+TEST(transaction, transaction_level_options_should_not_cause_sql_syntax_errors) {
+    ozo::io_context io;
+    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+
+    asio::spawn(io, [&] (asio::yield_context yield) {
+        auto level = ozo::isolation_level::serializable;
+        auto const options = ozo::make_options(ozo::transaction_options::isolation_level = level);
+        ozo::error_code ec;
+        auto transaction = ozo::begin.with_transaction_options(options)(conn_info[io], ozo::none, yield[ec]);
+
+        static_assert(std::is_same_v<decltype(ozo::get_transaction_isolation_level(transaction)), decltype(level)>);
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_mode(transaction))>::value);
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_deferrability(transaction))>::value);
+
+        EXPECT_FALSE(ec);
+        ozo::rollback(std::move(transaction), yield[ec]);
+        EXPECT_FALSE(ec);
+    });
+
+    asio::spawn(io, [&] (asio::yield_context yield) {
+        auto level = ozo::isolation_level::repeatable_read;
+        auto const options = ozo::make_options(ozo::transaction_options::isolation_level = level);
+        ozo::error_code ec;
+        auto transaction = ozo::begin.with_transaction_options(options)(conn_info[io], ozo::none, yield[ec]);
+
+        static_assert(std::is_same_v<decltype(ozo::get_transaction_isolation_level(transaction)), decltype(level)>);
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_mode(transaction))>::value);
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_deferrability(transaction))>::value);
+
+        EXPECT_FALSE(ec);
+        ozo::rollback(std::move(transaction), yield[ec]);
+        EXPECT_FALSE(ec);
+    });
+
+    asio::spawn(io, [&] (asio::yield_context yield) {
+        auto level = ozo::isolation_level::read_committed;
+        auto const options = ozo::make_options(ozo::transaction_options::isolation_level = level);
+        ozo::error_code ec;
+        auto transaction = ozo::begin.with_transaction_options(options)(conn_info[io], ozo::none, yield[ec]);
+
+        static_assert(std::is_same_v<decltype(ozo::get_transaction_isolation_level(transaction)), decltype(level)>);
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_mode(transaction))>::value);
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_deferrability(transaction))>::value);
+
+        EXPECT_FALSE(ec);
+        ozo::rollback(std::move(transaction), yield[ec]);
+        EXPECT_FALSE(ec);
+    });
+
+    asio::spawn(io, [&] (asio::yield_context yield) {
+        auto level = ozo::isolation_level::read_uncommitted;
+        auto const options = ozo::make_options(ozo::transaction_options::isolation_level = level);
+        ozo::error_code ec;
+        auto transaction = ozo::begin.with_transaction_options(options)(conn_info[io], ozo::none, yield[ec]);
+
+        static_assert(std::is_same_v<decltype(ozo::get_transaction_isolation_level(transaction)), decltype(level)>);
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_mode(transaction))>::value);
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_deferrability(transaction))>::value);
+
+        EXPECT_FALSE(ec);
+        ozo::rollback(std::move(transaction), yield[ec]);
+        EXPECT_FALSE(ec);
+    });
+
+    io.run();
+}
+
+TEST(transaction, transaction_mode_options_should_not_cause_sql_syntax_errors) {
+    ozo::io_context io;
+    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+
+    asio::spawn(io, [&] (asio::yield_context yield) {
+        auto mode = ozo::transaction_mode::read_write;
+        auto const options = ozo::make_options(ozo::transaction_options::mode = mode);
+        ozo::error_code ec;
+        auto transaction = ozo::begin.with_transaction_options(options)(conn_info[io], ozo::none, yield[ec]);
+
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_isolation_level(transaction))>::value);
+        static_assert(std::is_same_v<decltype(ozo::get_transaction_mode(transaction)), decltype(mode)>);
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_deferrability(transaction))>::value);
+
+        EXPECT_FALSE(ec);
+        ozo::rollback(std::move(transaction), yield[ec]);
+        EXPECT_FALSE(ec);
+    });
+
+    asio::spawn(io, [&] (asio::yield_context yield) {
+        auto mode = ozo::transaction_mode::read_only;
+        auto const options = ozo::make_options(ozo::transaction_options::mode = mode);
+        ozo::error_code ec;
+        auto transaction = ozo::begin.with_transaction_options(options)(conn_info[io], ozo::none, yield[ec]);
+
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_isolation_level(transaction))>::value);
+        static_assert(std::is_same_v<decltype(ozo::get_transaction_mode(transaction)), decltype(mode)>);
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_deferrability(transaction))>::value);
+
+        EXPECT_FALSE(ec);
+        ozo::rollback(std::move(transaction), yield[ec]);
+        EXPECT_FALSE(ec);
+    });
+
+    io.run();
+}
+
+TEST(transaction, transaction_deferrability_options_should_not_generate_syntax_errors) {
+    using ozo::transaction_options;
+    ozo::io_context io;
+    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+
+    asio::spawn(io, [&] (asio::yield_context yield) {
+        auto defer = ozo::deferrable;
+        auto const options = ozo::make_options(ozo::transaction_options::deferrability = defer);
+        ozo::error_code ec;
+        auto transaction = ozo::begin.with_transaction_options(options)(conn_info[io], yield[ec]);
+
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_isolation_level(transaction))>::value);
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_mode(transaction))>::value);
+        static_assert(std::is_same_v<decltype(ozo::get_transaction_deferrability(transaction)), decltype(defer)>);
+
+        EXPECT_FALSE(ec);
+        ozo::rollback(std::move(transaction), yield[ec]);
+        EXPECT_FALSE(ec);
+    });
+
+    asio::spawn(io, [&] (asio::yield_context yield) {
+        auto defer = !ozo::deferrable;
+        auto const options = ozo::make_options(ozo::transaction_options::deferrability = defer);
+        ozo::error_code ec;
+        auto transaction = ozo::begin.with_transaction_options(options)(conn_info[io], yield[ec]);
+
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_isolation_level(transaction))>::value);
+        static_assert(ozo::is_none<decltype(ozo::get_transaction_mode(transaction))>::value);
+        static_assert(std::is_same_v<decltype(ozo::get_transaction_deferrability(transaction)), decltype(defer)>);
+
+        EXPECT_FALSE(ec);
+        ozo::rollback(std::move(transaction), yield[ec]);
+        EXPECT_FALSE(ec);
+    });
+
+    io.run();
+}
+
 } // namespace


### PR DESCRIPTION
- model postgres transaction options in code
- add options parameter to long-form of begin_op::operator()
- add .with_options()-helper to begin_op to control the implicit options

All credit for the interface ideas goes to @thed636 