### PR TITLE
Add boost::tuple support

### DIFF
--- a/include/ozo/ext/boost.h
+++ b/include/ozo/ext/boost.h
@@ -11,5 +11,6 @@
 #include <ozo/ext/boost/optional.h>
 #include <ozo/ext/boost/scoped_ptr.h>
 #include <ozo/ext/boost/shared_ptr.h>
+#include <ozo/ext/boost/tuple.h>
 #include <ozo/ext/boost/weak_ptr.h>
 #include <ozo/ext/boost/uuid.h>

--- a/include/ozo/ext/boost/tuple.h
+++ b/include/ozo/ext/boost/tuple.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <ozo/pg/definitions.h>
+
+#include <boost/hana/ext/boost/tuple.hpp>
+#include <boost/tuple/tuple.hpp>
+/**
+ * @defgroup group-ext-boost-tuple boost::tuple
+ * @ingroup group-ext-boost
+ * @brief [boost::tuple](https://www.boost.org/doc/libs/1_66_0/libs/tuple/doc/html/tuple_users_guide.html) support
+ *
+ *@code
+#include <ozo/ext/boost/tuple.h>
+ *@endcode
+ *
+ * `boost::tuple<T...>` is defined as a generic composite type. and mapped as PostgreSQL
+ * `Record` type and its array.
+ */
+namespace ozo::definitions {
+
+template <typename ...Ts>
+struct type<boost::tuple<Ts...>> : pg::type_definition<decltype("record"_s)>{};
+
+template <typename ...Ts>
+struct array<boost::tuple<Ts...>> : pg::array_definition<decltype("record"_s)>{};
+
+} // namespace ozo::definitions
+
+namespace ozo {
+
+template <typename ...Ts>
+struct is_composite<boost::tuple<Ts...>> : std::true_type {};
+
+} // namespace ozo

--- a/include/ozo/ext/std/tuple.h
+++ b/include/ozo/ext/std/tuple.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ozo/pg/definitions.h>
+#include <boost/hana/ext/std/tuple.hpp>
 #include <tuple>
 
 /**

--- a/include/ozo/ozo.h
+++ b/include/ozo/ozo.h
@@ -35,12 +35,12 @@
  */
 
 /**
- * @defgroup group-ext Extentions
- * @brief Library extentions.
+ * @defgroup group-ext External adaptors
+ * @brief External type adaptors.
  *
  * The Library can be extended via specialization of different
- * functors and traits. Here in-library extentions are collected.
- * Use it as an example of extentions.
+ * functors and traits. Here in-library eternal type adaptors are collected.
+ * Use it as an example of external types adaptation.
  */
 
 #include <ozo/connection_pool.h>

--- a/tests/integration/result_integration.cpp
+++ b/tests/integration/result_integration.cpp
@@ -7,6 +7,7 @@
 #include <ozo/io/composite.h>
 #include <ozo/shortcuts.h>
 
+#include <boost/tuple/tuple_comparison.hpp>
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -162,6 +163,21 @@ TEST(result, should_convert_rows_of_records_in_rows_of_std_pairs) {
         std::make_tuple(std::make_pair(int(1), "one")),
         std::make_tuple(std::make_pair(int(2), "two")),
         std::make_tuple(std::make_pair(int(3), "three"))
+    ));
+}
+
+TEST(result, should_convert_rows_of_records_in_rows_of_boost_tuple) {
+    auto result = execute_query("SELECT * FROM (VALUES ((1, 'one'::text)), ((2, 'two'::text)), ((3, 'three'::text))) AS t (tuple);");
+    auto oid_map = ozo::empty_oid_map();
+
+    ozo::rows_of<boost::tuple<int, std::string>> out;
+
+    ozo::recv_result(result, oid_map, ozo::into(out));
+
+    EXPECT_THAT(out, ElementsAre(
+        std::make_tuple(boost::make_tuple(int(1), "one")),
+        std::make_tuple(boost::make_tuple(int(2), "two")),
+        std::make_tuple(boost::make_tuple(int(3), "three"))
     ));
 }
 


### PR DESCRIPTION
The `boost::tuple` is adapted similar to `std::tuple` as PostgreSQL `RECORD` type.