### PR TITLE
Fix usage for external projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ matrix:
 
   - os: linux
     dist: xenial
+    env: BUILD_ARGS='pg docker gcc test_external_project'
+
+  - os: linux
+    dist: xenial
     env: BUILD_ARGS='pg docker clang debug'
 
   - os: linux

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(OZO_BUILD_EXAMPLES "Enable examples build" OFF)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_library(ozo INTERFACE)
+add_library(yandex::ozo ALIAS ozo)
 
 target_compile_features(ozo INTERFACE cxx_std_17)
 
@@ -34,7 +35,7 @@ endif()
 
 target_include_directories(ozo INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include/ozo>
+    $<INSTALL_INTERFACE:include>
 )
 
 target_compile_definitions(ozo INTERFACE -DBOOST_COROUTINES_NO_DEPRECATION_WARNING)
@@ -57,6 +58,7 @@ install(
 
 install(
     EXPORT      ozo-targets
+    NAMESPACE   yandex::
     DESTINATION lib/cmake/ozo
 )
 
@@ -70,6 +72,7 @@ write_basic_package_version_file(
 export(
     EXPORT ozo-targets
     FILE "${CMAKE_CURRENT_BINARY_DIR}/ozo/ozo-targets.cmake"
+    NAMESPACE yandex::
 )
 
 configure_file(cmake/ozo-config.cmake
@@ -80,6 +83,7 @@ configure_file(cmake/ozo-config.cmake
 install(
     FILES
         cmake/ozo-config.cmake
+        cmake/modules/FindPostgreSQL.cmake
         "${CMAKE_CURRENT_BINARY_DIR}/ozo/ozo-config-version.cmake"
     DESTINATION
         lib/cmake/ozo

--- a/cmake/ozo-config.cmake
+++ b/cmake/ozo-config.cmake
@@ -1,1 +1,13 @@
+include(CMakeFindDependencyMacro)
+
+# Find PostgreSQL using new provided script
+# Remove this once we move to CMake 3.14+
+set(CMAKE_MODULE_PATH_old_ ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}")
+find_dependency(PostgreSQL)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH_old_})
+
+find_dependency(Boost COMPONENTS coroutine context system thread atomic)
+find_dependency(resource_pool)
+
 include("${CMAKE_CURRENT_LIST_DIR}/ozo-targets.cmake")

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -51,6 +51,11 @@ build_gcc() {
             CMAKE_BUILD_TYPE=RelWithDebInfo
             build
         ;;
+        test_external_project)
+            CMAKE_BUILD_TYPE=Release
+            OZO_TEST_EXTERNAL_PROJECT=ON
+            build
+        ;;
         coverage)
             CMAKE_BUILD_TYPE=Debug
             OZO_COVERAGE=ON
@@ -89,6 +94,7 @@ build_all() {
     $0 gcc debug
     $0 gcc release
     $0 gcc coverage
+    $0 gcc test_external_project
     $0 clang debug
     $0 clang release
     $0 clang asan
@@ -125,6 +131,28 @@ build() {
     ctest -V
     if [[ ${OZO_COVERAGE} == "ON" ]]; then
         make ozo_coverage
+    fi
+    if [[ ${OZO_TEST_EXTERNAL_PROJECT} == "ON" ]]; then
+        INSTALL_DIR="${BUILD_DIR}/ozo_install"
+        mkdir -p ${INSTALL_DIR}
+        make DESTDIR=${INSTALL_DIR} install
+
+        PREVIOUS_DIR="$(pwd)"
+        cd ${INSTALL_DIR}
+        OZO_ROOT_DIR="$(pwd)/usr/local"
+        cd ${PREVIOUS_DIR}
+
+
+        EXT_BUILD_DIR="${BUILD_DIR}_external_project"
+        mkdir -p ${EXT_BUILD_DIR}
+        cd ${EXT_BUILD_DIR}
+        cmake \
+            -DCMAKE_C_COMPILER="${CC_COMPILER}" \
+            -DCMAKE_CXX_COMPILER="${CXX_COMPILER}" \
+            -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
+            -Dozo_ROOT="${OZO_ROOT_DIR}" \
+            ${SOURCE_DIR}/tests/external_project
+        make
     fi
 }
 

--- a/tests/external_project/CMakeLists.txt
+++ b/tests/external_project/CMakeLists.txt
@@ -1,0 +1,6 @@
+cmake_minimum_required(VERSION 3.12)
+project(my_ozo_using_project)
+
+find_package(ozo REQUIRED)
+add_executable(my_app ../../examples/request.cpp)
+target_link_libraries(my_app PRIVATE yandex::ozo)


### PR DESCRIPTION
- find_package(ozo) will now resolve dependencies on it's own
- fixed include path when ozo is externally resolved
- moved installed tareget to yandex:: namespace
- vendored FindPostgreSQL of CMake 3.14
- added regression test to ensure ozo can be used from external projects