### PR TITLE
Update tests infrastructure

### DIFF
--- a/include/ozo/impl/connection.h
+++ b/include/ozo/impl/connection.h
@@ -28,7 +28,8 @@ inline error_code bind_connection_executor(Connection& conn, const Executor& ex)
     return {};
 }
 
-inline bool connection_status_bad(PGconn* handle) noexcept {
+template <typename NativeHandle>
+inline bool connection_status_bad(NativeHandle handle) noexcept {
     return !handle || PQstatus(handle) == CONNECTION_BAD;
 }
 

--- a/tests/bind.cpp
+++ b/tests/bind.cpp
@@ -15,16 +15,15 @@ using namespace ozo::tests;
 namespace asio = boost::asio;
 
 struct bind : Test {
-    StrictMock<executor_gmock> executor;
     StrictMock<callback_gmock<int>> cb_mock {};
-    ozo::tests::execution_context io{executor};
+    ozo::tests::execution_context io;
 };
 
 TEST_F(bind, should_use_handler_executor) {
     const InSequence s;
 
     EXPECT_CALL(cb_mock, get_executor()).WillOnce(Return(io.get_executor()));
-    EXPECT_CALL(executor, post(_)).WillOnce(InvokeArgument<0>());
+    EXPECT_CALL(io.executor_, post(_)).WillOnce(InvokeArgument<0>());
     EXPECT_CALL(cb_mock, call(_, _)).WillOnce(Return());
 
     asio::post(ozo::detail::bind(wrap(cb_mock), ozo::error_code{}, 42));

--- a/tests/connection_pool.cpp
+++ b/tests/connection_pool.cpp
@@ -83,10 +83,12 @@ using namespace testing;
 struct pooled_connection : Test {
     StrictMock<connection_gmock> connection_mock{};
     StrictMock<pool_handle_mock> handle_mock{};
+    StrictMock<stream_descriptor_mock> stream;
+    io_context io;
 
     using impl = ozo::impl::pooled_connection<connection_source>;
     auto make_connection() {
-        return std::make_shared<connection<>>();
+        return std::make_shared<connection<>>(connection<>{{}, {io, stream}, {}, nullptr, {} , nullptr});
     }
     auto make_connection(native_handle h) {
         auto conn = make_connection();
@@ -173,10 +175,11 @@ struct pooled_connection_wrapper : Test {
     StrictMock<callback_gmock<pooled_connection_ptr>> callback_mock;
     StrictMock<connection_gmock> connection_mock{};
     StrictMock<pool_handle_mock> handle_mock{};
+    StrictMock<stream_descriptor_mock> stream;
     io_context io;
 
     auto make_connection() {
-        return std::make_shared<connection<>>();
+        return std::make_shared<connection<>>(connection<>{{}, {io, stream}, {}, nullptr, {} , nullptr});
     }
 
     auto null_connection() {

--- a/tests/detail/deadline.cpp
+++ b/tests/detail/deadline.cpp
@@ -20,18 +20,15 @@ struct stream_mock {
 };
 
 struct io_deadline_handler : Test {
-    ozo::tests::executor_gmock executor;
-    ozo::tests::strand_executor_service_gmock strand_service;
-    ozo::tests::steady_timer_gmock timer;
-    ozo::tests::steady_timer_service_mock timer_service;
-    ozo::tests::execution_context io{executor, strand_service, timer_service};
+    ozo::tests::steady_timer_mock timer;
+    ozo::tests::execution_context io;
     StrictMock<ozo::tests::callback_gmock<int>> continuation;
-    StrictMock<ozo::tests::executor_gmock> continuation_executor;
+    StrictMock<ozo::tests::executor_mock> continuation_executor;
     StrictMock<stream_mock> stream;
     std::function<void (ozo::error_code)> on_timer_expired;
 
     io_deadline_handler() {
-        EXPECT_CALL(timer_service, timer(An<time_point>())).WillRepeatedly(ReturnRef(timer));
+        EXPECT_CALL(io.timer_service_, timer(An<time_point>())).WillRepeatedly(ReturnRef(timer));
         EXPECT_CALL(stream, get_executor()).WillRepeatedly(Return(io.get_executor()));
         EXPECT_CALL(continuation, get_executor())
             .WillRepeatedly(Return(ozo::tests::executor{continuation_executor, io}));

--- a/tests/detail/make_copyable.cpp
+++ b/tests/detail/make_copyable.cpp
@@ -15,9 +15,8 @@ using namespace ozo::tests;
 namespace asio = boost::asio;
 
 struct make_copyable : Test {
-    StrictMock<executor_gmock> executor;
     StrictMock<callback_gmock<int>> cb_mock {};
-    ozo::tests::execution_context io{executor};
+    ozo::tests::execution_context io;
 };
 
 struct handler_mock {

--- a/tests/impl/async_end_transaction.cpp
+++ b/tests/impl/async_end_transaction.cpp
@@ -16,13 +16,11 @@ using ozo::time_traits;
 
 struct async_end_transaction : Test {
     StrictMock<connection_gmock> connection {};
-    StrictMock<executor_gmock> callback_executor{};
+    StrictMock<executor_mock> callback_executor{};
     StrictMock<callback_gmock<connection_ptr<>>> callback {};
-    StrictMock<executor_gmock> executor {};
-    StrictMock<executor_gmock> strand {};
-    StrictMock<strand_executor_service_gmock> strand_service {};
-    StrictMock<stream_descriptor_gmock> socket {};
-    io_context io {executor, strand_service};
+    StrictMock<executor_mock> strand {};
+    StrictMock<stream_descriptor_mock> socket {};
+    io_context io;
     decltype(make_connection(connection, io, socket)) conn = make_connection(connection, io, socket);
     decltype(ozo::make_options()) options = ozo::make_options();
     time_traits::duration timeout {42};

--- a/tests/impl/async_end_transaction.cpp
+++ b/tests/impl/async_end_transaction.cpp
@@ -21,13 +21,14 @@ struct async_end_transaction : Test {
     StrictMock<executor_mock> strand {};
     StrictMock<stream_descriptor_mock> socket {};
     io_context io;
-    decltype(make_connection(connection, io, socket)) conn = make_connection(connection, io, socket);
+    StrictMock<PGconn_mock> handle;
+    decltype(make_connection(connection, io, socket)) conn = make_connection(connection, io, socket, handle, ozo::empty_oid_map{});
     decltype(ozo::make_options()) options = ozo::make_options();
     time_traits::duration timeout {42};
 };
 
 TEST_F(async_end_transaction, should_call_async_execute) {
-    *conn->handle_ = native_handle::good;
+    EXPECT_CALL(handle, PQstatus()).WillRepeatedly(Return(CONNECTION_OK));
 
     auto transaction = ozo::impl::transaction<decltype(conn), decltype(options)>(std::move(conn), options);
 

--- a/tests/impl/async_request.cpp
+++ b/tests/impl/async_request.cpp
@@ -22,16 +22,12 @@ using ozo::time_traits;
 
 struct async_request_op : Test {
     StrictMock<connection_gmock> connection {};
-    StrictMock<executor_gmock> callback_executor {};
     StrictMock<callback_mock> callback {};
-    StrictMock<executor_gmock> executor {};
-    StrictMock<executor_gmock> strand {};
-    StrictMock<strand_executor_service_gmock> strand_service {};
-    StrictMock<stream_descriptor_gmock> socket {};
-    StrictMock<steady_timer_gmock> timer {};
-    StrictMock<steady_timer_service_mock> timer_service;
-    io_context io {executor, strand_service, timer_service};
-    execution_context cb_io {callback_executor};
+    StrictMock<executor_mock> strand {};
+    StrictMock<stream_descriptor_mock> socket {};
+    StrictMock<steady_timer_mock> timer {};
+    io_context io;
+    execution_context cb_io;
     decltype(make_connection(connection, io, socket)) conn =
             make_connection(connection, io, socket);
     time_traits::duration timeout {42};
@@ -39,9 +35,9 @@ struct async_request_op : Test {
 
 TEST_F(async_request_op, should_set_timer_and_send_query_params_and_get_result_and_call_handler) {
 
-    EXPECT_CALL(strand_service, get_executor()).WillOnce(ReturnRef(strand));
+    EXPECT_CALL(io.strand_service_, get_executor()).WillOnce(ReturnRef(strand));
     EXPECT_CALL(callback, get_executor()).WillRepeatedly(Return(cb_io.get_executor()));
-    EXPECT_CALL(timer_service, timer(time_traits::duration(42))).WillRepeatedly(ReturnRef(timer));
+    EXPECT_CALL(io.timer_service_, timer(time_traits::duration(42))).WillRepeatedly(ReturnRef(timer));
 
     std::function<void (error_code)> on_timer_expired;
 
@@ -65,7 +61,7 @@ TEST_F(async_request_op, should_set_timer_and_send_query_params_and_get_result_a
 
     // Call client handler
     EXPECT_CALL(strand, post(_)).InSequence(s).WillOnce(InvokeArgument<0>());
-    EXPECT_CALL(callback_executor, dispatch(_)).InSequence(s).WillOnce(InvokeArgument<0>());
+    EXPECT_CALL(cb_io.executor_, dispatch(_)).InSequence(s).WillOnce(InvokeArgument<0>());
     EXPECT_CALL(callback, call(error_code {}, _)).InSequence(s).WillOnce(Return());
 
     ozo::impl::async_request_op{fake_query {}, timeout, ozo::none, wrap(callback)}(error_code {}, conn);
@@ -74,7 +70,7 @@ TEST_F(async_request_op, should_set_timer_and_send_query_params_and_get_result_a
 
 TEST_F(async_request_op, should_send_query_params_and_get_result_and_call_handler_whith_no_time_constraint) {
 
-    EXPECT_CALL(strand_service, get_executor()).WillOnce(ReturnRef(strand));
+    EXPECT_CALL(io.strand_service_, get_executor()).WillOnce(ReturnRef(strand));
     EXPECT_CALL(callback, get_executor()).WillRepeatedly(Return(cb_io.get_executor()));
 
     Sequence s;
@@ -90,7 +86,7 @@ TEST_F(async_request_op, should_send_query_params_and_get_result_and_call_handle
     EXPECT_CALL(connection, get_result()).InSequence(s).WillOnce(Return(boost::none));
 
     // Call client handler
-    EXPECT_CALL(callback_executor, dispatch(_)).InSequence(s).WillOnce(InvokeArgument<0>());
+    EXPECT_CALL(cb_io.executor_, dispatch(_)).InSequence(s).WillOnce(InvokeArgument<0>());
     EXPECT_CALL(callback, call(error_code {}, _)).InSequence(s).WillOnce(Return());
 
     ozo::impl::async_request_op{fake_query {}, ozo::none, ozo::none, wrap(callback)}(error_code {}, conn);
@@ -99,10 +95,10 @@ TEST_F(async_request_op, should_send_query_params_and_get_result_and_call_handle
 TEST_F(async_request_op, should_cancel_socket_on_timeout) {
     Sequence s;
 
-    EXPECT_CALL(strand_service, get_executor()).InSequence(s).WillOnce(ReturnRef(strand));
+    EXPECT_CALL(io.strand_service_, get_executor()).InSequence(s).WillOnce(ReturnRef(strand));
 
     // Set timer
-    EXPECT_CALL(timer_service, timer(time_traits::duration(42))).WillRepeatedly(ReturnRef(timer));
+    EXPECT_CALL(io.timer_service_, timer(time_traits::duration(42))).WillRepeatedly(ReturnRef(timer));
     EXPECT_CALL(timer, async_wait(_)).InSequence(s).WillOnce(InvokeArgument<0>(error_code {}));
 
     EXPECT_CALL(strand, post(_)).InSequence(s).WillOnce(InvokeArgument<0>());

--- a/tests/impl/async_send_query_params.cpp
+++ b/tests/impl/async_send_query_params.cpp
@@ -17,13 +17,10 @@ using callback_mock = callback_gmock<connection_ptr<>>;
 
 struct fixture {
     StrictMock<connection_gmock> connection{};
-    StrictMock<executor_gmock> callback_executor{};
     StrictMock<callback_mock> callback{};
-    StrictMock<executor_gmock> executor{};
-    StrictMock<strand_executor_service_gmock> strand_service{};
-    StrictMock<stream_descriptor_gmock> socket{};
-    io_context io{executor, strand_service};
-    execution_context cb_io {callback_executor};
+    StrictMock<stream_descriptor_mock> socket{};
+    io_context io;
+    execution_context cb_io;
     decltype(make_connection(connection, io, socket)) conn =
             make_connection(connection, io, socket);
 
@@ -174,7 +171,7 @@ TEST_F(async_send_query_params_op, should_wait_for_write_in_strand) {
     EXPECT_CALL(m.connection, flush_output()).InSequence(s)
         .WillOnce(Return(ozo::impl::query_state::send_in_progress));
     EXPECT_CALL(m.socket, async_write_some(_)).InSequence(s).WillOnce(InvokeArgument<0>(error_code{}));
-    EXPECT_CALL(m.callback_executor, post(_)).InSequence(s).WillOnce(InvokeArgument<0>());
+    EXPECT_CALL(m.cb_io.executor_, post(_)).InSequence(s).WillOnce(InvokeArgument<0>());
     EXPECT_CALL(m.connection, flush_output()).InSequence(s)
         .WillOnce(Return(ozo::impl::query_state::send_finish));
 

--- a/tests/impl/async_start_transaction.cpp
+++ b/tests/impl/async_start_transaction.cpp
@@ -17,13 +17,11 @@ using ozo::time_traits;
 struct async_start_transaction : Test {
     decltype(ozo::make_options()) options = ozo::make_options();
     StrictMock<connection_gmock> connection {};
-    StrictMock<executor_gmock> callback_executor{};
+    StrictMock<executor_mock> callback_executor{};
     StrictMock<callback_gmock<ozo::impl::transaction<connection_ptr<>, decltype(options)>>> callback {};
-    StrictMock<executor_gmock> executor {};
-    StrictMock<executor_gmock> strand {};
-    StrictMock<strand_executor_service_gmock> strand_service {};
-    StrictMock<stream_descriptor_gmock> socket {};
-    io_context io {executor, strand_service};
+    StrictMock<executor_mock> strand {};
+    StrictMock<stream_descriptor_mock> socket {};
+    io_context io;
     decltype(make_connection(connection, io, socket)) conn = make_connection(connection, io, socket);
     time_traits::duration timeout {42};
 };

--- a/tests/impl/async_start_transaction.cpp
+++ b/tests/impl/async_start_transaction.cpp
@@ -22,12 +22,13 @@ struct async_start_transaction : Test {
     StrictMock<executor_mock> strand {};
     StrictMock<stream_descriptor_mock> socket {};
     io_context io;
-    decltype(make_connection(connection, io, socket)) conn = make_connection(connection, io, socket);
+    StrictMock<PGconn_mock> handle;
+    decltype(make_connection(connection, io, socket)) conn = make_connection(connection, io, socket, handle, ozo::empty_oid_map{});
     time_traits::duration timeout {42};
 };
 
 TEST_F(async_start_transaction, should_call_async_execute) {
-    *conn->handle_ = native_handle::good;
+    EXPECT_CALL(handle, PQstatus()).WillRepeatedly(Return(CONNECTION_OK));
 
     EXPECT_CALL(connection, async_execute()).WillOnce(Return());
 

--- a/tests/impl/cancel.cpp
+++ b/tests/impl/cancel.cpp
@@ -81,14 +81,11 @@ struct cancel_handle {
 };
 
 struct initiate_async_cancel : Test {
-    StrictMock<ozo::tests::executor_gmock> executor;
-    StrictMock<ozo::tests::steady_timer_gmock> timer;
-    StrictMock<ozo::tests::steady_timer_service_mock> timer_service;
-    StrictMock<ozo::tests::executor_gmock> strand;
-    ozo::tests::strand_executor_service_gmock strand_service;
-    ozo::tests::execution_context io{executor, strand_service, timer_service};
+    StrictMock<ozo::tests::steady_timer_mock> timer;
+    StrictMock<ozo::tests::executor_mock> strand;
+    ozo::tests::execution_context io;
     StrictMock<cancel_handle_mock> cancel_handle_;
-    StrictMock<ozo::tests::executor_gmock> handle_executor;
+    StrictMock<ozo::tests::executor_mock> handle_executor;
     StrictMock<ozo::tests::callback_gmock<std::string>> callback;
 
     ozo::impl::initiate_async_cancel initiate_async_cancel_;
@@ -101,8 +98,8 @@ TEST_F(initiate_async_cancel, should_post_cancel_op_into_cancel_handle_attached_
 
 
 TEST_F(initiate_async_cancel, should_post_cancel_op_with_time_constraint_into_cancel_handle_attached_executor_and_wait_for_timer) {
-    EXPECT_CALL(timer_service, timer(An<ozo::time_traits::time_point>())).WillOnce(ReturnRef(timer));
-    EXPECT_CALL(strand_service, get_executor()).WillOnce(ReturnRef(strand));
+    EXPECT_CALL(io.timer_service_, timer(An<ozo::time_traits::time_point>())).WillOnce(ReturnRef(timer));
+    EXPECT_CALL(io.strand_service_, get_executor()).WillOnce(ReturnRef(strand));
     EXPECT_CALL(handle_executor, post(_));
     EXPECT_CALL(timer, async_wait(_));
     initiate_async_cancel_(ozo::tests::wrap(callback), cancel_handle(cancel_handle_, handle_executor), io, ozo::time_traits::time_point{});

--- a/tests/impl/transaction.cpp
+++ b/tests/impl/transaction.cpp
@@ -13,10 +13,8 @@ using namespace ozo::tests;
 
 struct impl_transaction : Test {
     StrictMock<connection_gmock> connection {};
-    StrictMock<executor_gmock> executor {};
-    StrictMock<strand_executor_service_gmock> strand_service {};
-    StrictMock<stream_descriptor_gmock> socket {};
-    io_context io {executor, strand_service};
+    StrictMock<stream_descriptor_mock> socket {};
+    io_context io;
     decltype(make_connection(connection, io, socket)) conn = make_connection(connection, io, socket);
     decltype(ozo::make_options()) options = ozo::make_options();
 };

--- a/tests/transaction_status.cpp
+++ b/tests/transaction_status.cpp
@@ -8,11 +8,13 @@
 namespace {
 
 struct get_transaction_status : testing::Test {
+    ozo::tests::io_context io;
+    testing::StrictMock<ozo::tests::stream_descriptor_mock> stream;
     auto make_connection() {
         using namespace ozo::tests;
         return std::make_shared<connection<>>(connection<>{
             std::make_unique<native_handle>(native_handle::good),
-            {}, {}, nullptr, "", nullptr
+            ozo::tests::stream_descriptor{io, stream}, {}, nullptr, "", nullptr
         });
     }
 };


### PR DESCRIPTION
Test infrastructure is not the best thing here. So to continue with connection refactoring these changes are needed:

* **Update native connection handler mock to normal mock.** Now native connection handler is represented by the mock class, so now it is possible to test `libpq` calls without intermediate overloaded functions. Since `libpq` is a C library it is really easy to mock calls with SFINAE.
* **Add a stream descriptor dispatching from an Executor type.**  Like with the operation timer this approach allows customizing the IO stream type for testing purposes.
* **Make IO related mocks hosted by the test `io_context` class.**  Make `executor`, `strand_service`, `timer_service`, and `stream_service` mocks are hosted by the test `io_context` class to reduce boilerplate of test fixtures.