### PR TITLE
Better oid map

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,10 @@ matrix:
     osx_image: xcode10
     install:
     - brew update
-    - brew upgrade
-    - brew install boost postgresql ccache
+    - brew upgrade boost
+    #- brew upgrade postgresql
+    - brew upgrade cmake
+    - brew install ccache
     env: BUILD_ARGS='clang debug'
 
 script: scripts/build.sh ${BUILD_ARGS}

--- a/include/ozo/ext/boost/uuid.h
+++ b/include/ozo/ext/boost/uuid.h
@@ -22,8 +22,8 @@ namespace ozo {
 
 template <>
 struct send_impl<boost::uuids::uuid> {
-    template <typename M>
-    static ostream& apply(ostream& out, const oid_map_t<M>&, const boost::uuids::uuid& in) {
+    template <typename OidMap>
+    static ostream& apply(ostream& out, const OidMap&, const boost::uuids::uuid& in) {
         out.write(reinterpret_cast<const char*>(in.data), std::size(in));
         return out;
     }
@@ -31,8 +31,8 @@ struct send_impl<boost::uuids::uuid> {
 
 template <>
 struct recv_impl<boost::uuids::uuid> {
-    template <typename M>
-    static istream& apply(istream& in, size_type size, const oid_map_t<M>&, const boost::uuids::uuid& out) {
+    template <typename OidMap>
+    static istream& apply(istream& in, size_type size, const OidMap&, const boost::uuids::uuid& out) {
         in.read(const_cast<char*>(reinterpret_cast<const char*>(out.data)), size);
         return in;
     }

--- a/include/ozo/ext/std/time_point.h
+++ b/include/ozo/ext/std/time_point.h
@@ -26,8 +26,8 @@ namespace ozo {
 
 template <>
 struct send_impl<std::chrono::system_clock::time_point> {
-    template <typename M>
-    static ostream& apply(ostream& out, const oid_map_t<M>&, const std::chrono::system_clock::time_point& in) {
+    template <typename OidMap>
+    static ostream& apply(ostream& out, const OidMap&, const std::chrono::system_clock::time_point& in) {
         int64_t value = std::chrono::duration_cast<std::chrono::microseconds>(in - detail::epoch).count();
         return impl::write(out, value);
     }
@@ -35,8 +35,8 @@ struct send_impl<std::chrono::system_clock::time_point> {
 
 template <>
 struct recv_impl<std::chrono::system_clock::time_point> {
-    template <typename M>
-    static istream& apply(istream& in, size_type, const oid_map_t<M>&, std::chrono::system_clock::time_point& out) {
+    template <typename OidMap>
+    static istream& apply(istream& in, size_type, const OidMap&, std::chrono::system_clock::time_point& out) {
         int64_t value;
         impl::read(in, value);
         out = detail::epoch + std::chrono::microseconds{ value };

--- a/include/ozo/impl/async_request.h
+++ b/include/ozo/impl/async_request.h
@@ -133,8 +133,8 @@ struct async_send_query_params_op {
     }
 };
 
-template <typename T, typename Allocator, typename ...Ts>
-inline auto make_binary_query(const query_builder<Ts...>& builder, const oid_map_t<T>& m, Allocator a) {
+template <typename OidMap, typename Allocator, typename ...Ts>
+inline auto make_binary_query(const query_builder<Ts...>& builder, const OidMap& m, Allocator a) {
     return binary_query(builder.build(), m, a);
 }
 

--- a/include/ozo/impl/request_oid_map.h
+++ b/include/ozo/impl/request_oid_map.h
@@ -8,8 +8,8 @@ namespace ozo::impl {
 template <typename T>
 inline T unwrap_type_c(hana::basic_type<T>);
 
-template <typename Impl>
-inline auto get_types_names(const oid_map_t<Impl>& oid_map) {
+template <typename ...Ts>
+inline auto get_types_names(const oid_map_t<Ts...>& oid_map) {
     return hana::unpack(hana::keys(oid_map.impl), [](auto const& ...x) {
         return std::array<std::string_view, sizeof...(x)>{
             {type_name<decltype(unwrap_type_c(x))>()...}
@@ -17,8 +17,8 @@ inline auto get_types_names(const oid_map_t<Impl>& oid_map) {
     });
 }
 
-template <typename Impl>
-inline auto make_oids_query(const oid_map_t<Impl>& oid_map) {
+template <typename ...Ts>
+inline auto make_oids_query(const oid_map_t<Ts...>& oid_map) {
     using namespace literals;
     return "SELECT COALESCE(to_regtype(f)::oid, 0) AS oid FROM UNNEST("_SQL
         + get_types_names(oid_map) + ") AS f"_SQL;
@@ -26,8 +26,8 @@ inline auto make_oids_query(const oid_map_t<Impl>& oid_map) {
 
 using oids_result = std::vector<oid_t>;
 
-template <typename Impl>
-inline void set_oid_map(oid_map_t<Impl>& oid_map, const oids_result& res) {
+template <typename ...Ts>
+inline void set_oid_map(oid_map_t<Ts...>& oid_map, const oids_result& res) {
     if (hana::length(oid_map.impl).value != res.size()) {
         throw std::length_error(std::string("result size ")
             + std::to_string(res.size())

--- a/include/ozo/io/array.h
+++ b/include/ozo/io/array.h
@@ -114,8 +114,8 @@ struct size_of_impl_dispatcher<T, Require<Array<T>>> { using type = size_of_arra
 
 template <typename T>
 struct send_array_impl {
-    template <typename M>
-    static ostream& apply(ostream& out, const oid_map_t<M>& oid_map, const T& in) {
+    template <typename OidMap>
+    static ostream& apply(ostream& out, const OidMap& oid_map, const T& in) {
         using value_type = typename T::value_type;
         write(out, pg_array {1, 0, type_oid<value_type>(oid_map)});
         write(out, pg_array_dimension {std::int32_t(std::size(in)), 0});
@@ -131,8 +131,8 @@ template <typename T>
 struct recv_array_impl {
     using out_type = T;
 
-    template <typename M>
-    static istream& apply(istream& in, size_type, const oid_map_t<M>& oids, out_type& out) {
+    template <typename OidMap>
+    static istream& apply(istream& in, size_type, const OidMap& oids, out_type& out) {
         pg_array array_header;
         pg_array_dimension dim_header;
 

--- a/include/ozo/io/composite.h
+++ b/include/ozo/io/composite.h
@@ -75,8 +75,8 @@ struct size_of_impl_dispatcher<T, Require<Composite<T>>> { using type = size_of_
 
 template <typename T>
 struct send_composite_impl {
-    template <typename M>
-    static ostream& apply(ostream& out, const oid_map_t<M>& oid_map, const T& in) {
+    template <typename OidMap>
+    static ostream& apply(ostream& out, const OidMap& oid_map, const T& in) {
         write(out, pg_composite{fields_number(in)});
         for_each_member(in, [&] (const auto& v) {
             send_frame(out, oid_map, v);
@@ -102,8 +102,8 @@ inline Require<Composite<T>> read_and_verify_header(istream& in, const T& v) {
 
 template <typename T>
 struct recv_fusion_adapted_composite_impl {
-    template <typename M>
-    static istream& apply(istream& in, size_type, const oid_map_t<M>& oid_map, T& out) {
+    template <typename OidMap>
+    static istream& apply(istream& in, size_type, const OidMap& oid_map, T& out) {
         read_and_verify_header(in, out);
         fusion::for_each(out, [&] (auto& v) {
             recv_frame(in, oid_map, v);
@@ -114,8 +114,8 @@ struct recv_fusion_adapted_composite_impl {
 
 template <typename T>
 struct recv_hana_adapted_composite_impl {
-    template <typename M>
-    static istream& apply(istream& in, size_type, const oid_map_t<M>& oid_map, T& out) {
+    template <typename OidMap>
+    static istream& apply(istream& in, size_type, const OidMap& oid_map, T& out) {
         read_and_verify_header(in, out);
         hana::for_each(hana::keys(out), [&in, &out, &oid_map](auto key) {
             recv_frame(in, oid_map, hana::at_key(out, key));

--- a/include/ozo/io/send.h
+++ b/include/ozo/io/send.h
@@ -47,12 +47,12 @@ struct send_impl{
      * @brief Implementation of serialization object into stream.
      *
      * @param out --- output stream
-     * @param oid_map_t<M> --- #OidMap to get oid for custom types
+     * @param OidMap --- #OidMap to get oid for custom types
      * @param in --- object to serialize
      * @return ostream& --- output stream
      */
-    template <typename M>
-    static ostream& apply(ostream& out, const oid_map_t<M>&, const In& in) {
+    template <typename OidMap>
+    static ostream& apply(ostream& out, const OidMap&, const In& in) {
         return write(out, in);
     }
 };
@@ -89,8 +89,8 @@ using get_send_impl = typename send_impl_dispatcher<unwrap_type<T>>::type;
  * @param in --- object to send.
  * @return ostream& --- reference to the output stream.
  */
-template <class M, class In>
-inline ostream& send(ostream& out, const oid_map_t<M>& oid_map, const In& in) {
+template <class OidMap, class In>
+inline ostream& send(ostream& out, const OidMap& oid_map, const In& in) {
     return ozo::is_null(in) ? out : detail::get_send_impl<In>::apply(out, oid_map, ozo::unwrap(in));
 }
 
@@ -107,8 +107,8 @@ inline ostream& send(ostream& out, const oid_map_t<M>& oid_map, const In& in) {
  * @param in --- object to send
  * @return ostream& --- reference to the output stream
  */
-template <class M, class In>
-inline ostream& send_data_frame(ostream& out, const oid_map_t<M>& oid_map, const In& in) {
+template <class OidMap, class In>
+inline ostream& send_data_frame(ostream& out, const OidMap& oid_map, const In& in) {
     write(out, size_of(in));
     return send(out, oid_map, in);
 }
@@ -127,8 +127,8 @@ inline ostream& send_data_frame(ostream& out, const oid_map_t<M>& oid_map, const
  * @param in --- object to send
  * @return ostream& --- reference to the output stream
  */
-template <class M, class In>
-inline ostream& send_frame(ostream& out, const oid_map_t<M>& oid_map, const In& in) {
+template <class OidMap, class In>
+inline ostream& send_frame(ostream& out, const OidMap& oid_map, const In& in) {
     write(out, type_oid(oid_map, in));
     return send_data_frame(out, oid_map, in);
 }

--- a/include/ozo/pg/types/jsonb.h
+++ b/include/ozo/pg/types/jsonb.h
@@ -44,8 +44,8 @@ struct size_of_impl<pg::jsonb> {
 
 template <>
 struct send_impl<pg::jsonb> {
-    template <typename M>
-    static ostream& apply(ostream& out, const oid_map_t<M>&, const pg::jsonb& in) {
+    template <typename OidMap>
+    static ostream& apply(ostream& out, const OidMap&, const pg::jsonb& in) {
         const std::int8_t version = 1;
         write(out, version);
         return write(out, in.value);
@@ -54,8 +54,8 @@ struct send_impl<pg::jsonb> {
 
 template <>
 struct recv_impl<pg::jsonb> {
-    template <typename M>
-    static istream& apply(istream& in, size_type size, const oid_map_t<M>&, pg::jsonb& out) {
+    template <typename OidMap>
+    static istream& apply(istream& in, size_type size, const OidMap&, pg::jsonb& out) {
         if (size < 1) {
             throw std::range_error("data size " + std::to_string(size) + " is too small to read jsonb");
         }

--- a/include/ozo/result.h
+++ b/include/ozo/result.h
@@ -42,7 +42,7 @@ public:
     }
 
     /**
-     * Determine whether the value is in binary format. Should be always false for current
+     * Determine whether the value is in text format. Should be always false for current
      * implementation.
      *
      * @return `true` --- value in text format

--- a/include/ozo/type_traits.h
+++ b/include/ozo/type_traits.h
@@ -15,6 +15,7 @@
 #include <boost/hana/map.hpp>
 #include <boost/hana/pair.hpp>
 #include <boost/hana/type.hpp>
+#include <boost/hana/not_equal.hpp>
 
 #include <memory>
 #include <string>
@@ -565,7 +566,10 @@ oid_t type_oid(const OidMap& map) noexcept;
 template <typename T, typename MapImplT>
 inline auto type_oid(const oid_map_t<MapImplT>& map) noexcept
         -> Require<!BuiltIn<T>, oid_t> {
-    return map.impl[hana::type_c<unwrap_type<T>>];
+    constexpr auto key = hana::type_c<unwrap_type<T>>;
+    static_assert(decltype(hana::find(map.impl, key) != hana::nothing)::value,
+        "type OID for T can not be found in the OidMap, it should be registered via register_type()");
+    return map.impl[key];
 }
 
 template <typename T, typename MapImplT>

--- a/include/ozo/type_traits.h
+++ b/include/ozo/type_traits.h
@@ -435,15 +435,26 @@ OZO_PG_DEFINE_CUSTOM_TYPE(smtp::message, "code.message")
 
 namespace ozo {
 
+namespace detail {
+
+template <typename ... T>
+constexpr decltype(auto) register_types() noexcept {
+    return hana::make_map(
+        hana::make_pair(hana::type_c<T>, null_oid()) ...
+    );
+}
+
+} // namespace detail
+
 /**
  * @brief OidMap implementation type.
  * @ingroup group-type_system-types
  *
  * This type implements OidMap concept based on `boost::hana::map`.
  */
-template <typename ImplT>
+template <typename ...Ts>
 struct oid_map_t {
-    using impl_type = ImplT;
+    using impl_type = decltype(detail::register_types<Ts...>());
 
     impl_type impl;
 };
@@ -452,8 +463,8 @@ struct oid_map_t {
 template <typename T>
 struct is_oid_map : std::false_type {};
 
-template <typename T>
-struct is_oid_map<oid_map_t<T>> : std::true_type {};
+template <typename ...Ts>
+struct is_oid_map<oid_map_t<Ts...>> : std::true_type {};
 
 /**
  * @brief Map of C++ types to corresponding PostgreSQL types OIDs
@@ -491,17 +502,6 @@ bool res = empty(map);
 template <typename T>
 constexpr auto OidMap = is_oid_map<std::decay_t<T>>::value;
 
-namespace detail {
-
-template <typename ... T>
-constexpr decltype(auto) register_types() noexcept {
-    return hana::make_map(
-        hana::make_pair(hana::type_c<T>, null_oid()) ...
-    );
-}
-
-} // namespace detail
-
 /**
  * @brief Provides #OidMap implementation for user-defined types.
  *
@@ -527,10 +527,9 @@ const auto conn_source = ozo::make_connection_info("...", regiter_types<custom_t
  *
  * @return `oid_map_t` object.
  */
-template <typename ... T>
-constexpr decltype(auto) register_types() noexcept {
-    using impl_type = decltype(detail::register_types<T ...>());
-    return oid_map_t<impl_type> {detail::register_types<T ...>()};
+template <typename ...Ts>
+constexpr oid_map_t<Ts...> register_types() noexcept {
+    return {};
 }
 
 /**
@@ -539,6 +538,8 @@ constexpr decltype(auto) register_types() noexcept {
  */
 using empty_oid_map = std::decay_t<decltype(register_types<>())>;
 
+constexpr empty_oid_map empty_oid_map_c;
+
 /**
 * Function sets oid for a type in #OidMap.
 * @ingroup group-type_system-functions
@@ -546,8 +547,8 @@ using empty_oid_map = std::decay_t<decltype(register_types<>())>;
 * @param map --- #OidMap to modify.
 * @param oid --- OID to set.
 */
-template <typename T, typename MapImplT>
-inline void set_type_oid(oid_map_t<MapImplT>& map, oid_t oid) noexcept {
+template <typename T, typename ...Ts>
+inline void set_type_oid(oid_map_t<Ts...>& map, oid_t oid) noexcept {
     static_assert(!is_built_in<T>::value, "type must not be built-in");
     map.impl[hana::type_c<T>] = oid;
 }
@@ -563,8 +564,8 @@ inline void set_type_oid(oid_map_t<MapImplT>& map, oid_t oid) noexcept {
 template <typename T, typename OidMap>
 oid_t type_oid(const OidMap& map) noexcept;
 #else
-template <typename T, typename MapImplT>
-inline auto type_oid(const oid_map_t<MapImplT>& map) noexcept
+template <typename T, typename ...Ts>
+inline auto type_oid(const oid_map_t<Ts...>& map) noexcept
         -> Require<!BuiltIn<T>, oid_t> {
     constexpr auto key = hana::type_c<unwrap_type<T>>;
     static_assert(decltype(hana::find(map.impl, key) != hana::nothing)::value,
@@ -572,9 +573,10 @@ inline auto type_oid(const oid_map_t<MapImplT>& map) noexcept
     return map.impl[key];
 }
 
-template <typename T, typename MapImplT>
-constexpr auto type_oid(const oid_map_t<MapImplT>&) noexcept
+template <typename T, typename OidMap>
+constexpr auto type_oid(const OidMap&) noexcept
         -> Require<BuiltIn<T>, oid_t> {
+    static_assert(ozo::OidMap<OidMap>, "map should model OidMap concept");
     return typename type_traits<T>::oid();
 }
 #endif
@@ -590,8 +592,9 @@ constexpr auto type_oid(const oid_map_t<MapImplT>&) noexcept
 template <typename T, typename OidMap>
 oid_t type_oid(const OidMap& map, const T& v) noexcept
 #else
-template <typename T, typename MapImplT>
-inline auto type_oid(const oid_map_t<MapImplT>& map, const T&) noexcept{
+template <typename T, typename OidMap>
+inline auto type_oid(const OidMap& map, const T&) noexcept{
+    static_assert(ozo::OidMap<OidMap>, "map should model OidMap concept");
     return type_oid<std::decay_t<T>>(map);
 }
 #endif
@@ -604,8 +607,9 @@ inline auto type_oid(const oid_map_t<MapImplT>& map, const T&) noexcept{
 * @param map --- #OidMap to get type OID from
 * @param oid --- OID to check for compatibility
 */
-template <typename T, typename MapImplT>
-inline bool accepts_oid(const oid_map_t<MapImplT>& map, oid_t oid) noexcept {
+template <typename T, typename OidMap>
+inline bool accepts_oid(const OidMap& map, oid_t oid) noexcept {
+    static_assert(ozo::OidMap<OidMap>, "map should model OidMap concept");
     return type_oid<T>(map) == oid;
 }
 
@@ -617,8 +621,8 @@ inline bool accepts_oid(const oid_map_t<MapImplT>& map, oid_t oid) noexcept {
 * @param const T& --- type to examine
 * @param oid --- OID to check for compatibility
 */
-template <typename T, typename MapImplT>
-inline bool accepts_oid(const oid_map_t<MapImplT>& map, const T& , oid_t oid) noexcept {
+template <typename T, typename OidMap>
+inline bool accepts_oid(const OidMap& map, const T& , oid_t oid) noexcept {
     return accepts_oid<std::decay_t<T>>(map, oid);
 }
 
@@ -635,8 +639,8 @@ static_assert(empty(ozo::empty_oid_map{}));
  * @return `true` --- if map contains no items
  * @return `false` --- if contains items.
  */
-template <typename MapImplT>
-inline constexpr bool empty(const oid_map_t<MapImplT>& map) noexcept {
+template <typename ...Ts>
+inline constexpr bool empty(const oid_map_t<Ts...>& map) noexcept {
     return hana::length(map.impl) == hana::size_c<0>;
 }
 


### PR DESCRIPTION
* Add a static assertion to `type_oid()` to reduce a bunch of long compiler errors about no element in `boost::hana::map`.
* Change `oid_map_t` template specification. It changed from specification by implementation type to specification by types. In this case, the compiler error message will display only registered types without `boost::hana::map` implementation details.