### PR TITLE
Reduce connection wrappers and unwrap stack

### DIFF
--- a/include/ozo/connection.h
+++ b/include/ozo/connection.h
@@ -42,7 +42,7 @@ struct unwrap_connection_impl : unwrap_recursive_impl<T> {};
  *
  * This is customization point for the Connection enhancement. To customize it
  * it is better to specialize `ozo::unwrap_connection_impl` template for custom type.
- * E.g. such overload is used for the `ozo::impl::pooled_connection` of this library.
+ * E.g. such overload is used for the `ozo::pooled_connection` of this library.
  * The deafult implementation of the function is perfect forwarding. And may look like
  * this (*for exposition only - actual implementation may be different*):
  * @code

--- a/tests/connection.cpp
+++ b/tests/connection.cpp
@@ -214,36 +214,6 @@ TEST_F(async_get_connection, should_reset_connection_error_context) {
     });
 }
 
-TEST(bind_connection_executor, should_leave_same_io_context_and_socket_when_address_of_new_io_is_equal_to_old) {
-    io_context io;
-    connection<> conn(io);
-    EXPECT_EQ(ozo::detail::bind_connection_executor(conn, io.get_executor()), error_code());
-    EXPECT_EQ(ozo::get_executor(conn), io.get_executor());
-}
-
-TEST(bind_connection_executor, should_change_socket_when_address_of_new_io_is_not_equal_to_old) {
-    io_context old_io;
-    connection<> conn(old_io);
-    io_context new_io;
-
-    EXPECT_CALL(*conn.socket_.native_handle(), assign(_)).WillOnce(Return());
-    EXPECT_CALL(*conn.socket_.native_handle(), release()).WillOnce(Return());
-
-    EXPECT_EQ(ozo::detail::bind_connection_executor(conn, new_io.get_executor()), error_code());
-    EXPECT_EQ(ozo::get_executor(conn), new_io.get_executor());
-}
-
-TEST(bind_connection_executor, should_return_error_when_socket_assign_fails_with_error) {
-    io_context old_io;
-    connection<> conn(old_io);
-    io_context new_io;
-
-    EXPECT_CALL(*conn.socket_.native_handle(), assign(_))
-        .WillOnce(SetArgReferee<0>(error_code(error::code::error)));
-
-    EXPECT_EQ(ozo::detail::bind_connection_executor(conn, new_io.get_executor()), error_code(error::code::error));
-}
-
 struct fake_native_pq_handle {
     std::string message;
     friend const char* PQerrorMessage(const fake_native_pq_handle& self) {

--- a/tests/connection_mock.h
+++ b/tests/connection_mock.h
@@ -99,7 +99,6 @@ struct connection_mock {
     MOCK_METHOD0(async_request, void());
     MOCK_METHOD0(async_execute, void());
     MOCK_METHOD0(request_oid_map, void());
-    MOCK_METHOD0(set_executor, ozo::error_code());
     MOCK_METHOD0(get_cancel_handle, cancel_handle_mock*());
 };
 
@@ -253,11 +252,6 @@ struct connection {
         std::shared_ptr<connection> connection;
         transaction.take_connection(connection);
         connection->mock_->async_execute();
-    }
-
-    template <typename Executor>
-    ozo::error_code set_executor(const Executor&) {
-        return mock_->set_executor();
     }
 
     template <typename WaitHandler>

--- a/tests/test_asio.h
+++ b/tests/test_asio.h
@@ -58,10 +58,7 @@ struct stream_descriptor_mock {
     MOCK_METHOD1(cancel, void(error_code&));
     MOCK_METHOD1(close, void(error_code&));
     MOCK_METHOD0(release, int());
-
-    friend bool invalid_stream_descriptor(stream_descriptor_mock* v) {
-        return v != nullptr;
-    }
+    MOCK_METHOD1(assign, void(int));
 };
 
 struct stream_descriptor_service_mock {
@@ -201,6 +198,8 @@ struct stream_descriptor {
     void close(error_code& ec) { mock_->close(ec);}
 
     void release() { mock_->release();}
+
+    void assign(int fd) { mock_->assign(fd);}
 
     using executor_type = boost::asio::executor;
 


### PR DESCRIPTION
## Explicit pooled_connection

### Problem

Connection in the pool is stored with a reference to last used io_context and active IO stream that attached to. The connection pool is io_context agnostic and is not served by any particular io_context. So it can be a dangling reference on io_context inside stored connection if the io_context object has been destroyed.

### The solution

The only right solution is to exclude `io_context` related entities from stored in the pool objects. Since there is a difference in the behavior of `connection` and `pooled_connection` it should be two different types.

The `pooled_connection` should not provide write access to oid_map, or allow to assign different connection handle. That's why some functionality has been removed from the `Connection` concept requirements.

Member function `connection::set_executor()` has been deleted, since no more such functionality is needed.

Add `is_open()` requirement as it is needed to determine the situation if the connection does not own the native handle.

Add `connection::release()` as it is needed to transfer the connection handle to different implementations. E.g., it is needed to implement a true io-context-unbound connection pool.

Using of `dup()` to make a duplicate of the connection file descriptor is removed in favor of `posix_descriptor::release()`. It should reduce the cost of the stream object attaching.