### PR TITLE
Explicit connection implementation

### DIFF
--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -467,10 +467,7 @@ inline std::string_view error_message(T&& conn);
  * @return `std::string` contains a context
  */
 template <typename T>
-inline const auto& get_error_context(const T& conn) {
-    static_assert(Connection<T>, "T must be a Connection");
-    return get_connection_error_context(unwrap_connection(conn));
-}
+inline const auto& get_error_context(const T& conn);
 
 /**
  * @brief Additional error context setter
@@ -484,10 +481,7 @@ inline const auto& get_error_context(const T& conn) {
  * @param ctx --- context to set, now only `std::string` is supported
  */
 template <typename T, typename Ctx>
-inline void set_error_context(T& conn, Ctx&& ctx) {
-    static_assert(Connection<T>, "T must be a Connection");
-    get_connection_error_context(unwrap_connection(conn)) = std::forward<Ctx>(ctx);
-}
+inline void set_error_context(T& conn, Ctx&& ctx);
 
 /**
  * @brief Reset additional error context
@@ -500,11 +494,7 @@ inline void set_error_context(T& conn, Ctx&& ctx) {
  * @param conn --- #Connection to reset context, should not be in null state
  */
 template <typename T>
-inline void reset_error_context(T& conn) {
-    static_assert(Connection<T>, "T must be a Connection");
-    using ctx_type = std::decay_t<decltype(get_error_context(conn))>;
-    set_error_context(conn, ctx_type{});
-}
+inline void reset_error_context(T& conn);
 
 /**
  * @brief Access to a connection OID map

--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -378,22 +378,6 @@ constexpr auto Connection = is_connection<std::decay_t<T>>::value;
  * @brief Connection related functions
  */
 ///@{
-/**
- * @brief PostgreSQL connection handle
- *
- * PostgreSQL native connection handle wrapped with RAII smart pointer.
- * In common cases you do not need this function. It's purpose is to support
- * extention and customization of the library. See get_native_handle for details.
- *
- * @param conn --- #Connection object
- * @return refernce to a wrapped PostgreSQL connection handle
- */
-template <typename T>
-inline decltype(auto) get_handle(T&& conn) noexcept {
-    static_assert(Connection<T>, "T must be a Connection");
-    return get_connection_handle(
-        unwrap_connection(std::forward<T>(conn)));
-}
 
 /**
  * @brief PostgreSQL native connection handle
@@ -407,9 +391,7 @@ inline decltype(auto) get_handle(T&& conn) noexcept {
  * @return native handle
  */
 template <typename Connection>
-inline auto get_native_handle(const Connection& conn) noexcept {
-    return get_handle(conn).get();
-}
+inline auto get_native_handle(const Connection& conn) noexcept;
 
 /**
  * @brief Executor for connection related asynchronous operations

--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -13,6 +13,7 @@
 #include <ozo/detail/functional.h>
 
 #include <boost/asio/dispatch.hpp>
+#include <boost/asio/posix/stream_descriptor.hpp>
 
 namespace ozo {
 
@@ -300,22 +301,67 @@ constexpr detail::result_of<get_connection_error_context_impl, T> get_connection
     return detail::apply<get_connection_error_context_impl>(std::forward<T>(conn));
 }
 #endif
+namespace detail {
+template <typename Connection, typename Executor>
+inline error_code bind_connection_executor(Connection&, const Executor&);
+}
+
+template <typename OidMap, typename Statistics>
+class connection {
+public:
+    using native_handle_type = native_conn_handle::pointer;
+    using oid_map_type = OidMap;
+    using error_context = std::string;
+    using executor_type = io_context::executor_type;
+
+    connection(io_context& io, Statistics statistics);
+
+    native_handle_type native_handle() const noexcept { return handle_.get(); }
+
+    oid_map_type& oid_map() noexcept { return oid_map_;}
+    const oid_map_type& oid_map() const noexcept { return oid_map_;}
+
+    Statistics& statistics() noexcept { return statistics_;}
+    const Statistics& statistics() const noexcept { return statistics_;}
+
+    const error_context& get_error_context() const noexcept { return error_context_; }
+    void set_error_context(error_context v = error_context{}) { error_context_ = std::move(v); }
+
+    executor_type get_executor() const noexcept { return io_->get_executor(); }
+
+    error_code set_executor(const executor_type& ex);
+
+    error_code assign(native_conn_handle&& handle);
+
+    template <typename WaitHandler>
+    void async_wait_write(WaitHandler&& h);
+
+    template <typename WaitHandler>
+    void async_wait_read(WaitHandler&& h);
+
+    error_code close() noexcept;
+
+    void cancel() noexcept;
+
+private:
+    using stream_type = asio::posix::stream_descriptor;
+
+    template <typename Connection, typename Executor>
+    friend error_code ozo::detail::bind_connection_executor(Connection&, const Executor&);
+
+    native_conn_handle handle_;
+    io_context* io_ = nullptr;
+    stream_type socket_;
+    oid_map_type oid_map_;
+    Statistics statistics_;
+    error_context error_context_;
+};
 
 template <typename, typename = std::void_t<>>
 struct is_connection : std::false_type {};
-template <typename T>
-struct is_connection<T, std::void_t<
-    decltype(get_connection_oid_map(unwrap_connection(std::declval<T&>()))),
-    decltype(get_connection_socket(unwrap_connection(std::declval<T&>()))),
-    decltype(get_connection_handle(unwrap_connection(std::declval<T&>()))),
-    decltype(get_connection_error_context(unwrap_connection(std::declval<T&>()))),
-    decltype(get_connection_oid_map(unwrap_connection(std::declval<const T&>()))),
-    decltype(get_connection_socket(unwrap_connection(std::declval<const T&>()))),
-    decltype(get_connection_handle(unwrap_connection(std::declval<const T&>()))),
-    decltype(get_connection_error_context(unwrap_connection(std::declval<const T&>()))),
-    decltype(get_connection_executor(unwrap_connection(std::declval<const T&>())))
->> : std::true_type {};
 
+template <typename ...Ts>
+struct is_connection<connection<Ts...>> : std::true_type {};
 
 /**
 * @ingroup group-connection-concepts
@@ -370,7 +416,7 @@ ozo::get_connection_executor()
 * @hideinitializer
 */
 template <typename T>
-constexpr auto Connection = is_connection<std::decay_t<T>>::value;
+constexpr auto Connection = is_connection<std::decay_t<decltype(unwrap_connection(std::declval<T>()))>>::value;
 
 /**
  * @defgroup group-connection-functions Related functions
@@ -403,18 +449,8 @@ inline auto get_native_handle(const Connection& conn) noexcept;
  * @param conn --- #Connection object
  * @return `executor` of socket stream object of the connection
  */
-template <typename T>
-inline auto get_executor(T& conn) noexcept;
-
-/**
- * @brief Binds executor for the connection
- *
- * @param conn --- #Connection which must be rebound
- * @param ex --- Executor whish should be used for IO and timers
- * @return `error_code` in case of error has been
- */
-template <typename T, typename Executor>
-inline error_code bind_executor(T& conn, const Executor& ex);
+template <typename Connection>
+inline auto get_executor(const Connection& conn) noexcept;
 
 /**
  * @brief Indicates if connection state is bad
@@ -449,8 +485,8 @@ inline bool connection_good(const T& conn) noexcept {
  * @param conn --- #Connection to get message from
  * @return `std::string_view` contains a message
  */
-template <typename T>
-inline std::string_view error_message(T&& conn);
+template <typename Connection>
+inline std::string_view error_message(const Connection& conn);
 
 /**
  * @brief Additional error context getter
@@ -607,6 +643,11 @@ template <typename ConnectionProvider>
 struct get_connection_type_default<ConnectionProvider,
     std::void_t<typename ConnectionProvider::connection_type>> {
     using type = typename ConnectionProvider::connection_type;
+};
+
+template <typename T>
+struct get_connection_type_default<T, Require<ozo::Connection<T>>> {
+    using type = T;
 };
 
 } // namespace detail
@@ -963,14 +1004,6 @@ struct initiate_async_get_connection {
 constexpr get_connection_op<detail::initiate_async_get_connection> get_connection;
 #endif
 
-namespace detail {
-
-template <typename T>
-struct get_connection_type_default<T, Require<Connection<T>>> {
-    using type = T;
-};
-
-} // namespace detail
 
 /**
  * @brief Close connection to the database immediately

--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -1036,14 +1036,8 @@ struct get_connection_type_default<T, Require<Connection<T>>> {
  *
  * @param conn --- #Connection to be closed
  */
-template <typename T>
-inline void close_connection(T&& conn) {
-    static_assert(Connection<T>, "T is not a Connection concept");
-
-    error_code ec;
-    get_socket(conn).close(ec);
-    get_handle(std::forward<T>(conn)).reset();
-}
+template <typename Connection>
+inline error_code close_connection(Connection&& conn);
 
 /**
  * @brief Close connection to the database when leaving the scope

--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -84,41 +84,10 @@ struct get_connection_oid_map_impl {
     }
 };
 
-/**
- * @ingroup group-connection-functions
- * @brief Get the connection oid map object
- *
- * #Connection types' OID map getter. This function must be specified for a #Connection concept
- * implementation to be conform to. Function must return reference to ozo::oid_map_t template
- * specialization or proxy class object to access connection's types' OID map.
- *
- * **Customization Point**
- *
- * This is customization point for #Connection concept implementation. To customize it please
- * specialize `ozo::get_connection_oid_map_impl` template. Default specialization may look like this
- * (`for exposition only`):
- * @code
-    template <typename T, typename = std::void_t<>>
-    struct get_connection_oid_map_impl {
-        template <typename Conn>
-        constexpr static auto apply(Conn&& c) -> decltype((c.oid_map_)) {
-            return c.oid_map_;
-        }
-    };
- * @endcode
- * Function overload works as well, but it is safer to specialize the template.
- * @param conn --- #Connection object
- * @return reference or proxy to OID map object.
- */
-#ifdef OZO_DOCUMENTATION
-template <typename T>
-constexpr OidMap& get_connection_oid_map(T&& conn);
-#else
 template <typename T>
 constexpr detail::result_of<get_connection_oid_map_impl, T> get_connection_oid_map(T&& conn) {
     return detail::apply<get_connection_oid_map_impl>(std::forward<T>(conn));
 }
-#endif
 
 template <typename T, typename = std::void_t<>>
 struct get_connection_socket_impl {
@@ -127,42 +96,10 @@ struct get_connection_socket_impl {
         return c.socket_;
     }
 };
-
-/**
- * @ingroup group-connection-functions
- * @brief Get the connection socket object
- *
- * #Connection socket object getter. #Connection must provide socket for IO. In general it must return
- * reference to an instance of [boost::asio::posix::stream_descriptor](https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/posix__stream_descriptor.html).
- *
- * **Customization Point**
- *
- * This is customization point for #Connection concept implementation. To customize it please
- * specialize `ozo::get_connection_socket_impl` template. Default specialization may look like this
- * (`for exposition only`):
- * @code
-    template <typename T, typename = std::void_t<>>
-    struct get_connection_socket_impl {
-        template <typename Conn>
-        constexpr static auto apply(Conn&& c) -> decltype((c.socket_)) {
-            return c.socket_;
-        }
-    };
- * @endcode
- * Function overload works as well, but it is safer to specialize the template.
- *
- * @param conn --- #Connection object
- * @return reference or proxy to the socket object
- */
-#ifdef OZO_DOCUMENTATION
-template <typename T>
-constexpr auto get_connection_socket(T&& conn);
-#else
 template <typename T>
 constexpr detail::result_of<get_connection_socket_impl, T> get_connection_socket(T&& conn) {
     return detail::apply<get_connection_socket_impl>(std::forward<T>(conn));
 }
-#endif
 
 template <typename T, typename = hana::when<true>>
 struct get_connection_executor_impl;
@@ -176,41 +113,10 @@ struct get_connection_executor_impl<T,
     }
 };
 
-/**
- * @ingroup group-connection-functions
- * @brief Get the connection associated executor object
- *
- * #Connection should provide an executor for IO and timer operations. In general it should return
- * [boost::asio::io_context::executor_type](https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/io_context__executor_type.html) object.
- *
- * **Customization Point**
- *
- * This is customization point for #Connection concept implementation. To customize it please
- * specialize `ozo::get_connection_executor_impl` template. Default specialization may look like this
- * (`for exposition only`):
- * @code
-    template <typename T, typename = std::void_t<>>
-    struct get_connection_socket_impl {
-        template <typename Conn>
-        constexpr static auto apply(Conn&& c) -> decltype((c.socket_)) {
-            return c.socket_;
-        }
-    };
- * @endcode
- * Function overload works as well, but it is safer to specialize the template.
- *
- * @param conn --- #Connection object
- * @return reference or proxy to the socket object
- */
-#ifdef OZO_DOCUMENTATION
-template <typename T>
-constexpr auto get_connection_executor(T&& conn);
-#else
 template <typename T>
 constexpr detail::result_of<get_connection_executor_impl, T> get_connection_executor(T&& conn) {
     return detail::apply<get_connection_executor_impl>(std::forward<T>(conn));
 }
-#endif
 
 template <typename T, typename = std::void_t<>>
 struct get_connection_handle_impl {
@@ -220,41 +126,10 @@ struct get_connection_handle_impl {
     }
 };
 
-/**
- * @ingroup group-connection-functions
- * @brief Get the connection handle object
- *
- * PosgreSQL connection handle getter. In general it must return reference or proxy object to
- * `ozo::native_conn_handle` object.
- *
- * **Customization Point**
- *
- * This is customization point for #Connection concept implementation. To customize it please
- * specialize `ozo::get_connection_handle_impl` template. Default specialization may look like this
- * (`for exposition only`):
- * @code
-    template <typename T, typename = std::void_t<>>
-    struct get_connection_handle_impl {
-        template <typename Conn>
-        constexpr static auto apply(Conn&& c) -> decltype((c.handle_)) {
-            return c.handle_;
-        }
-    };
- * @endcode
- * Function overload works as well, but it is safer to specialize the template.
- *
- * @param conn --- #Connection object
- * @return reference or proxy object to `ozo::native_conn_handle` object
- */
-#ifdef OZO_DOCUMENTATION
-template <typename T>
-constexpr auto get_connection_handle(T&& conn);
-#else
 template <typename T>
 constexpr detail::result_of<get_connection_handle_impl, T> get_connection_handle(T&& conn) {
     return detail::apply<get_connection_handle_impl>(std::forward<T>(conn));
 }
-#endif
 
 template <typename T, typename = std::void_t<>>
 struct get_connection_error_context_impl {
@@ -264,83 +139,165 @@ struct get_connection_error_context_impl {
     }
 };
 
-/**
- * @ingroup group-connection-functions
- * @brief Get the connection error context object
- *
- * Connection OZO error context getter. In many cases the `error_code` is a good thing, but sometimes
- * you need an additional context which unlucky can not be placed inside an `error_code` object. To
- * solve this problem this additional error context is introduced. Usually it returns a reference to an
- * std::string object. The error context is reset inside get_connection implementation for Connection.
- *
- * **Customization Point**
- *
- * This is customization point for #Connection concept implementation. To customize it please
- * specialize `ozo::get_connection_error_context_impl` template. Default specialization may look like this
- * (`for exposition only`):
- * @code
-    template <typename T, typename = std::void_t<>>
-    struct get_connection_error_context_impl {
-        template <typename Conn>
-        constexpr static auto apply(Conn&& c) -> decltype((c.error_context_)) {
-            return c.error_context_;
-        }
-    };
- * @endcode
- * Function overload works as well, but it is safer to specialize the template.
- *
- * @param conn --- #Connection object
- * @return additional error context, for now `std::string` is supported only
- */
-#ifdef OZO_DOCUMENTATION
-template <typename T>
-constexpr auto get_connection_error_context(T&& conn);
-#else
 template <typename T>
 constexpr detail::result_of<get_connection_error_context_impl, T> get_connection_error_context(T&& conn) {
     return detail::apply<get_connection_error_context_impl>(std::forward<T>(conn));
 }
-#endif
+
 namespace detail {
 template <typename Connection, typename Executor>
 inline error_code bind_connection_executor(Connection&, const Executor&);
 }
 
+/**
+ * @brief Default model for `Connection` concept
+ *
+ * `Connection` concept model which is used by the library as default model.
+ *
+ * @tparam OidMap --- oid map of types are used with connection
+ * @tparam Statistics --- statistics of the connection (not supported yet)
+ *
+ * ### Thread safety
+ *
+ * *Distinct objects*: Safe.
+ *
+ * *Shared objects*: Unsafe.
+ *
+ * @ingroup group-connection-types
+ */
 template <typename OidMap, typename Statistics>
 class connection {
 public:
-    using native_handle_type = native_conn_handle::pointer;
-    using oid_map_type = OidMap;
-    using error_context = std::string;
-    using executor_type = io_context::executor_type;
+    using native_handle_type = native_conn_handle::pointer; //!< Native connection handle type
+    using oid_map_type = OidMap; //!< Oid map of types that are used with the connection
+    using error_context = std::string; //!< Additional error context which could provide context depended information for errors
+    using executor_type = io_context::executor_type; //!< The type of the executor associated with the object.
 
+    /**
+     * Construct a new connection object.
+     *
+     * @param io --- execution context for IO operations associated with the object.
+     * @param statistics --- initial statistics (not supported yet)
+     */
     connection(io_context& io, Statistics statistics);
 
+    /**
+     * Get native connection handle object.
+     *
+     * This function may be used to obtain the underlying representation of the connection.
+     * This is intended to allow access to native `libpq` functionality that is not otherwise provided.
+     *
+     * @return native_handle_type --- native connection handle.
+     */
     native_handle_type native_handle() const noexcept { return handle_.get(); }
 
+    /**
+     * Get a reference to an oid map object for types that are used with the connection.
+     *
+     * @return oid_map_type& --- reference on oid map object.
+     */
     oid_map_type& oid_map() noexcept { return oid_map_;}
+    /**
+     * Get a reference to an oid map object for types that are used with the connection.
+     *
+     * @return const oid_map_type& --- reference on oid map object.
+     */
     const oid_map_type& oid_map() const noexcept { return oid_map_;}
 
     Statistics& statistics() noexcept { return statistics_;}
     const Statistics& statistics() const noexcept { return statistics_;}
 
+    /**
+     * Get the additional context object for an error that occurred during the last operation on the connection.
+     *
+     * @return const error_context& --- additional context for the error
+     */
     const error_context& get_error_context() const noexcept { return error_context_; }
+    /**
+     * Set the additional error context object. This function may be used to provide additional context-depended
+     * data that is related to the current operation error.
+     *
+     * @param v --- new error context.
+     */
     void set_error_context(error_context v = error_context{}) { error_context_ = std::move(v); }
 
+    /**
+     * Get the executor associated with the object.
+     *
+     * @return executor_type --- executor object.
+     */
     executor_type get_executor() const noexcept { return io_->get_executor(); }
 
+    /**
+     * Set the new executor for the object.
+     *
+     * This function may be used to migrate the object between different execution contexts.
+     *
+     * Typically this function is used by the library in the connection pool implementation.
+     * Users should not use it directly other than for a special purpose (e.g., own connection pool
+     * implementation and so on).
+     *
+     * @note The function shall not be called while any active operation executes on the object.
+     *
+     * @param ex --- new executor object.
+     * @return error_code --- error code of the function call.
+     */
     error_code set_executor(const executor_type& ex);
 
+    /**
+     * Assign an existing native connection handle to the object.
+     *
+     * Typically this function is used by the library within the connection establishing process.
+     * Users should not use it directly other than for a special purpose (e.g., special connection pool
+     * implementation and so on).
+     *
+     * @note The function shall not be called while any active operation executes on the object.
+     *
+     * @param handle --- rvalue reference on a new handle.
+     * @return error_code --- error code of the function call.
+     */
     error_code assign(native_conn_handle&& handle);
 
+    /**
+     * Asynchronously wait for the connection socket to become ready to write or to have pending error conditions.
+     *
+     * Typically this function is used by the library within the connection establishing process and operation execution.
+     * Users should not use it directly other than for custom `libpq`-based opeartions.
+     *
+     * @param handler --- wait handler with `void(ozo::error_code, int=0)` signature.
+     */
     template <typename WaitHandler>
-    void async_wait_write(WaitHandler&& h);
+    void async_wait_write(WaitHandler&& handler);
 
+    /**
+     * Asynchronously wait for the connection socket to become ready to read or to have pending error conditions.
+     *
+     * Typically this function is used by the library within the connection establishing process and operation execution.
+     * Users should not use it directly other than for custom `libpq`-based opeartions.
+     *
+     * @param handler --- wait handler with `void(ozo::error_code, int=0)` signature.
+     */
     template <typename WaitHandler>
-    void async_wait_read(WaitHandler&& h);
+    void async_wait_read(WaitHandler&& handler);
 
+    /**
+     * Close the connection.
+     *
+     * Any asynchronous operations will be cancelled immediately,
+     * and will complete with the `boost::asio::error::operation_aborted` error.
+     *
+     * @return error_code - indicates what error occurred, if any. Note that,
+     *                      even if the function indicates an error, the underlying
+     *                      connection is closed.
+     */
     error_code close() noexcept;
 
+    /**
+     * Cancel all asynchronous operations associated with the connection.
+     *
+     * This function causes all outstanding asynchronous operations to finish immediately,
+     * and the handlers for cancelled operations will be passed the `boost::asio::error::operation_aborted` error.
+     */
     void cancel() noexcept;
 
 private:
@@ -357,6 +314,13 @@ private:
     error_context error_context_;
 };
 
+/**
+ * @ingroup group-connection-types
+ * @brief Connection indicator
+ *
+ * This structure template should be specialized as `std::true_type`
+ * for a type that models the `Connection` concept.
+ */
 template <typename, typename = std::void_t<>>
 struct is_connection : std::false_type {};
 
@@ -367,52 +331,47 @@ struct is_connection<connection<Ts...>> : std::true_type {};
 * @ingroup group-connection-concepts
 * @brief Database connection concept
 *
-* We define the `Connection` to database not as a concrete class or type,
-* but as an entity which must support some traits. The reason why we
-* choose such strategy is - we want to provide flexibility and extension ability
-* for implementation and testing. User can implement a connection bound additional
-* functionality.
+* `Connection` concept represents a minimum set of attributes and functions that are required
+* by the library to establish communication and execute operations. `Connection` should provide:
+* * the native PostgreSQL connection handle from `libpq`,
+* * an executor to perform IO-related operation (according to the current version of Boost.Asio
+*   it should be `boost::asio::io_context::executor_type` object),
+* * an additional error context to provide context-depended information for errors,
+* * IO functions that are necessary to perform operations.
 *
-* ###Connection Definition
+* The default implementation of the concept is `ozo::connection`.
 *
-* Connection `conn` is an object for which these next statements are valid:
+* ### Requirements
 *
-* @code{cpp}
-decltype(auto) oid_map = get_connection_oid_map(unwrap_connection(conn));
-* @endcode
-* There the `oid_map` must be a reference or proxy for connection's #OidMap object, which allows to read and modify it.
-* Object must be created via `ozo::register_types()` template function or be empty_oid_map in case if no custom
-* types are used with the connection.
+* Any wrapper object, which may be unwrapped to the underlying `Connection` model via
+* `ozo::unwrap_connection` is valid `Connection` model.
 *
-* @code
-decltype(auto) socket = get_connection_socket(unwrap_connection(conn));
-* @endcode
-* Must return reference or proxy for a socket IO stream object which allows to bind the connection to the asio
-* io_context, currently <a href="https://www.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/posix__stream_descriptor.html">boost::asio::posix::stream_descriptor</a> is suppurted only.
+* Connection `c` is an object of type `C` for which these next requirements are valid:
 *
+* | Expression | Type | Description |
+* |------------|------|-------------|
+* | <PRE>as_const(c).native_handle()</PRE> | `C::native_handle_type` | Should return native handle type of PostgreSQL connection. In the current implementation it should be `PGconn*` type. Shall not throw an exception. |
+* | <PRE>c.oid_map()<sup>[1]</sup><br/>as_const(c).oid_map()<sup>[2]</sup></PRE> | `C::oid_map_type` | Should return a reference<sup>[1]</sup> or a const reference<sup>[2]</sup> on `OidMap` which is used by the connection, the library may update this map during connection establishing. Shall not throw an exception. |
+* | <PRE>as_const(c).%get_error_context()</PRE> | `C::error_context_type` | Should return a const reference on an additional error context is related to at least the last error. In the current implementation, the type supported is `std::string`. Shall not throw an exception. |
+* | <PRE>c.set_error_context(error_context)<sup>[1]</sup><br/>%c.set_error_context()<sup>[2]</sup></PRE> | | Should set<sup>[1]</sup> or reset<sup>[2]</sup> additional error context. |
+* | <PRE>as_const(c).%get_executor()</PRE> | `C::executor_type` | Should provide an executor object that is useful for IO-related operations, like timer and so on. In the current implementation `boost::asio::io_context::executor_type` is only applicable. Shall not throw an exception. |
+* | <PRE>c.set_executor(executor)</PRE> | `error_code` | Should change the executor for the specified one. This operation is used by `ozo::connection_pool` to provide connection migration between different instances of `boost::asio::io_service`. The call of the function during the active operation on connection is UB. The error should be indicated via the result. |
+* | <PRE>c.assign(move(native_conn_handle))</PRE> | `error_code` | Should assign `ozo::native_conn_handle` to the connection object. If success - the previous handle should be destroyed. The error should be indicated via the result. |
+* | <PRE>c.async_wait_write(WaitHandler)</PRE> | | Should asynchronously wait for write ready state of the connection socket. |
+* | <PRE>c.async_wait_read(WaitHandler)</PRE> | | Should asynchronously wait for read ready state of the connection socket. |
+* | <PRE>c.close()</PRE> | `error_code` | Should close connection socket and cancel all IO operation on the connection (like `async_wait_write`, `async_wait_read`). Shall not throw an exception. |
+* | <PRE>%c.cancel()</PRE> | | Should cancel all IO operation on the connection (like `async_wait_write`, `async_wait_read`). Should not throw an exception. |
+* | <PRE>ozo::get_connection(c, t, Handler)</PRE> | | Should reset the additional error context. This behaviour is performed in default implementation of `ozo::get_connection()` via `%c.set_error_context()` call. |
+* | <PRE>ozo::is_connection<C></PRE> | `std::true_type` | The template `ozo::is_connection` should be specialized for the connection type via inheritance from `std::true_type`. |
 *
-* @code
-decltype(auto) handle = get_connection_handle(unwrap_connection(conn));
-* @endcode
-* Must return reference or proxy for native_conn_handle object.
+* Where:
+* * `Handler` is callable with `template <typename Connection> void(ozo::error_code, Connection&&)` signature,
+* * `WaitHandler` is callable with `void(ozo::error_code, int = 0)` signature,
+* * `t` is a `TimeConstraint` model object,
+* * `as_const()` is `std::as_const()`,
+* * `move()` is `std::move()`.
 *
-*
-* @code
-decltype(auto) error_ctx = get_connection_error_context(unwrap_connection(conn));
-* @endcode
-* Must return reference or proxy for an additional error context.
-*
-*
-* @code
-decltype(auto) ex = get_connection_executor(unwrap_connection(conn));
-* @endcode
-* Should return IO operations executor associated with connection.
-* @sa ozo::unwrap_connection(),
-ozo::get_connection_oid_map(),
-ozo::get_connection_socket(),
-ozo::get_connection_handle(),
-ozo::get_connection_error_context(),
-ozo::get_connection_executor()
+* @sa ozo::connection, ozo::get_connection(), ozo::is_connection
 * @hideinitializer
 */
 template <typename T>

--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -412,20 +412,6 @@ inline auto get_native_handle(const Connection& conn) noexcept {
 }
 
 /**
- * @brief Socket stream object of the connection
- *
- * See underlying `ozo::get_connection_socket` for details.
- *
- * @param conn --- #Connection object
- * @return socket stream object of the connection
- */
-template <typename T>
-inline decltype(auto) get_socket(T&& conn) noexcept {
-    static_assert(Connection<T>, "T must be a Connection");
-    return get_connection_socket(unwrap_connection(std::forward<T>(conn)));
-}
-
-/**
  * @brief Executor for connection related asynchronous operations
  *
  * This executor must be used to schedule all the asynchronous operations

--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -300,6 +300,26 @@ public:
      */
     void cancel() noexcept;
 
+    /**
+     * Determine whether the connection is in bad state.
+     *
+     * @return false --- connection established, and it is ok to execute operations
+     * @return true  --- connection is not established, no operation shall be performed,
+     *                   but an error context may be obtained via `get_error_context()`
+     *                   and `ozo::error_message()`.
+     */
+    bool is_bad() const noexcept;
+
+    /**
+     * Determine whether the connection is not in bad state.
+     *
+     * @return true  --- connection established, and it is ok to execute operations
+     * @return false --- connection is not established, no operation shall be performed,
+     *                   but an error context may be obtained via `get_error_context()`
+     *                   and `ozo::error_message()`.
+     */
+    operator bool () const noexcept { return !is_bad();}
+
 private:
     using stream_type = asio::posix::stream_descriptor;
 
@@ -361,6 +381,8 @@ struct is_connection<connection<Ts...>> : std::true_type {};
 * | <PRE>c.async_wait_read(WaitHandler)</PRE> | | Should asynchronously wait for read ready state of the connection socket. |
 * | <PRE>c.close()</PRE> | `error_code` | Should close connection socket and cancel all IO operation on the connection (like `async_wait_write`, `async_wait_read`). Shall not throw an exception. |
 * | <PRE>%c.cancel()</PRE> | | Should cancel all IO operation on the connection (like `async_wait_write`, `async_wait_read`). Should not throw an exception. |
+* | <PRE>%c.is_bad()</PRE> | bool | Should return `false` for the established connection that can perform operations. Shall not throw an exception. |
+* | <PRE>%bool(as_const(c))</PRE> | bool | Should return `true` for the established connection that can perform operations. In fact it should be the negation of `c.is_bad()`. Shall not throw an exception. |
 * | <PRE>ozo::get_connection(c, t, Handler)</PRE> | | Should reset the additional error context. This behaviour is performed in default implementation of `ozo::get_connection()` via `%c.set_error_context()` call. |
 * | <PRE>ozo::is_connection<C></PRE> | `std::true_type` | The template `ozo::is_connection` should be specialized for the connection type via inheritance from `std::true_type`. |
 *

--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -404,10 +404,7 @@ inline auto get_native_handle(const Connection& conn) noexcept;
  * @return `executor` of socket stream object of the connection
  */
 template <typename T>
-inline auto get_executor(T& conn) noexcept {
-    static_assert(Connection<T>, "T must be a Connection");
-    return get_connection_executor(unwrap_connection(conn));
-}
+inline auto get_executor(T& conn) noexcept;
 
 /**
  * @brief Binds executor for the connection
@@ -508,10 +505,7 @@ inline void reset_error_context(T& conn);
  * @return OID map of the Connection
  */
 template <typename T>
-inline decltype(auto) get_oid_map(T&& conn) noexcept {
-    static_assert(Connection<T>, "T must be a Connection");
-    return get_connection_oid_map(unwrap_connection(std::forward<T>(conn)));
-}
+inline decltype(auto) get_oid_map(T&& conn) noexcept;
 
 /**
  * @brief Access to a Connection statistics
@@ -525,10 +519,7 @@ inline decltype(auto) get_oid_map(T&& conn) noexcept {
  * @return statistics of the Connection
  */
 template <typename T>
-inline decltype(auto) get_statistics(T&& conn) noexcept {
-    static_assert(Connection<T>, "T must be a Connection");
-    return get_connection_statistics(unwrap_connection(std::forward<T>(conn)));
-}
+inline decltype(auto) get_statistics(T&& conn) noexcept;
 
 /**
  * @brief Get the database name of the active connection

--- a/include/ozo/connection_info.h
+++ b/include/ozo/connection_info.h
@@ -26,7 +26,7 @@ class connection_info {
     Statistics statistics;
 
 public:
-    using connection = impl::connection_impl<OidMap, Statistics>;
+    using connection = ozo::connection<OidMap, Statistics>;
 
      /**
      * @brief Type of connection depends on built-in implementation

--- a/include/ozo/core/nullable.h
+++ b/include/ozo/core/nullable.h
@@ -117,8 +117,8 @@ inline void allocate_nullable(T& out, const Alloc& a) {
 template <typename T, typename Alloc = std::allocator<char>>
 inline void init_nullable(T& n, const Alloc& a = Alloc{}) {
     static_assert(Nullable<T>, "T must be nullable");
-    if (is_null(n)) {
-        allocate_nullable(n, a);
+    if (ozo::is_null(n)) {
+        ozo::allocate_nullable(n, a);
     }
 }
 

--- a/include/ozo/core/recursive.h
+++ b/include/ozo/core/recursive.h
@@ -41,7 +41,7 @@ template <typename T>
 struct unwrap_recursive_impl<T, hana::when<!std::is_same_v<T, unwrap_type<T>>>> {
     template <typename TT>
     static constexpr decltype(auto) apply(TT&& v) noexcept {
-        return unwrap_recursive(unwrap(v));
+        return ozo::unwrap_recursive(ozo::unwrap(v));
     }
 };
 
@@ -83,7 +83,7 @@ template <typename T>
 struct is_null_recursive_impl<T, hana::when<!std::is_same_v<T, unwrap_type<T>>>> {
     template <typename TT>
     static constexpr bool apply(TT&& v) noexcept {
-        return is_null(v) ? true : is_null_recursive(unwrap(v));
+        return ozo::is_null(v) ? true : ozo::is_null_recursive(ozo::unwrap(v));
     }
 };
 

--- a/include/ozo/detail/timeout_handler.h
+++ b/include/ozo/detail/timeout_handler.h
@@ -6,11 +6,11 @@
 namespace ozo::detail {
 
 template <typename Connection, typename Allocator>
-struct cancel_socket {
+struct cancel_io {
     Connection conn_;
     Allocator allocator_;
 
-    cancel_socket(Connection&& conn, const Allocator& allocator)
+    cancel_io(Connection&& conn, const Allocator& allocator)
     : conn_(std::forward<Connection>(conn)), allocator_(allocator) {}
 
     void operator() (error_code) const {
@@ -23,6 +23,6 @@ struct cancel_socket {
 };
 
 template <typename Connection, typename Allocator>
-cancel_socket(Connection&& conn, const Allocator& allocator) -> cancel_socket<Connection, Allocator>;
+cancel_io(Connection&& conn, const Allocator& allocator) -> cancel_io<Connection, Allocator>;
 
 } // namespace ozo::detail

--- a/include/ozo/detail/timeout_handler.h
+++ b/include/ozo/detail/timeout_handler.h
@@ -5,21 +5,24 @@
 
 namespace ozo::detail {
 
-template <typename Socket, typename Allocator>
+template <typename Connection, typename Allocator>
 struct cancel_socket {
-    Socket& socket_;
+    Connection conn_;
     Allocator allocator_;
 
-    cancel_socket(Socket& socket, const Allocator& allocator)
-    : socket_(socket), allocator_(allocator) {}
+    cancel_socket(Connection&& conn, const Allocator& allocator)
+    : conn_(std::forward<Connection>(conn)), allocator_(allocator) {}
 
-    void operator() (error_code ec) const {
-        socket_.cancel(ec);
+    void operator() (error_code) const {
+        conn_.cancel();
     }
 
     using allocator_type = Allocator;
 
     allocator_type get_allocator() const noexcept { return allocator_;}
 };
+
+template <typename Connection, typename Allocator>
+cancel_socket(Connection&& conn, const Allocator& allocator) -> cancel_socket<Connection, Allocator>;
 
 } // namespace ozo::detail

--- a/include/ozo/ext/boost/weak_ptr.h
+++ b/include/ozo/ext/boost/weak_ptr.h
@@ -35,8 +35,8 @@ struct unwrap_impl<boost::weak_ptr<T>> {
 template <typename T>
 struct is_null_impl<boost::weak_ptr<T>> {
     constexpr static auto apply(const boost::weak_ptr<T>& v) noexcept(
-            noexcept(is_null(v.lock()))) {
-        return is_null(v.lock());
+            noexcept(ozo::is_null(v.lock()))) {
+        return ozo::is_null(v.lock());
     }
 };
 ///@}

--- a/include/ozo/ext/std/weak_ptr.h
+++ b/include/ozo/ext/std/weak_ptr.h
@@ -35,8 +35,8 @@ struct unwrap_impl<std::weak_ptr<T>> {
 template <typename T>
 struct is_null_impl<std::weak_ptr<T>> {
     constexpr static auto apply(const std::weak_ptr<T>& v) noexcept(
-            noexcept(is_null(v.lock()))) {
-        return is_null(v.lock());
+            noexcept(ozo::is_null(v.lock()))) {
+        return ozo::is_null(v.lock());
     }
 };
 ///@}

--- a/include/ozo/failover/retry.h
+++ b/include/ozo/failover/retry.h
@@ -92,8 +92,8 @@ public:
      */
     auto get_context() const {
         return hana::concat(
-            hana::make_tuple(unwrap(ctx_).provider, time_constraint()),
-            unwrap(ctx_).args
+            hana::make_tuple(ozo::unwrap(ctx_).provider, time_constraint()),
+            ozo::unwrap(ctx_).args
         );
     }
 
@@ -141,7 +141,7 @@ public:
     }
 
     auto time_constraint() const {
-        return detail::get_try_time_constraint(unwrap(ctx_).time_constraint, tries_remain());
+        return detail::get_try_time_constraint(ozo::unwrap(ctx_).time_constraint, tries_remain());
     }
 
 private:

--- a/include/ozo/failover/role_based.h
+++ b/include/ozo/failover/role_based.h
@@ -270,7 +270,7 @@ public:
     constexpr decltype(auto) rebind_role(OtherRole r) const & {
         static_assert(is_supported(r), "role is not supported by a connection provider");
         using rebind_type = role_based_connection_provider<decltype(source_.rebind_role(r))>;
-        return rebind_type{unwrap(source_).rebind_role(r), io_};
+        return rebind_type{ozo::unwrap(source_).rebind_role(r), io_};
     }
 
     /**
@@ -283,7 +283,7 @@ public:
     constexpr decltype(auto) rebind_role(OtherRole r) & {
         static_assert(is_supported(r), "role is not supported by a connection provider");
         using rebind_type = role_based_connection_provider<decltype(source_.rebind_role(r))>;
-        return rebind_type{unwrap(source_).rebind_role(r), io_};
+        return rebind_type{ozo::unwrap(source_).rebind_role(r), io_};
     }
 
     /**
@@ -296,25 +296,25 @@ public:
     constexpr decltype(auto) rebind_role(OtherRole r) && {
         static_assert(is_supported(r), "role is not supported by a connection provider");
         using rebind_type = role_based_connection_provider<decltype(std::move(source_).rebind_role(r))>;
-        return rebind_type{unwrap(std::forward<Source>(source_)).rebind_role(r), io_};
+        return rebind_type{ozo::unwrap(std::forward<Source>(source_)).rebind_role(r), io_};
     }
 
     template <typename TimeConstraint, typename Handler>
     void async_get_connection(TimeConstraint t, Handler&& h) const & {
         static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
-        unwrap(source_)(io_, std::move(t), std::forward<Handler>(h));
+        ozo::unwrap(source_)(io_, std::move(t), std::forward<Handler>(h));
     }
 
     template <typename TimeConstraint, typename Handler>
     void async_get_connection(TimeConstraint t, Handler&& h) & {
         static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
-        unwrap(source_)(io_, std::move(t), std::forward<Handler>(h));
+        ozo::unwrap(source_)(io_, std::move(t), std::forward<Handler>(h));
     }
 
     template <typename TimeConstraint, typename Handler>
     void async_get_connection(TimeConstraint t, Handler&& h) && {
         static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
-        unwrap(std::forward<Source>(source_))(io_, std::move(t), std::forward<Handler>(h));
+        ozo::unwrap(std::forward<Source>(source_))(io_, std::move(t), std::forward<Handler>(h));
     }
 };
 
@@ -474,8 +474,8 @@ public:
      */
     auto get_context() const {
         return hana::concat(
-            hana::make_tuple(unwrap(ctx_).provider.rebind_role(role()), time_constraint()),
-            unwrap(ctx_).args
+            hana::make_tuple(ozo::unwrap(ctx_).provider.rebind_role(role()), time_constraint()),
+            ozo::unwrap(ctx_).args
         );
     }
 
@@ -485,7 +485,7 @@ public:
      * @return time constraint type value calculated for the try
      */
     auto time_constraint() const {
-        return detail::get_try_time_constraint(unwrap(ctx_).time_constraint, tries_left().value);
+        return detail::get_try_time_constraint(ozo::unwrap(ctx_).time_constraint, tries_left().value);
     }
 
     /**

--- a/include/ozo/failover/strategy.h
+++ b/include/ozo/failover/strategy.h
@@ -250,7 +250,7 @@ struct get_try_context_impl<my_strategy_try> {
  */
 template <typename FailoverTry>
 inline auto get_try_context(const FailoverTry& a_try) {
-    auto res = detail::apply<get_try_context_impl>(unwrap(a_try));
+    auto res = detail::apply<get_try_context_impl>(ozo::unwrap(a_try));
     static_assert(HanaSequence<decltype(res)>,
         "get_try_context_impl::apply() should provide HanaSequence");
     return res;
@@ -304,14 +304,14 @@ struct get_next_try_impl<my_strategy_try> {
  */
 template <typename Try, typename Connection>
 inline auto get_next_try(Try& a_try, const error_code& ec, Connection& conn) {
-    return detail::apply<get_next_try_impl>(unwrap(a_try), ec, conn);
+    return detail::apply<get_next_try_impl>(ozo::unwrap(a_try), ec, conn);
 }
 
 template <typename Try>
 struct initiate_next_try_impl {
     template <typename Connection, typename Initiator>
     static auto apply(Try& a_try, const error_code& ec, Connection& conn, Initiator init) {
-        if (auto next = get_next_try(a_try, ec, conn); !is_null(next)) {
+        if (auto next = get_next_try(a_try, ec, conn); !ozo::is_null(next)) {
             init(std::move(next));
         }
     }
@@ -359,7 +359,7 @@ struct initiate_next_try_impl {
  */
 template <typename Try, typename Connection, typename Initiator>
 inline auto initiate_next_try(Try& a_try, const error_code& ec, Connection& conn, Initiator&& init) {
-    return detail::apply<initiate_next_try_impl>(unwrap(a_try), ec, conn, std::forward<Initiator>(init));
+    return detail::apply<initiate_next_try_impl>(ozo::unwrap(a_try), ec, conn, std::forward<Initiator>(init));
 }
 
 namespace detail {

--- a/include/ozo/impl/async_connect.h
+++ b/include/ozo/impl/async_connect.h
@@ -64,6 +64,7 @@ struct async_connect_op {
             return done(error::pq_connection_start_failed);
         }
 
+        using detail::connection_status_bad;
         if (connection_status_bad(handle.get())) {
             return done(error::pq_connection_status_bad);
         }

--- a/include/ozo/impl/async_connect.h
+++ b/include/ozo/impl/async_connect.h
@@ -179,7 +179,7 @@ inline auto apply_time_constaint(const TimeConstraint& t, [[maybe_unused]] Conne
     if constexpr (IsNone<TimeConstraint>) {
         return detail::wrap_executor {get_executor(conn), std::forward<Handler>(handler)};
     } else {
-        auto on_deadline = detail::cancel_socket(unwrap_connection(conn), asio::get_associated_allocator(handler));
+        auto on_deadline = detail::cancel_io(unwrap_connection(conn), asio::get_associated_allocator(handler));
         return detail::deadline_handler {
             ozo::get_executor(conn), t, std::forward<Handler>(handler), std::move(on_deadline)
         };

--- a/include/ozo/impl/async_connect.h
+++ b/include/ozo/impl/async_connect.h
@@ -179,7 +179,7 @@ inline auto apply_time_constaint(const TimeConstraint& t, [[maybe_unused]] Conne
     if constexpr (IsNone<TimeConstraint>) {
         return detail::wrap_executor {get_executor(conn), std::forward<Handler>(handler)};
     } else {
-        auto on_deadline = detail::cancel_socket(get_socket(conn), asio::get_associated_allocator(handler));
+        auto on_deadline = detail::cancel_socket(unwrap_connection(conn), asio::get_associated_allocator(handler));
         return detail::deadline_handler {
             ozo::get_executor(conn), t, std::forward<Handler>(handler), std::move(on_deadline)
         };

--- a/include/ozo/impl/async_request.h
+++ b/include/ozo/impl/async_request.h
@@ -42,7 +42,7 @@ using request_operation_context_ptr = std::shared_ptr<request_operation_context<
 
 template <typename ...Ts>
 inline auto& get_connection(const request_operation_context_ptr<Ts...>& ctx) noexcept {
-    return ctx->conn;
+    return unwrap_connection(ctx->conn);
 }
 
 template <typename ...Ts>
@@ -75,7 +75,7 @@ auto& get_handler(const request_operation_context_ptr<Ts ...>& context) noexcept
 template <typename ...Ts>
 inline void done(const request_operation_context_ptr<Ts...>& ctx, error_code ec) {
     set_query_state(ctx, query_state::error);
-    decltype(auto) conn = get_connection(ctx);
+    decltype(auto) conn = ctx->conn;
     error_code _;
     get_socket(conn).cancel(_);
     std::move(get_handler(ctx))(std::move(ec), conn);
@@ -83,17 +83,7 @@ inline void done(const request_operation_context_ptr<Ts...>& ctx, error_code ec)
 
 template <typename ...Ts>
 inline void done(const request_operation_context_ptr<Ts...>& ctx) {
-    std::move(get_handler(ctx))(error_code {}, get_connection(ctx));
-}
-
-template <typename Continuation, typename ...Ts>
-inline void write_poll(const request_operation_context_ptr<Ts...>& ctx, Continuation&& c) {
-    write_poll(get_connection(ctx), std::forward<Continuation>(c));
-}
-
-template <typename Continuation, typename ...Ts>
-inline void read_poll(const request_operation_context_ptr<Ts...>& ctx, Continuation&& c) {
-    read_poll(get_connection(ctx), std::forward<Continuation>(c));
+    std::move(get_handler(ctx))(error_code {}, ctx->conn);
 }
 
 template <typename Context, typename BinaryQuery>
@@ -138,7 +128,7 @@ struct async_send_query_params_op {
                 done(ctx_, error::pg_flush_failed);
                 break;
             case query_state::send_in_progress:
-                write_poll(ctx_, *this);
+                get_connection(ctx_).async_wait_write(std::move(*this));
                 break;
             case query_state::send_finish:
                 set_query_state(ctx_, query_state::send_finish);
@@ -227,7 +217,7 @@ struct async_get_result_op : boost::asio::coroutine {
 
         reenter(*this) {
             while (is_busy(get_connection(ctx_))) {
-                yield read_poll(ctx_, *this);
+                yield get_connection(ctx_).async_wait_read(std::move(*this));
                 if (auto err = consume_input(get_connection(ctx_))) {
                     return done(err);
                 }
@@ -242,7 +232,7 @@ struct async_get_result_op : boost::asio::coroutine {
             if (result_status(*get_request_result(ctx_)) != PGRES_SINGLE_TUPLE) {
                 do {
                     while (is_busy(get_connection(ctx_))) {
-                        yield read_poll(ctx_, *this);
+                        yield get_connection(ctx_).async_wait_read(std::move(*this));
                         if (consume_input(get_connection(ctx_))) {
                             return handle_result();
                         }

--- a/include/ozo/impl/async_request.h
+++ b/include/ozo/impl/async_request.h
@@ -326,7 +326,7 @@ struct async_request_op {
         } else {
             return detail::deadline_handler {
                 ozo::get_executor(conn), time_constraint_, std::move(handler),
-                detail::cancel_socket(unwrap_connection(conn), get_allocator())
+                detail::cancel_io(unwrap_connection(conn), get_allocator())
             };
         }
     }

--- a/include/ozo/impl/connection.h
+++ b/include/ozo/impl/connection.h
@@ -159,10 +159,7 @@ inline error_code bind_executor(Connection& conn, const Executor& ex) {
 template <typename Connection>
 inline error_code close_connection(Connection&& conn) {
     static_assert(ozo::Connection<Connection>, "conn should model Connection");
-    error_code ec;
-    get_socket(conn).close(ec);
-    get_handle(conn).reset();
-    return ec;
+    return unwrap_connection(conn).close();
 }
 
 template <typename T>

--- a/include/ozo/impl/connection.h
+++ b/include/ozo/impl/connection.h
@@ -53,7 +53,7 @@ struct connection_impl {
     const oid_map_type& oid_map() const noexcept { return oid_map_;}
 
     const error_context& get_error_context() const noexcept { return error_context_; }
-    void set_error_context(error_context v) { error_context_ = std::move(v); }
+    void set_error_context(error_context v = error_context{}) { error_context_ = std::move(v); }
 
     executor_type get_executor() const noexcept { return io_->get_executor(); }
 
@@ -159,6 +159,24 @@ template <typename Connection>
 inline auto get_native_handle(const Connection& conn) noexcept {
     static_assert(ozo::Connection<Connection>, "conn should model Connection");
     return unwrap_connection(conn).native_handle();
+}
+
+template <typename Connection>
+inline const auto& get_error_context(const Connection& conn) {
+    static_assert(ozo::Connection<Connection>, "conn should model Connection");
+    return unwrap_connection(conn).get_error_context();
+}
+
+template <typename Connection, typename Ctx>
+inline void set_error_context(Connection& conn, Ctx&& ctx) {
+    static_assert(ozo::Connection<Connection>, "conn should model Connection");
+    unwrap_connection(conn).set_error_context(std::forward<Ctx>(ctx));
+}
+
+template <typename Connection>
+inline void reset_error_context(Connection& conn) {
+    static_assert(ozo::Connection<Connection>, "conn should model Connection");
+    unwrap_connection(conn).set_error_context();
 }
 
 template <typename Connection>

--- a/include/ozo/impl/connection.h
+++ b/include/ozo/impl/connection.h
@@ -106,6 +106,11 @@ void connection<OidMap, Statistics>::cancel() noexcept {
     socket_.cancel(_);
 }
 
+template <typename OidMap, typename Statistics>
+bool connection<OidMap, Statistics>::is_bad() const noexcept {
+    return detail::connection_status_bad(native_handle());
+}
+
 template <typename Connection>
 inline std::string_view error_message(const Connection& conn) {
     static_assert(ozo::Connection<Connection>, "conn should model Connection");
@@ -124,8 +129,7 @@ inline error_code close_connection(Connection&& conn) {
 template <typename Connection>
 inline bool connection_bad(const Connection& conn) noexcept {
     static_assert(ozo::Connection<Connection>, "conn should model Connection");
-    using detail::connection_status_bad;
-    return is_null_recursive(conn) ? true : connection_status_bad(get_native_handle(conn));
+    return is_null_recursive(conn) ? true : unwrap_connection(conn).is_bad();
 }
 
 template <typename Connection>

--- a/include/ozo/impl/connection.h
+++ b/include/ozo/impl/connection.h
@@ -4,14 +4,13 @@
 #include <ozo/native_conn_handle.h>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/asio/steady_timer.hpp>
-#include <boost/asio/posix/stream_descriptor.hpp>
 
 #include <string>
 #include <sstream>
 
 namespace ozo {
 
-namespace impl {
+namespace detail {
 
 template <typename Connection, typename Executor>
 inline error_code bind_connection_executor(Connection& conn, const Executor& ex) {
@@ -29,86 +28,6 @@ inline error_code bind_connection_executor(Connection& conn, const Executor& ex)
     return {};
 }
 
-template <typename OidMap, typename Statistics>
-struct connection_impl {
-    connection_impl(io_context& io, Statistics statistics)
-        : io_(std::addressof(io)), socket_(*io_), statistics_(std::move(statistics)) {}
-
-    using stream_type = asio::posix::stream_descriptor;
-    using native_handle_type = native_conn_handle::pointer;
-    using oid_map_type = OidMap;
-    using error_context = std::string;
-    using executor_type = io_context::executor_type;
-
-    native_conn_handle handle_;
-    io_context* io_;
-    stream_type socket_;
-    oid_map_type oid_map_;
-    Statistics statistics_; // statistics metatypes to be defined - counter, duration, whatever?
-    error_context error_context_;
-
-    native_handle_type native_handle() const noexcept { return handle_.get(); }
-
-    oid_map_type& oid_map() noexcept { return oid_map_;}
-    const oid_map_type& oid_map() const noexcept { return oid_map_;}
-
-    const error_context& get_error_context() const noexcept { return error_context_; }
-    void set_error_context(error_context v = error_context{}) { error_context_ = std::move(v); }
-
-    executor_type get_executor() const noexcept { return io_->get_executor(); }
-
-    template <typename Executor>
-    error_code bind_executor(const Executor& ex) {
-        return ozo::impl::bind_connection_executor(*this, ex);
-    }
-
-    error_code assign(native_conn_handle&& handle) {
-        int fd = PQsocket(handle.get());
-        if (fd == -1) {
-            return error::pq_socket_failed;
-        }
-
-        int new_fd = dup(fd);
-        if (new_fd == -1) {
-            set_error_context("error while dup(fd) for socket stream");
-            return error_code{errno, boost::system::generic_category()};
-        }
-
-        error_code ec;
-        socket_.assign(new_fd, ec);
-
-        if (ec) {
-            set_error_context("assign socket failed");
-            return ec;
-        }
-
-        handle_ = std::move(handle);
-        return ec;
-    }
-
-    template <typename WaitHandler>
-    void async_wait_write(WaitHandler&& h) {
-        socket_.async_write_some(asio::null_buffers(), std::forward<WaitHandler>(h));
-    }
-
-    template <typename WaitHandler>
-    void async_wait_read(WaitHandler&& h) {
-        socket_.async_read_some(asio::null_buffers(), std::forward<WaitHandler>(h));
-    }
-
-    error_code close() noexcept {
-        error_code ec;
-        socket_.close(ec);
-        handle_.reset();
-        return ec;
-    }
-
-    void cancel() noexcept {
-        error_code _;
-        socket_.cancel(_);
-    }
-};
-
 inline bool connection_status_bad(PGconn* handle) noexcept {
     return !handle || PQstatus(handle) == CONNECTION_BAD;
 }
@@ -125,21 +44,75 @@ inline auto connection_error_message(NativeHandleType handle) {
     return v;
 }
 
-} // namespace impl
+} // namespace detail
 
-template <typename T>
-inline std::string_view error_message(T&& conn) {
-    static_assert(Connection<T>, "T must be a Connection");
+template <typename OidMap, typename Statistics>
+connection<OidMap, Statistics>::connection(io_context& io, Statistics statistics)
+: io_(std::addressof(io)), socket_(*io_), statistics_(std::move(statistics)) {}
+
+template <typename OidMap, typename Statistics>
+error_code connection<OidMap, Statistics>::set_executor(const executor_type& ex) {
+    return ozo::detail::bind_connection_executor(*this, ex);
+}
+
+template <typename OidMap, typename Statistics>
+error_code connection<OidMap, Statistics>::assign(native_conn_handle&& handle) {
+    int fd = PQsocket(handle.get());
+    if (fd == -1) {
+        return error::pq_socket_failed;
+    }
+
+    int new_fd = dup(fd);
+    if (new_fd == -1) {
+        set_error_context("error while dup(fd) for socket stream");
+        return error_code{errno, boost::system::generic_category()};
+    }
+
+    error_code ec;
+    socket_.assign(new_fd, ec);
+
+    if (ec) {
+        set_error_context("assign socket failed");
+        return ec;
+    }
+
+    handle_ = std::move(handle);
+    return ec;
+}
+
+template <typename OidMap, typename Statistics>
+template <typename WaitHandler>
+void connection<OidMap, Statistics>::async_wait_write(WaitHandler&& h) {
+    socket_.async_write_some(asio::null_buffers(), std::forward<WaitHandler>(h));
+}
+
+template <typename OidMap, typename Statistics>
+template <typename WaitHandler>
+void connection<OidMap, Statistics>::async_wait_read(WaitHandler&& h) {
+    socket_.async_read_some(asio::null_buffers(), std::forward<WaitHandler>(h));
+}
+
+template <typename OidMap, typename Statistics>
+error_code connection<OidMap, Statistics>::close() noexcept {
+    error_code ec;
+    socket_.close(ec);
+    handle_.reset();
+    return ec;
+}
+
+template <typename OidMap, typename Statistics>
+void connection<OidMap, Statistics>::cancel() noexcept {
+    error_code _;
+    socket_.cancel(_);
+}
+
+template <typename Connection>
+inline std::string_view error_message(const Connection& conn) {
+    static_assert(ozo::Connection<Connection>, "conn should model Connection");
     if (is_null_recursive(conn)) {
         return {};
     }
-    return impl::connection_error_message(get_native_handle(conn));
-}
-
-template <typename Connection, typename Executor>
-inline error_code bind_executor(Connection& conn, const Executor& ex) {
-    static_assert(ozo::Connection<Connection>, "conn should model Connection");
-    return unwrap_connection(conn).bind_executor(ex);
+    return detail::connection_error_message(get_native_handle(conn));
 }
 
 template <typename Connection>
@@ -148,10 +121,10 @@ inline error_code close_connection(Connection&& conn) {
     return unwrap_connection(conn).close();
 }
 
-template <typename T>
-inline bool connection_bad(const T& conn) noexcept {
-    static_assert(Connection<T>, "T must be a Connection");
-    using impl::connection_status_bad;
+template <typename Connection>
+inline bool connection_bad(const Connection& conn) noexcept {
+    static_assert(ozo::Connection<Connection>, "conn should model Connection");
+    using detail::connection_status_bad;
     return is_null_recursive(conn) ? true : connection_status_bad(get_native_handle(conn));
 }
 

--- a/include/ozo/impl/connection.h
+++ b/include/ozo/impl/connection.h
@@ -156,6 +156,12 @@ inline bool connection_bad(const T& conn) noexcept {
 }
 
 template <typename Connection>
+inline auto get_native_handle(const Connection& conn) noexcept {
+    static_assert(ozo::Connection<Connection>, "conn should model Connection");
+    return unwrap_connection(conn).native_handle();
+}
+
+template <typename Connection>
 inline std::string_view get_database(const Connection& conn) {
     static_assert(ozo::Connection<Connection>, "conn should model Connection");
     return PQdb(get_native_handle(conn));

--- a/include/ozo/impl/connection.h
+++ b/include/ozo/impl/connection.h
@@ -180,6 +180,24 @@ inline void reset_error_context(Connection& conn) {
 }
 
 template <typename Connection>
+inline decltype(auto) get_oid_map(Connection&& conn) noexcept {
+    static_assert(ozo::Connection<Connection>, "conn should model Connection");
+    return unwrap_connection(std::forward<Connection>(conn)).oid_map();
+}
+
+template <typename Connection>
+inline decltype(auto) get_statistics(Connection&& conn) noexcept {
+    static_assert(ozo::Connection<Connection>, "conn should model Connection");
+    return unwrap_connection(std::forward<Connection>(conn)).statistics();
+}
+
+template <typename Connection>
+inline auto get_executor(const Connection& conn) noexcept {
+    static_assert(ozo::Connection<Connection>, "conn should model Connection");
+    return unwrap_connection(conn).get_executor();
+}
+
+template <typename Connection>
 inline std::string_view get_database(const Connection& conn) {
     static_assert(ozo::Connection<Connection>, "conn should model Connection");
     return PQdb(get_native_handle(conn));

--- a/include/ozo/impl/connection_pool.h
+++ b/include/ozo/impl/connection_pool.h
@@ -112,7 +112,7 @@ struct pooled_connection_wrapper {
 
         auto conn = std::allocate_shared<connection>(get_allocator(), std::forward<Handle>(handle));
         if (connection_good(conn)) {
-            ec = bind_executor(conn, io_.get_executor());
+            ec = unwrap_connection(conn).set_executor(io_.get_executor());
             return handler_(std::move(ec), std::move(conn));
         }
 
@@ -141,10 +141,10 @@ auto wrap_pooled_connection_handler(IoContext& io, Source&& source, TimeConstrai
     };
 }
 
-static_assert(Connection<pooled_connection_ptr<connection_impl<empty_oid_map, no_statistics>>>,
+static_assert(Connection<pooled_connection_ptr<connection<empty_oid_map, no_statistics>>>,
     "pooled_connection_ptr is not a Connection concept");
 
-static_assert(ConnectionProvider<pooled_connection_ptr<connection_impl<empty_oid_map, no_statistics>>>,
+static_assert(ConnectionProvider<pooled_connection_ptr<connection<empty_oid_map, no_statistics>>>,
     "pooled_connection_ptr is not a ConnectionProvider concept");
 
 } // namespace ozo::impl

--- a/include/ozo/impl/connection_pool.h
+++ b/include/ozo/impl/connection_pool.h
@@ -48,7 +48,7 @@ template <typename T>
 struct unwrap_impl<impl::pooled_connection<T>> {
     template <typename Conn>
     static constexpr decltype(auto) apply(Conn&& conn) noexcept {
-        return unwrap(*conn.handle_);
+        return ozo::unwrap(*conn.handle_);
     }
 };
 
@@ -58,7 +58,7 @@ struct is_nullable<impl::pooled_connection<T>> : std::true_type {};
 template <typename T>
 struct is_null_impl<impl::pooled_connection<T>> {
     static bool apply(const impl::pooled_connection<T>& conn) {
-        return conn.empty() ? true : is_null(unwrap(conn));
+        return conn.empty() ? true : ozo::is_null(ozo::unwrap(conn));
     }
 };
 } // namespace ozo

--- a/include/ozo/impl/io.h
+++ b/include/ozo/impl/io.h
@@ -150,12 +150,6 @@ inline void read_poll(T& conn, Handler&& h) {
             asio::null_buffers(), std::forward<Handler>(h));
 }
 
-// Shortcut for post operation with connection associated executor
-template <typename T, typename Oper, typename = Require<Connection<T>>>
-inline void post(T& conn, Oper&& op) {
-    asio::post(get_executor(conn), std::forward<Oper>(op));
-}
-
 template <typename T>
 inline decltype(auto) connect_poll(T& conn) {
     static_assert(Connection<T>, "T must be a Connection");

--- a/include/ozo/impl/transaction.h
+++ b/include/ozo/impl/transaction.h
@@ -15,7 +15,7 @@ public:
     transaction() = default;
 
     transaction(T connection, Options options)
-            : impl(is_null(connection) ? nullptr : std::make_shared<impl_type>(std::move(connection))), options_(std::move(options)) {}
+            : impl(ozo::is_null(connection) ? nullptr : std::make_shared<impl_type>(std::move(connection))), options_(std::move(options)) {}
 
     ~transaction() {
         const auto c = std::move(impl);
@@ -69,7 +69,7 @@ template <typename... Ts>
 struct unwrap_impl<impl::transaction<Ts...>> {
     template <typename Transaction>
     static constexpr decltype(auto) apply(Transaction&& self) noexcept {
-        return unwrap(*self.impl->connection);
+        return ozo::unwrap(*self.impl->connection);
     }
 };
 

--- a/include/ozo/impl/transaction_status.h
+++ b/include/ozo/impl/transaction_status.h
@@ -9,7 +9,7 @@ template <typename T>
 inline transaction_status get_transaction_status(T&& conn) {
     static_assert(Connection<T>, "T must be a Connection");
 
-    if (is_null(conn)) {
+    if (ozo::is_null(conn)) {
         return transaction_status::unknown;
     }
 

--- a/include/ozo/io/recv.h
+++ b/include/ozo/io/recv.h
@@ -157,7 +157,7 @@ inline istream& recv(istream& in, [[maybe_unused]] Oid oid, size_type size, cons
             + boost::core::demangle(typeid(out).name()));
     }
 
-    return detail::get_recv_impl<Out>::apply(in, size, oids, unwrap(out));
+    return detail::get_recv_impl<Out>::apply(in, size, oids, ozo::unwrap(out));
 }
 
 template <typename M, typename Oid, typename Out>

--- a/include/ozo/io/send.h
+++ b/include/ozo/io/send.h
@@ -91,7 +91,7 @@ using get_send_impl = typename send_impl_dispatcher<unwrap_type<T>>::type;
  */
 template <class M, class In>
 inline ostream& send(ostream& out, const oid_map_t<M>& oid_map, const In& in) {
-    return is_null(in) ? out : detail::get_send_impl<In>::apply(out, oid_map, unwrap(in));
+    return ozo::is_null(in) ? out : detail::get_send_impl<In>::apply(out, oid_map, ozo::unwrap(in));
 }
 
 /**

--- a/include/ozo/io/size_of.h
+++ b/include/ozo/io/size_of.h
@@ -104,7 +104,7 @@ using get_size_of_impl = typename size_of_impl_dispatcher<unwrap_type<T>>::type;
 template <typename T>
 constexpr size_type size_of(const T& v) {
     static_assert(HasDefinition<T>, "the type has not been defined with PostgreSQL type traits");
-    return is_null(v) ? null_state_size : detail::get_size_of_impl<T>::apply(unwrap(v));
+    return ozo::is_null(v) ? null_state_size : detail::get_size_of_impl<T>::apply(ozo::unwrap(v));
 }
 
 template <typename T, typename>

--- a/include/ozo/native_conn_handle.h
+++ b/include/ozo/native_conn_handle.h
@@ -10,8 +10,9 @@ struct native_conn_handle_deleter {
 };
 
 /**
- * @brief libpq PGconn safe RAII representation.
- * libpq PGconn safe RAII representation.
+ * @ingroup group-connection-types
+ *
+ * RAII safe native connection handler representation.
  */
 using native_conn_handle = std::unique_ptr<::PGconn, native_conn_handle_deleter>;
 

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -85,6 +85,8 @@ struct connection {
     auto native_handle() const noexcept { return handle_.get(); }
     const error_context& get_error_context() const noexcept { return error_context_; }
     void set_error_context(error_context v = error_context{}) { error_context_ = std::move(v); }
+    bool is_bad() const noexcept { return connection_status_bad(native_handle()); }
+    operator bool () const noexcept { return !is_bad();}
 
     explicit connection(io_context& io) : socket_(io), io_(&io) {}
 };

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -73,6 +73,7 @@ template <typename OidMap = empty_oid_map>
 struct connection {
     using handle_type = std::unique_ptr<::native_handle>;
     using stream_type = socket_mock;
+    using error_context = std::string;
 
     handle_type handle_ = std::make_unique<::native_handle>();
     socket_mock socket_;
@@ -82,6 +83,8 @@ struct connection {
 
     auto get_executor() const { return io_->get_executor(); }
     auto native_handle() const noexcept { return handle_.get(); }
+    const error_context& get_error_context() const noexcept { return error_context_; }
+    void set_error_context(error_context v = error_context{}) { error_context_ = std::move(v); }
 
     explicit connection(io_context& io) : socket_(io), io_(&io) {}
 };

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -72,6 +72,7 @@ struct timer_mock {
 template <typename OidMap = empty_oid_map>
 struct connection {
     using handle_type = std::unique_ptr<native_handle>;
+    using stream_type = socket_mock;
 
     handle_type handle_ = std::make_unique<native_handle>();
     socket_mock socket_;

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -227,8 +227,8 @@ TEST(bind_connection_executor, should_change_socket_when_address_of_new_io_is_no
     connection<> conn(old_io);
     io_context new_io;
 
-    EXPECT_CALL(*ozo::get_socket(conn).native_handle(), assign(_)).WillOnce(Return());
-    EXPECT_CALL(*ozo::get_socket(conn).native_handle(), release()).WillOnce(Return());
+    EXPECT_CALL(*conn.socket_.native_handle(), assign(_)).WillOnce(Return());
+    EXPECT_CALL(*conn.socket_.native_handle(), release()).WillOnce(Return());
 
     EXPECT_EQ(ozo::impl::bind_connection_executor(conn, new_io.get_executor()), error_code());
     EXPECT_EQ(ozo::get_executor(conn), new_io.get_executor());
@@ -239,7 +239,7 @@ TEST(bind_connection_executor, should_return_error_when_socket_assign_fails_with
     connection<> conn(old_io);
     io_context new_io;
 
-    EXPECT_CALL(*ozo::get_socket(conn).native_handle(), assign(_))
+    EXPECT_CALL(*conn.socket_.native_handle(), assign(_))
         .WillOnce(SetArgReferee<0>(error_code(error::code::error)));
 
     EXPECT_EQ(ozo::impl::bind_connection_executor(conn, new_io.get_executor()), error_code(error::code::error));

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -71,16 +71,17 @@ struct timer_mock {
 
 template <typename OidMap = empty_oid_map>
 struct connection {
-    using handle_type = std::unique_ptr<native_handle>;
+    using handle_type = std::unique_ptr<::native_handle>;
     using stream_type = socket_mock;
 
-    handle_type handle_ = std::make_unique<native_handle>();
+    handle_type handle_ = std::make_unique<::native_handle>();
     socket_mock socket_;
     OidMap oid_map_;
     std::string error_context_;
     io_context* io_;
 
     auto get_executor() const { return io_->get_executor(); }
+    auto native_handle() const noexcept { return handle_.get(); }
 
     explicit connection(io_context& io) : socket_(io), io_(&io) {}
 };

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -111,6 +111,7 @@ template <typename OidMap = empty_oid_map>
 struct connection {
     using handle_type = std::shared_ptr<ozo::tests::native_handle>;
     using error_context = std::string;
+    using oid_map_type = OidMap;
 
     handle_type handle_;
     stream_descriptor socket_;
@@ -126,6 +127,10 @@ struct connection {
     const error_context& get_error_context() const noexcept { return error_context_; }
 
     void set_error_context(error_context v = error_context{}) { error_context_ = std::move(v); }
+
+    oid_map_type& oid_map() noexcept { return oid_map_;}
+
+    const oid_map_type& oid_map() const noexcept { return oid_map_;}
 
     friend int pq_set_nonblocking(connection& c) {
         return c.mock_->set_nonblocking();

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -63,8 +63,8 @@ struct connection_mock {
     MOCK_METHOD0(get_result, boost::optional<pg_result>());
 
     MOCK_CONST_METHOD0(connect_poll, int());
-    MOCK_METHOD1(start_connection, ozo::error_code(const std::string&));
-    MOCK_METHOD0(assign_socket, ozo::error_code());
+    MOCK_METHOD1(start_connection, std::shared_ptr<native_handle>(const std::string&));
+    MOCK_METHOD0(assign, ozo::error_code());
     MOCK_METHOD0(async_request, void());
     MOCK_METHOD0(async_execute, void());
     MOCK_METHOD0(request_oid_map, void());
@@ -109,7 +109,7 @@ static_assert(Query<fake_query>, "fake_query is not a Query");
 
 template <typename OidMap = empty_oid_map>
 struct connection {
-    using handle_type = std::unique_ptr<native_handle>;
+    using handle_type = std::shared_ptr<ozo::tests::native_handle>;
 
     handle_type handle_;
     stream_descriptor socket_;
@@ -149,13 +149,17 @@ struct connection {
         return c.mock_->connect_poll();
     }
 
-    friend ozo::error_code pq_start_connection(
+    friend handle_type pq_start_connection(
             connection& c, const std::string& conninfo) {
         return c.mock_->start_connection(conninfo);
     }
 
-    friend ozo::error_code pq_assign_socket(connection& c) {
-        return c.mock_->assign_socket();
+    ozo::error_code assign(handle_type&& handle) {
+        ozo::error_code ec = mock_->assign();
+        if (!ec) {
+            handle_ = std::move(handle);
+        }
+        return ec;
     }
 
     friend decltype(auto) get_cancel_handle(connection& c) {

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -162,6 +162,11 @@ struct connection {
         return ec;
     }
 
+    void cancel() {
+        ozo::error_code _;
+        socket_.cancel(_);
+    }
+
     friend decltype(auto) get_cancel_handle(connection& c) {
         return c.mock_->get_cancel_handle();
     }

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -186,8 +186,18 @@ struct connection {
     }
 
     template <typename Executor>
-    friend ozo::error_code bind_connection_executor(connection& c, const Executor&) {
-        return c.mock_->bind_executor();
+    ozo::error_code bind_executor(const Executor&) {
+        return mock_->bind_executor();
+    }
+
+    template <typename WaitHandler>
+    void async_wait_write(WaitHandler&& h) {
+        socket_.async_write_some(asio::null_buffers(), std::forward<WaitHandler>(h));
+    }
+
+    template <typename WaitHandler>
+    void async_wait_read(WaitHandler&& h) {
+        socket_.async_read_some(asio::null_buffers(), std::forward<WaitHandler>(h));
     }
 };
 

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -68,7 +68,7 @@ struct connection_mock {
     MOCK_METHOD0(async_request, void());
     MOCK_METHOD0(async_execute, void());
     MOCK_METHOD0(request_oid_map, void());
-    MOCK_METHOD0(bind_executor, ozo::error_code());
+    MOCK_METHOD0(set_executor, ozo::error_code());
     MOCK_METHOD0(get_cancel_handle, cancel_handle_mock*());
 };
 
@@ -214,8 +214,8 @@ struct connection {
     }
 
     template <typename Executor>
-    ozo::error_code bind_executor(const Executor&) {
-        return mock_->bind_executor();
+    ozo::error_code set_executor(const Executor&) {
+        return mock_->set_executor();
     }
 
     template <typename WaitHandler>
@@ -228,6 +228,17 @@ struct connection {
         socket_.async_read_some(asio::null_buffers(), std::forward<WaitHandler>(h));
     }
 };
+
+} // namespace ozo::tests
+
+namespace ozo {
+
+template <typename OidMap>
+struct is_connection<tests::connection<OidMap>> : std::true_type {};
+
+} // namespace ozo
+
+namespace ozo::tests {
 
 template <typename ...Ts>
 using connection_ptr = std::shared_ptr<connection<Ts...>>;

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -120,6 +120,8 @@ struct connection {
 
     auto get_executor() const { return io_->get_executor(); }
 
+    auto native_handle() const noexcept { return handle_.get(); }
+
     friend int pq_set_nonblocking(connection& c) {
         return c.mock_->set_nonblocking();
     }

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -162,6 +162,13 @@ struct connection {
         return ec;
     }
 
+    ozo::error_code close() {
+        error_code ec;
+        socket_.close(ec);
+        handle_.reset();
+        return ec;
+    }
+
     void cancel() {
         ozo::error_code _;
         socket_.cancel(_);

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -110,17 +110,22 @@ static_assert(Query<fake_query>, "fake_query is not a Query");
 template <typename OidMap = empty_oid_map>
 struct connection {
     using handle_type = std::shared_ptr<ozo::tests::native_handle>;
+    using error_context = std::string;
 
     handle_type handle_;
     stream_descriptor socket_;
     OidMap oid_map_;
     connection_mock* mock_ = nullptr;
-    std::string error_context_;
+    error_context error_context_;
     io_context* io_;
 
     auto get_executor() const { return io_->get_executor(); }
 
     auto native_handle() const noexcept { return handle_.get(); }
+
+    const error_context& get_error_context() const noexcept { return error_context_; }
+
+    void set_error_context(error_context v = error_context{}) { error_context_ = std::move(v); }
 
     friend int pq_set_nonblocking(connection& c) {
         return c.mock_->set_nonblocking();

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -132,6 +132,12 @@ struct connection {
 
     const oid_map_type& oid_map() const noexcept { return oid_map_;}
 
+    bool is_bad() const noexcept {
+        return connection_status_bad(native_handle());
+    }
+
+    operator bool () const noexcept { return !is_bad();}
+
     friend int pq_set_nonblocking(connection& c) {
         return c.mock_->set_nonblocking();
     }

--- a/tests/connection_pool.cpp
+++ b/tests/connection_pool.cpp
@@ -229,7 +229,7 @@ TEST_F(pooled_connection_wrapper, should_invoke_handler_if_passed_connection_is_
 
     EXPECT_CALL(handle_mock, value()).WillRepeatedly(ReturnRef(conn));
     EXPECT_CALL(handle_mock, empty()).WillRepeatedly(Return(false));
-    EXPECT_CALL(connection_mock, bind_executor()).WillRepeatedly(Return(ozo::error_code{}));
+    EXPECT_CALL(connection_mock, set_executor()).WillRepeatedly(Return(ozo::error_code{}));
 
     EXPECT_CALL(callback_mock, call(_, _)).WillOnce(Return());
 

--- a/tests/detail/timeout_handler.cpp
+++ b/tests/detail/timeout_handler.cpp
@@ -12,11 +12,11 @@ struct connection_mock {
     MOCK_METHOD0(cancel, void());
 };
 
-TEST(cancel_socket, should_cancel_socket_io) {
+TEST(cancel_io, should_cancel_socket_io) {
     connection_mock conn;
-    ozo::detail::cancel_socket cancel_socket_handler{conn, std::allocator<char>{}};
+    ozo::detail::cancel_io cancel_io_handler{conn, std::allocator<char>{}};
     EXPECT_CALL(conn, cancel()).WillOnce(Return());
-    cancel_socket_handler(ozo::error_code{});
+    cancel_io_handler(ozo::error_code{});
 }
 
 } // namespace

--- a/tests/detail/timeout_handler.cpp
+++ b/tests/detail/timeout_handler.cpp
@@ -8,10 +8,14 @@ namespace {
 
 using namespace testing;
 
+struct connection_mock {
+    MOCK_METHOD0(cancel, void());
+};
+
 TEST(cancel_socket, should_cancel_socket_io) {
-    ozo::tests::stream_descriptor_gmock socket;
-    ozo::detail::cancel_socket cancel_socket_handler{socket, std::allocator<char>{}};
-    EXPECT_CALL(socket, cancel(_)).WillOnce(Return());
+    connection_mock conn;
+    ozo::detail::cancel_socket cancel_socket_handler{conn, std::allocator<char>{}};
+    EXPECT_CALL(conn, cancel()).WillOnce(Return());
     cancel_socket_handler(ozo::error_code{});
 }
 

--- a/tests/impl/async_get_result.cpp
+++ b/tests/impl/async_get_result.cpp
@@ -51,7 +51,7 @@ struct async_get_result_op_call : async_get_result_op,
 
 TEST_P(async_get_result_op_call, when_query_state_is_error_should_exit_and_preserve_state){
     m.ctx->state = ozo::impl::query_state::error;
-    ozo::impl::async_get_result_op{m.ctx, [](auto, auto){}}(GetParam());
+    ozo::impl::async_get_result_op{m.ctx, ozo::none}(GetParam());
     EXPECT_EQ(m.ctx->state, query_state::error);
 }
 
@@ -73,7 +73,7 @@ TEST_P(async_get_result_op_call_with_error, should_call_callback_with_given_erro
     EXPECT_CALL(m.socket, cancel(_)).WillOnce(Return());
     EXPECT_CALL(m.callback, call(error_code{error::error}, _)).WillOnce(Return());
 
-    ozo::impl::async_get_result_op{m.ctx, [](auto, auto){}}(error::error);
+    ozo::impl::async_get_result_op{m.ctx, ozo::none}(error::error);
 }
 
 TEST_P(async_get_result_op_call_with_error, should_post_callback_with_operation_aborted_if_called_with_bad_descriptor) {
@@ -84,7 +84,7 @@ TEST_P(async_get_result_op_call_with_error, should_post_callback_with_operation_
     EXPECT_CALL(m.socket, cancel(_)).WillOnce(Return());
     EXPECT_CALL(m.callback, call(error_code{boost::asio::error::operation_aborted}, _)).WillOnce(Return());
 
-    ozo::impl::async_get_result_op{m.ctx, [](auto, auto){}}(boost::asio::error::bad_descriptor);
+    ozo::impl::async_get_result_op{m.ctx, ozo::none}(boost::asio::error::bad_descriptor);
 }
 
 TEST_P(async_get_result_op_call_with_error, should_set_query_state_in_error) {
@@ -95,7 +95,7 @@ TEST_P(async_get_result_op_call_with_error, should_set_query_state_in_error) {
     EXPECT_CALL(m.socket, cancel(_)).WillOnce(Return());
     EXPECT_CALL(m.callback, call(error_code{error::error}, _)).WillOnce(Return());
 
-    ozo::impl::async_get_result_op{m.ctx, [](auto, auto){}}(error::error);
+    ozo::impl::async_get_result_op{m.ctx, ozo::none}(error::error);
 
     EXPECT_EQ(m.ctx->state, query_state::error);
 }
@@ -108,7 +108,7 @@ TEST_P(async_get_result_op_call_with_error, should_replace_empty_connection_erro
     EXPECT_CALL(m.socket, cancel(_)).WillOnce(Return());
     EXPECT_CALL(m.callback, call(error_code{error::error}, _)).WillOnce(Return());
 
-    ozo::impl::async_get_result_op{m.ctx, [](auto, auto){}}(error::error);
+    ozo::impl::async_get_result_op{m.ctx, ozo::none}(error::error);
 
     EXPECT_EQ(m.conn->error_context_, "error while get request result");
 }
@@ -122,7 +122,7 @@ TEST_P(async_get_result_op_call_with_error, should_preserve_not_empty_connection
     EXPECT_CALL(m.socket, cancel(_)).WillOnce(Return());
     EXPECT_CALL(m.callback, call(error_code{error::error}, _)).WillOnce(Return());
 
-    ozo::impl::async_get_result_op{m.ctx, [](auto, auto){}}(error::error);
+    ozo::impl::async_get_result_op{m.ctx, ozo::none}(error::error);
 
     EXPECT_EQ(m.conn->error_context_, "my error");
 }

--- a/tests/impl/async_request.cpp
+++ b/tests/impl/async_request.cpp
@@ -65,7 +65,7 @@ TEST_F(async_request_op, should_set_timer_and_send_query_params_and_get_result_a
     EXPECT_CALL(callback_executor, dispatch(_)).InSequence(s).WillOnce(InvokeArgument<0>());
     EXPECT_CALL(callback, call(error_code {}, _)).InSequence(s).WillOnce(Return());
 
-    ozo::impl::async_request_op{fake_query {}, timeout, [] (auto, auto) {}, wrap(callback)}(error_code {}, conn);
+    ozo::impl::async_request_op{fake_query {}, timeout, ozo::none, wrap(callback)}(error_code {}, conn);
 }
 
 TEST_F(async_request_op, should_send_query_params_and_get_result_and_call_handler_whith_no_time_constraint) {
@@ -89,7 +89,7 @@ TEST_F(async_request_op, should_send_query_params_and_get_result_and_call_handle
     EXPECT_CALL(callback_executor, dispatch(_)).InSequence(s).WillOnce(InvokeArgument<0>());
     EXPECT_CALL(callback, call(error_code {}, _)).InSequence(s).WillOnce(Return());
 
-    ozo::impl::async_request_op{fake_query {}, ozo::none, [] (auto, auto) {}, wrap(callback)}(error_code {}, conn);
+    ozo::impl::async_request_op{fake_query {}, ozo::none, ozo::none, wrap(callback)}(error_code {}, conn);
 }
 
 TEST_F(async_request_op, should_cancel_socket_on_timeout) {
@@ -114,7 +114,7 @@ TEST_F(async_request_op, should_cancel_socket_on_timeout) {
     EXPECT_CALL(socket, async_read_some(_)).InSequence(s).WillOnce(InvokeArgument<0>(error_code {}));
     EXPECT_CALL(strand, post(_)).InSequence(s).WillOnce(Return());
 
-    ozo::impl::async_request_op{fake_query {}, timeout, [] (auto, auto) {}, wrap(callback)}(error_code {}, conn);
+    ozo::impl::async_request_op{fake_query {}, timeout, ozo::none, wrap(callback)}(error_code {}, conn);
 }
 
 } // namespace

--- a/tests/impl/request_oid_map.cpp
+++ b/tests/impl/request_oid_map.cpp
@@ -55,18 +55,18 @@ TEST(set_oid_map, should_throw_on_null_oid_in_oids_result) {
 
 template <class OidMap = ozo::empty_oid_map>
 struct connection {
-    OidMap oid_map;
+    OidMap oid_map_;
     std::string error_context_;
     using error_context = std::string;
 
     const error_context& get_error_context() const noexcept { return error_context_; }
     void set_error_context(error_context v = error_context{}) { error_context_ = std::move(v); }
 
-    friend OidMap& get_connection_oid_map(connection& self) {
-        return self.oid_map;
+    OidMap& oid_map() noexcept {
+        return oid_map_;
     }
-    friend const OidMap& get_connection_oid_map(const connection& self) {
-        return self.oid_map;
+    const OidMap& oid_map() const noexcept {
+        return oid_map_;
     }
 };
 

--- a/tests/impl/request_oid_map.cpp
+++ b/tests/impl/request_oid_map.cpp
@@ -56,19 +56,17 @@ TEST(set_oid_map, should_throw_on_null_oid_in_oids_result) {
 template <class OidMap = ozo::empty_oid_map>
 struct connection {
     OidMap oid_map;
-    std::string error_context;
+    std::string error_context_;
+    using error_context = std::string;
+
+    const error_context& get_error_context() const noexcept { return error_context_; }
+    void set_error_context(error_context v = error_context{}) { error_context_ = std::move(v); }
 
     friend OidMap& get_connection_oid_map(connection& self) {
         return self.oid_map;
     }
     friend const OidMap& get_connection_oid_map(const connection& self) {
         return self.oid_map;
-    }
-    friend std::string& get_connection_error_context(connection& self) {
-        return self.error_context;
-    }
-    friend const std::string& get_connection_error_context(const connection& self) {
-        return self.error_context;
     }
 };
 

--- a/tests/impl/transaction.cpp
+++ b/tests/impl/transaction.cpp
@@ -51,17 +51,17 @@ TEST_F(impl_transaction, has_connection_when_constructed_with) {
 TEST_F(impl_transaction, transaction_with_initialized_connection_is_not_null) {
     EXPECT_CALL(socket, close(_)).WillOnce(Return());
 
-    EXPECT_FALSE(is_null(ozo::impl::make_transaction(std::move(conn), options)));
+    EXPECT_FALSE(ozo::is_null(ozo::impl::make_transaction(std::move(conn), options)));
 }
 
 TEST_F(impl_transaction, transaction_without_connection_is_null) {
     ozo::impl::transaction<decltype(conn), decltype(options)> transaction;
-    EXPECT_TRUE(is_null(transaction));
+    EXPECT_TRUE(ozo::is_null(transaction));
 }
 
 TEST_F(impl_transaction, transaction_without_null_state_connection_is_null) {
     ozo::impl::transaction<decltype(conn), decltype(options)> transaction(nullptr, options);
-    EXPECT_TRUE(is_null(transaction));
+    EXPECT_TRUE(ozo::is_null(transaction));
 }
 
 TEST_F(impl_transaction, transaction_become_null_after_take_connection) {
@@ -69,7 +69,7 @@ TEST_F(impl_transaction, transaction_become_null_after_take_connection) {
 
     transaction.take_connection(conn);
 
-    EXPECT_TRUE(is_null(transaction));
+    EXPECT_TRUE(ozo::is_null(transaction));
 }
 
 } // namespace


### PR DESCRIPTION
## Motivation

Connection in its current state is not a solid entity with a strong guarantee about consistency with a weak specification of data members. It is hard to support and it is hard to understand. The customization points had been shown as useless and wrong in terms of the absence of a solid concept guarantee.

## New concept

It is very similar to stream_descriptor from Asio, except the Connection allows changing its executor. In other cases, it led to clone-like interfaces that model more sophisticated behavior.

Here the description of the Connection concept from the documentation.

`Connection` concept represents a minimum set of attributes and functions that are required
by the library to establish communication and execute operations. `Connection` should provide:
* the native PostgreSQL connection handle from `libpq`,
* an executor to perform IO-related operation (according to the current version of Boost.Asio
  it should be `boost::asio::io_context::executor_type` object),
* an additional error context to provide context-depended information for errors,
* IO functions that are necessary to perform operations.

The default implementation of the concept is `ozo::connection`.

### Requirements

Any wrapper object, which may be unwrapped to the underlying Connection model via
`ozo::unwrap_connection` is valid Connection model.

Connection `c` is an object of type `C` for which these next requirements are valid:

| Expression | Type | Description |
|------------|------|-------------|
| <PRE>as_const(c).native_handle()</PRE> | `C::native_handle_type` | Should return native handle type of PostgreSQL connection. In the current implementation it should be `PGconn*` type. Shall not throw an exception. |
| <PRE>c.oid_map()<sup>[1]</sup><br/>as_const(c).oid_map()<sup>[2]</sup></PRE> | `C::oid_map_type` | Should return a reference<sup>[1]</sup> or a const reference<sup>[2]</sup> on `OidMap` which is used by the connection, the library may update this map during connection establishing. Shall not throw an exception. |
| <PRE>as_const(c).get_error_context()</PRE> | `C::error_context_type` | Should return a const reference on an additional error context is related to at least the last error. In the current implementation, the type supported is `std::string`. Shall not throw an exception. |
| <PRE>c.set_error_context(error_context)<sup>[1]</sup><br/>c.set_error_context()<sup>[2]</sup></PRE> | | Should set<sup>[1]</sup> or reset<sup>[2]</sup> additional error context. |
| <PRE>as_const(c).get_executor()</PRE> | `C::executor_type` | Should provide an executor object that is useful for IO-related operations, like timer and so on. In the current implementation `boost::asio::io_context::executor_type` is only applicable. Shall not throw an exception. |
| <PRE>c.set_executor(executor)</PRE> | `error_code` | Should change the executor for the specified one. This operation is used by `ozo::connection_pool` to provide connection migration between different instances of `boost::asio::io_service`. The call of the function during the active operation on connection is UB. The error should be indicated via the result. |
| <PRE>c.assign(move(native_conn_handle))</PRE> | `error_code` | Should assign `ozo::native_conn_handle` to the connection object. If success - the previous handle should be destroyed. The error should be indicated via the result. |
| <PRE>c.async_wait_write(WaitHandler)</PRE> | | Should asynchronously wait for write ready state of the connection socket. |
| <PRE>c.async_wait_read(WaitHandler)</PRE> | | Should asynchronously wait for read ready state of the connection socket. |
| <PRE>c.close()</PRE> | `error_code` | Should close connection socket and cancel all IO operation on the connection (like `async_wait_write`, `async_wait_read`). Shall not throw an exception. |
| <PRE>c.cancel()</PRE> | | Should cancel all IO operation on the connection (like `async_wait_write`, `async_wait_read`). Should not throw an exception. |
| <PRE>c.is_bad()</PRE> | bool | Should return `false` for the established connection that can perform operations. Shall not throw an exception. |
| <PRE>bool(as_const(c))</PRE> | bool | Should return `true` for the established connection that can perform operations. In fact it should be the negation of `c.is_bad()`. Shall not throw an exception. |
| <PRE>ozo::get_connection(c, t, Handler)</PRE> | | Should reset the additional error context. This behaviour is performed in default implementation of `ozo::get_connection()` via `c.set_error_context()` call. |
| <PRE>ozo::is_connection<C></PRE> | `std::true_type` | The template `ozo::is_connection` should be specialized for the connection type via inheritance from `std::true_type`. |

Where:
* `Handler` is callable with `template <typename Connection> void(ozo::error_code, Connection&&)` signature,
* `WaitHandler` is callable with `void(ozo::error_code, int = 0)` signature,
* `t` is a `TimeConstraint` model object,
* `as_const()` is `std::as_const()`,
* `move()` is `std::move()`.