### PR TITLE
Fix deadlines handler

### DIFF
--- a/include/ozo/detail/deadline.h
+++ b/include/ozo/detail/deadline.h
@@ -9,20 +9,25 @@
 
 namespace ozo::detail {
 
-template <typename Executor, typename Continuation>
+template <typename Executor, typename Continuation, typename TimerHandler>
 class deadline_handler {
 public:
-    template <typename TimeConstraint, typename TimerHandler>
+    template <typename TimeConstraint>
     deadline_handler(const Executor& ex, TimeConstraint t, Continuation handler, TimerHandler on_deadline)
-    : timer_(ozo::detail::get_operation_timer(ex, t)), handler_(std::move(handler)),
-            executor_(ozo::detail::make_strand_executor(ex)) {
-        timer_.async_wait(wrapper<TimerHandler>{std::move(on_deadline), get_executor()});
+    : timer_(ozo::detail::get_operation_timer(ex, t)), executor_(ozo::detail::make_strand_executor(ex)) {
+        auto allocator = asio::get_associated_allocator(handler);
+        ctx_ = std::allocate_shared<context>(allocator, std::move(handler), std::move(on_deadline));
+        timer_.async_wait(wrapper{get_executor(), get_allocator(), ctx_});
     }
 
     template <typename ...Args>
     void operator() (error_code ec, Args&& ...args) {
-        timer_.cancel();
-        asio::dispatch(ozo::detail::bind(std::move(handler_), std::move(ec), std::forward<Args>(args)...));
+        if (--ctx_->state_) {
+            timer_.cancel();
+            asio::dispatch(ozo::detail::bind(std::move(ctx_->handler_), std::move(ec), std::forward<Args>(args)...));
+        } else {
+            asio::dispatch(ozo::detail::bind(std::move(ctx_->handler_), asio::error::timed_out, std::forward<Args>(args)...));
+        }
     }
 
     using timer_type = typename ozo::detail::operation_timer<Executor>::type;
@@ -33,32 +38,46 @@ public:
 
     using allocator_type = asio::associated_allocator_t<Continuation>;
 
-    allocator_type get_allocator() const noexcept { return asio::get_associated_allocator(handler_);}
+    allocator_type get_allocator() const noexcept { return asio::get_associated_allocator(ctx_->handler_);}
 
 private:
-    template <typename Target>
+
+    timer_type timer_;
+    executor_type executor_;
+    struct context {
+        Continuation handler_;
+        TimerHandler on_deadline_;
+        std::atomic<int> state_{2};
+
+        context(Continuation&& handler, TimerHandler&& on_deadline)
+        : handler_(std::move(handler)), on_deadline_(std::move(on_deadline)) {
+        }
+    };
+
+    std::shared_ptr<context> ctx_;
+
     struct wrapper {
         using executor_type = deadline_handler::executor_type;
 
         executor_type get_executor() const noexcept { return executor_;}
 
-        using allocator_type = asio::associated_allocator_t<Target>;
+        using allocator_type = deadline_handler::allocator_type;
 
-        allocator_type get_allocator() const noexcept { return asio::get_associated_allocator(target_);}
+        allocator_type get_allocator() const noexcept { return allocator_;}
 
         void operator() (error_code ec) {
             if (ec != asio::error::operation_aborted) {
-                asio::dispatch(ozo::detail::bind(std::move(target_), std::move(ec)));
+                if (--(ctx_->state_)) {
+                    asio::dispatch(ozo::detail::bind(std::move(ctx_->on_deadline_), std::move(ec)));
+                }
             }
         }
 
-        Target target_;
         executor_type executor_;
+        allocator_type allocator_;
+        std::shared_ptr<context> ctx_;
     };
 
-    timer_type timer_;
-    Continuation handler_;
-    executor_type executor_;
 };
 
 } // namespace ozo::detail

--- a/include/ozo/impl/connection.h
+++ b/include/ozo/impl/connection.h
@@ -174,34 +174,40 @@ inline auto get_executor(const Connection& conn) noexcept {
     return unwrap_connection(conn).get_executor();
 }
 
+namespace detail {
+inline constexpr std::string_view make_string_view(const char* src) {
+    return src == nullptr ? std::string_view{} : std::string_view{src};
+}
+} // namespace detail
+
 template <typename Connection>
 inline std::string_view get_database(const Connection& conn) {
     static_assert(ozo::Connection<Connection>, "conn should model Connection");
-    return PQdb(get_native_handle(conn));
+    return detail::make_string_view(PQdb(get_native_handle(conn)));
 }
 
 template <typename Connection>
 inline std::string_view get_host(const Connection& conn) {
     static_assert(ozo::Connection<Connection>, "conn should model Connection");
-    return PQhost(get_native_handle(conn));
+    return detail::make_string_view(PQhost(get_native_handle(conn)));
 }
 
 template <typename Connection>
 inline std::string_view get_port(const Connection& conn) {
     static_assert(ozo::Connection<Connection>, "conn should model Connection");
-    return PQport(get_native_handle(conn));
+    return detail::make_string_view(PQport(get_native_handle(conn)));
 }
 
 template <typename Connection>
 inline std::string_view get_user(const Connection& conn) {
     static_assert(ozo::Connection<Connection>, "conn should model Connection");
-    return PQuser(get_native_handle(conn));
+    return detail::make_string_view(PQuser(get_native_handle(conn)));
 }
 
 template <typename Connection>
 inline std::string_view get_password(const Connection& conn) {
     static_assert(ozo::Connection<Connection>, "conn should model Connection");
-    return PQpass(get_native_handle(conn));
+    return detail::make_string_view(PQpass(get_native_handle(conn)));
 }
 
 } // namespace ozo

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -305,8 +305,8 @@ TEST(ConnectionProvider, should_return_false_for_non_connection_provider_type){
     EXPECT_FALSE(ozo::ConnectionProvider<int>);
 }
 
-static const char* PQdb(const native_handle*) {
-    return "PQdb";
+static const char* PQdb(const native_handle* h) {
+    return h ? "PQdb" : nullptr;
 }
 
 TEST(get_database, should_return_PQdb_call_result){
@@ -314,8 +314,15 @@ TEST(get_database, should_return_PQdb_call_result){
     EXPECT_EQ(std::string(ozo::get_database(connection<>{io})), "PQdb");
 }
 
-static const char* PQhost(const native_handle*) {
-    return "PQhost";
+TEST(get_database, should_return_empty_string_view_for_null_handle){
+    io_context io;
+    connection<> conn{io};
+    conn.handle_.reset();
+    EXPECT_TRUE(ozo::get_database(conn).empty());
+}
+
+static const char* PQhost(const native_handle* h) {
+    return h ? "PQhost" : nullptr;
 }
 
 TEST(get_host, should_return_PQhost_call_result){
@@ -323,8 +330,15 @@ TEST(get_host, should_return_PQhost_call_result){
     EXPECT_EQ(std::string(ozo::get_host(connection<>{io})), "PQhost");
 }
 
-static const char* PQport(const native_handle*) {
-    return "PQport";
+TEST(get_host, should_return_empty_string_view_for_null_handle){
+    io_context io;
+    connection<> conn{io};
+    conn.handle_.reset();
+    EXPECT_TRUE(ozo::get_host(conn).empty());
+}
+
+static const char* PQport(const native_handle* h) {
+    return h ? "PQport" : nullptr;
 }
 
 TEST(get_port, should_return_PQport_call_result){
@@ -332,8 +346,15 @@ TEST(get_port, should_return_PQport_call_result){
     EXPECT_EQ(std::string(ozo::get_port(connection<>{io})), "PQport");
 }
 
-static const char* PQuser(const native_handle*) {
-    return "PQuser";
+TEST(get_port, should_return_empty_string_view_for_null_handle){
+    io_context io;
+    connection<> conn{io};
+    conn.handle_.reset();
+    EXPECT_TRUE(ozo::get_port(conn).empty());
+}
+
+static const char* PQuser(const native_handle* h) {
+    return h ? "PQuser" : nullptr;
 }
 
 TEST(get_user, should_return_PQport_call_result){
@@ -341,13 +362,27 @@ TEST(get_user, should_return_PQport_call_result){
     EXPECT_EQ(std::string(ozo::get_user(connection<>{io})), "PQuser");
 }
 
-static const char* PQpass(const native_handle*) {
-    return "PQpass";
+TEST(get_user, should_return_empty_string_view_for_null_handle){
+    io_context io;
+    connection<> conn{io};
+    conn.handle_.reset();
+    EXPECT_TRUE(ozo::get_user(conn).empty());
+}
+
+static const char* PQpass(const native_handle* h) {
+    return h ? "PQpass" : nullptr;
 }
 
 TEST(get_password, should_return_PQport_call_result){
     io_context io;
     EXPECT_EQ(std::string(ozo::get_password(connection<>{io})), "PQpass");
+}
+
+TEST(get_password, should_return_empty_string_view_for_null_handle){
+    io_context io;
+    connection<> conn{io};
+    conn.handle_.reset();
+    EXPECT_TRUE(ozo::get_password(conn).empty());
 }
 
 } //namespace

--- a/tests/integration/cancel_integration.cpp
+++ b/tests/integration/cancel_integration.cpp
@@ -79,7 +79,7 @@ TEST(cancel, should_stop_cancel_operation_on_zero_timeout) {
             }
         });
         ozo::execute(conn, "SELECT pg_sleep(1000000)"_SQL, 2s, yield[ec]);
-        EXPECT_EQ(ec, boost::asio::error::operation_aborted);
+        EXPECT_EQ(ec, boost::asio::error::timed_out);
     });
 
     io.run();

--- a/tests/integration/get_connection_integration.cpp
+++ b/tests/integration/get_connection_integration.cpp
@@ -13,7 +13,7 @@ TEST(get_connection, should_return_timeout_error_for_zero_connect_timeout) {
     std::atomic_flag called {};
     ozo::get_connection(conn_info[io], timeout, [&] (ozo::error_code ec, auto conn) {
         EXPECT_FALSE(called.test_and_set());
-        EXPECT_EQ(ec, boost::system::error_condition(boost::system::errc::operation_canceled));
+        EXPECT_EQ(ec, boost::asio::error::timed_out);
         EXPECT_FALSE(ozo::connection_bad(conn));
         EXPECT_EQ(ozo::get_error_context(conn), "error while connection polling");
     });

--- a/tests/integration/request_integration.cpp
+++ b/tests/integration/request_integration.cpp
@@ -226,7 +226,7 @@ TEST(request, should_call_handler_with_error_for_zero_timeout) {
     ozo::request(conn_info[io], "SELECT 1"_SQL, timeout, std::ref(res),
             [&](ozo::error_code ec, auto conn) {
         EXPECT_FALSE(called.test_and_set());
-        EXPECT_EQ(ec, boost::system::error_condition(boost::system::errc::operation_canceled));
+        EXPECT_EQ(ec, boost::asio::error::timed_out);
         EXPECT_FALSE(ozo::connection_bad(conn));
     });
 


### PR DESCRIPTION
## PROBLEM

Both callbacks (normal flow and cancel timer) appear in the io_context queue so both are called. No such proper handling for the situation.

## FIX

Add a shared state to prevent both callbacks execution. The backward atomic counter is used to indicate the calling sequence.
Error code for timed out operation now is `boost::asio::error::timed_out`.

## Add-on

Make `get_database`, `get_host`, `get_port`, `get_user`, `get_password` compatible with null handler

In `libpq` corresponding functions return `nullptr` for `nullptr` connection handle, `std::string_view` does not handle `nullptr` for `const char*` argument, so it leads to UB. This commit makes OZO functions to behave like the underlying `libpq` functions - return empty `std::string_view` for `nullptr` native connection handle.