### PR TITLE
Make binary_query type erasure to reduce instantiation hell

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -226,6 +226,12 @@ TAB_SIZE               = 4
 # alias to insert a newline as if a physical newline was in the original file.
 
 ALIASES                =
+ALIASES                +=models{1}="@par Models^^`\1`\n"
+ALIASES                +=models{2}="@par Models^^`\1`, `\2`\n"
+ALIASES                +=models{3}="@par Models^^`\1`, `\2`, `\3`\n"
+ALIASES                +=models{4}="@par Models^^`\1`, `\2`, `\3`, `\4`\n"
+ALIASES                +=models{5}="@par Models^^`\1`, `\2`, `\3`, `\4`, `\5`\n"
+ALIASES                +=concept{1}="@interface \1 <>"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/include/ozo/execute.h
+++ b/include/ozo/execute.h
@@ -14,14 +14,14 @@ namespace ozo {
  * @note The function does not particitate in ADL since could be implemented via functional object.
  *
  * @param provider --- #ConnectionProvider object
- * @param query --- #Query or `ozo::binary_query` to execute
+ * @param query --- query object to execute
  * @param time_constraint --- request #TimeConstraint; this time constrain <b>includes</b> time for getting connection from provider.
  * @param token --- operation #CompletionToken.
  * @return deduced from #CompletionToken.
  * @ingroup group-requests-functions
  */
-template <typename ConnectionProvider, typename Query, typename TimeConstraint, typename CompletionToken>
-decltype(auto) execute(ConnectionProvider&& provider, Query&& query, TimeConstraint time_constraint, CompletionToken&& token);
+template <typename ConnectionProvider, typename BinaryQueryConvertible, typename TimeConstraint, typename CompletionToken>
+decltype(auto) execute(ConnectionProvider&& provider, BinaryQueryConvertible&& query, TimeConstraint time_constraint, CompletionToken&& token);
 
 /**
  * @brief Executes query with no result data expected
@@ -32,13 +32,13 @@ decltype(auto) execute(ConnectionProvider&& provider, Query&& query, TimeConstra
  * @note The function does not particitate in ADL since could be implemented via functional object.
  *
  * @param provider --- #ConnectionProvider object
- * @param query --- #Query or `ozo::binary_query` to execute
+ * @param query --- query object to execute
  * @param token --- operation #CompletionToken.
  * @return deduced from #CompletionToken.
  * @ingroup group-requests-functions
  */
-template <typename P, typename Q, typename CompletionToken>
-decltype(auto) execute(P&& provider, Q&& query, CompletionToken&& token);
+template <typename P, typename BinaryQueryConvertible, typename CompletionToken>
+decltype(auto) execute(P&& provider, BinaryQueryConvertible&& query, CompletionToken&& token);
 #else
 
 template <typename Initiator>

--- a/include/ozo/execute.h
+++ b/include/ozo/execute.h
@@ -14,7 +14,7 @@ namespace ozo {
  * @note The function does not particitate in ADL since could be implemented via functional object.
  *
  * @param provider --- #ConnectionProvider object
- * @param query --- #Query to execute
+ * @param query --- #Query or `ozo::binary_query` to execute
  * @param time_constraint --- request #TimeConstraint; this time constrain <b>includes</b> time for getting connection from provider.
  * @param token --- operation #CompletionToken.
  * @return deduced from #CompletionToken.
@@ -32,7 +32,7 @@ decltype(auto) execute(ConnectionProvider&& provider, Query&& query, TimeConstra
  * @note The function does not particitate in ADL since could be implemented via functional object.
  *
  * @param provider --- #ConnectionProvider object
- * @param query --- #Query to execute
+ * @param query --- #Query or `ozo::binary_query` to execute
  * @param token --- operation #CompletionToken.
  * @return deduced from #CompletionToken.
  * @ingroup group-requests-functions

--- a/include/ozo/impl/async_execute.h
+++ b/include/ozo/impl/async_execute.h
@@ -8,7 +8,7 @@ namespace ozo::impl {
 template <typename P, typename Q, typename TimeConstraint, typename Handler>
 inline void async_execute(P&& provider, Q&& query, TimeConstraint t, Handler&& handler) {
     static_assert(ConnectionProvider<P>, "is not a ConnectionProvider");
-    static_assert(Query<Q> || QueryBuilder<Q>, "is neither Query nor QueryBuilder");
+    static_assert(Query<Q> || std::is_same_v<std::decay_t<Q>, binary_query>, "query should model Query concept");
     static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
     async_get_connection(std::forward<P>(provider), deadline(t),
         async_request_op {

--- a/include/ozo/impl/async_execute.h
+++ b/include/ozo/impl/async_execute.h
@@ -8,7 +8,7 @@ namespace ozo::impl {
 template <typename P, typename Q, typename TimeConstraint, typename Handler>
 inline void async_execute(P&& provider, Q&& query, TimeConstraint t, Handler&& handler) {
     static_assert(ConnectionProvider<P>, "is not a ConnectionProvider");
-    static_assert(Query<Q> || std::is_same_v<std::decay_t<Q>, binary_query>, "query should model Query concept");
+    static_assert(BinaryQueryConvertible<Q>, "query should be convertible to the binary_query");
     static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
     async_get_connection(std::forward<P>(provider), deadline(t),
         async_request_op {

--- a/include/ozo/impl/async_request.h
+++ b/include/ozo/impl/async_request.h
@@ -133,11 +133,6 @@ struct async_send_query_params_op {
     }
 };
 
-template <typename OidMap, typename Allocator, typename ...Ts>
-inline auto make_binary_query(const query_builder<Ts...>& builder, const OidMap& m, Allocator a) {
-    return binary_query(builder.build(), m, a);
-}
-
 template <typename T, typename M, typename Alloc, typename = Require<Query<T>>>
 inline auto make_binary_query(const T& query, const M& oid_map, const Alloc& allocator) {
     return binary_query(query, oid_map, allocator);
@@ -357,8 +352,8 @@ struct async_request_out_handler {
 template <typename P, typename Q, typename TimeConstraint, typename Out, typename Handler>
 inline void async_request(P&& provider, Q&& query, TimeConstraint t, Out&& out, Handler&& handler) {
     static_assert(ConnectionProvider<P>, "is not a ConnectionProvider");
-    static_assert(Query<Q> || QueryBuilder<Q> || std::is_same_v<std::decay_t<Q>, binary_query>,
-        "query should be binary_query type or model Query or QueryBuilder concept");
+    static_assert(Query<Q> || std::is_same_v<std::decay_t<Q>, binary_query>,
+        "query should be binary_query type or model Query concept");
     static_assert(ozo::TimeConstraint<TimeConstraint>, "should model TimeConstraint concept");
     async_get_connection(std::forward<P>(provider), deadline(t),
         async_request_op{

--- a/include/ozo/impl/io.h
+++ b/include/ozo/impl/io.h
@@ -40,11 +40,11 @@ inline native_conn_handle pq_start_connection(const T&, const std::string& conni
 }
 
 template <typename T, typename ...Ts>
-inline int pq_send_query_params(T& conn, const binary_query<Ts...>& q) noexcept {
+inline int pq_send_query_params(T& conn, const binary_query& q) noexcept {
     static_assert(Connection<T>, "T must be a Connection");
     return PQsendQueryParams(get_native_handle(conn),
                 q.text(),
-                q.params_count,
+                q.params_count(),
                 q.types(),
                 q.values(),
                 q.lengths(),

--- a/include/ozo/query.h
+++ b/include/ozo/query.h
@@ -16,6 +16,12 @@
  */
 
 /**
+ * @defgroup group-query-types types
+ * @ingroup group-query
+ * @brief Query-related concepts.
+ */
+
+/**
  * @defgroup group-query-functions Functions
  * @ingroup group-query
  * @brief Query-related functions.

--- a/include/ozo/query.h
+++ b/include/ozo/query.h
@@ -246,6 +246,9 @@ static_assert(ozo::HanaSequence<decltype(ozo::get_query_params(query))>);
  * To adapt custom type as #Query for the library it is needed to customize
  * `ozo::get_query_text()` and `ozo::get_query_params()` via its' implementations.
  * See both functions description for more details.
+ *
+ * Query may be constructed via `ozo::make_query` function or `ozo::query_builder`.
+ *
  * @hideinitializer
  * @ingroup group-query-concepts
  */

--- a/include/ozo/query_builder.h
+++ b/include/ozo/query_builder.h
@@ -123,15 +123,6 @@ struct query_builder {
 };
 
 template <class T>
-struct is_query_builder : std::false_type {};
-
-template <class T>
-struct is_query_builder<query_builder<T>> : std::true_type {};
-
-template <class T>
-constexpr auto QueryBuilder = is_query_builder<std::decay_t<T>>::value;
-
-template <class T>
 constexpr auto make_query_text(T&& value) {
     return query_element<std::decay_t<T>, query_text_tag> {std::forward<T>(value)};
 }
@@ -176,6 +167,19 @@ constexpr auto operator +(query_element<LhsValueT, LhsTagT>&& lhs, RhsValueT&& r
     return make_query_builder(hana::make_tuple(std::move(lhs), make_query_param(std::forward<RhsValueT>(rhs))));
 }
 
+template <class ...Ts>
+struct get_query_text_impl<query_builder<Ts...>> {
+    static constexpr decltype(auto) apply(const query_builder<Ts...>& q) noexcept {
+        return q.text();
+    }
+};
+
+template <typename ...Ts>
+struct get_query_params_impl<query_builder<Ts...>> {
+    static constexpr decltype(auto) apply(const query_builder<Ts...>& q) noexcept {
+        return q.params();
+    }
+};
 
 namespace literals {
 

--- a/include/ozo/request.h
+++ b/include/ozo/request.h
@@ -14,7 +14,7 @@ namespace ozo {
  * @note The function does not particitate in ADL since could be implemented via functional object.
  *
  * @param provider --- #ConnectionProvider to get connection from.
- * @param query --- #Query or `ozo::query_builder` object to request from a database.
+ * @param query --- #Query or `ozo::binary_query` object to request from a database.
  * @param time_constraint --- request #TimeConstraint; this time constrain <b>includes</b> time for getting connection from provider.
  * @param out --- output object like Iterator, #InsertIterator or `ozo::result`.
  * @param token --- operation #CompletionToken.
@@ -70,7 +70,7 @@ decltype(auto) request (ConnectionProvider&& provider, Query&& query, TimeConstr
  * @note The function does not particitate in ADL since could be implemented via functional object.
  *
  * @param provider --- #ConnectionProvider to get connection from.
- * @param query --- #Query or `ozo::query_builder` object to request from a database.
+ * @param query --- #Query or `ozo::binary_query` object to request from a database.
  * @param out --- output object like Iterator, #InsertIterator or `ozo::result`.
  * @param token --- operation #CompletionToken.
  * @return deduced from #CompletionToken.

--- a/include/ozo/request.h
+++ b/include/ozo/request.h
@@ -14,7 +14,7 @@ namespace ozo {
  * @note The function does not particitate in ADL since could be implemented via functional object.
  *
  * @param provider --- #ConnectionProvider to get connection from.
- * @param query --- #Query or `ozo::binary_query` object to request from a database.
+ * @param query --- query object to request from a database.
  * @param time_constraint --- request #TimeConstraint; this time constrain <b>includes</b> time for getting connection from provider.
  * @param out --- output object like Iterator, #InsertIterator or `ozo::result`.
  * @param token --- operation #CompletionToken.
@@ -58,8 +58,8 @@ int main() {
  * @endcode
  * @ingroup group-requests-functions
  */
-template <typename ConnectionProvider, typename Query, typename TimeConstraint, typename Out, typename CompletionToken>
-decltype(auto) request (ConnectionProvider&& provider, Query&& query, TimeConstraint time_constraint, Out out, CompletionToken&& token);
+template <typename ConnectionProvider, typename BinaryQueryConvertible, typename TimeConstraint, typename Out, typename CompletionToken>
+decltype(auto) request (ConnectionProvider&& provider, BinaryQueryConvertible&& query, TimeConstraint time_constraint, Out out, CompletionToken&& token);
 
 /**
  * @brief Request query from a database
@@ -70,14 +70,14 @@ decltype(auto) request (ConnectionProvider&& provider, Query&& query, TimeConstr
  * @note The function does not particitate in ADL since could be implemented via functional object.
  *
  * @param provider --- #ConnectionProvider to get connection from.
- * @param query --- #Query or `ozo::binary_query` object to request from a database.
+ * @param query --- query object to request from a database.
  * @param out --- output object like Iterator, #InsertIterator or `ozo::result`.
  * @param token --- operation #CompletionToken.
  * @return deduced from #CompletionToken.
  * @ingroup group-requests-functions
  */
-template <typename ConnectionProvider, typename Query, typename Out, typename CompletionToken>
-decltype(auto) request (ConnectionProvider&& provider, Query&& query, Out out, CompletionToken&& token);
+template <typename ConnectionProvider, typename BinaryQueryConvertible, typename Out, typename CompletionToken>
+decltype(auto) request (ConnectionProvider&& provider, BinaryQueryConvertible&& query, Out out, CompletionToken&& token);
 
 #else
 

--- a/tests/binary_query.cpp
+++ b/tests/binary_query.cpp
@@ -21,17 +21,17 @@ struct binary_query_params_count : Test {};
 
 TEST_F(binary_query_params_count, without_parameters_should_be_equal_to_0) {
     const auto query = make_binary_query("", hana::make_tuple());
-    EXPECT_EQ(query.params_count, 0u);
+    EXPECT_EQ(query.params_count(), 0u);
 }
 
 TEST_F(binary_query_params_count, with_more_than_0_parameters_should_be_equal_to_that_number) {
     const auto query = make_binary_query("", hana::make_tuple(true, 42, std::string("text")));
-    EXPECT_EQ(query.params_count, 3u);
+    EXPECT_EQ(query.params_count(), 3u);
 }
 
 TEST_F(binary_query_params_count, from_query_concept_with_more_than_0_parameters_should_be_equal_to_that_number) {
     const auto query = ozo::binary_query(ozo::make_query("", true, 42, std::string("text")), ozo::empty_oid_map{});
-    EXPECT_EQ(query.params_count, 3u);
+    EXPECT_EQ(query.params_count(), 3u);
 }
 
 struct binary_query_text : Test {};

--- a/tests/binary_query.cpp
+++ b/tests/binary_query.cpp
@@ -30,7 +30,7 @@ TEST_F(binary_query_params_count, with_more_than_0_parameters_should_be_equal_to
 }
 
 TEST_F(binary_query_params_count, from_query_concept_with_more_than_0_parameters_should_be_equal_to_that_number) {
-    const auto query = ozo::binary_query(ozo::make_query("", true, 42, std::string("text")), ozo::empty_oid_map{});
+    const auto query = ozo::to_binary_query(ozo::make_query("", true, 42, std::string("text")), ozo::empty_oid_map{});
     EXPECT_EQ(query.params_count(), 3u);
 }
 

--- a/tests/impl/async_send_query_params.cpp
+++ b/tests/impl/async_send_query_params.cpp
@@ -23,7 +23,7 @@ struct fixture {
     execution_context cb_io;
     decltype(make_connection(connection, io, socket)) conn =
             make_connection(connection, io, socket);
-    ozo::binary_query query{fake_query {}, ozo::empty_oid_map_c};
+    ozo::binary_query query = ozo::to_binary_query(fake_query {}, ozo::empty_oid_map_c);
 
     auto make_operation_context() {
         EXPECT_CALL(callback, get_executor()).WillRepeatedly(Return(cb_io.get_executor()));


### PR DESCRIPTION
### Problem

In an internal project, we got an enormous deep of template instantiations that lead to enormous memory consumption and compilation time. It looks like other projects may have such a problem especially with using the failover micro-framework.

### Solution

The problem may be solved by means of type erasures. Part of such type erasures should be provided by the library. One of such type erasures should be `ozo::binary_query`, which allows implementing a type erasure for query objects. The only performance penalty here is a virtual function call. No additional memory allocation for non-type-erased queries types will be made. The second part of the solution is `ozo::BinaryQueryConvertible` concept that allows using any query type and converts it to the `ozo::binary_query` right before the query sending.

### What's New

`BinaryQueryConvertible` concept of a type that is convertible to `ozo::binary_query`.

To be convertible to the `ozo::binary_query` type should model `Query` concept or should have a valid `ozo::to_binary_query_impl<T>` overload.

A particular query object type may become `BinaryQueryConvertible` via the specialization of `ozo::to_binary_query_impl<T>::apply()` template function. By default, it handles any `Query` model object or `binary_query` object.

```c++
template <typename T>
struct to_binary_query_impl<T> {
    template <typename OidMap, typename Allocator>
    static binary_query apply(const T&, const OidMap&, const Allocator&);
};
```

**Example**

E.g., a custom library contains a type-erasure interface for its queries.

```c++
namespace demo {

constexpr auto oidMap = ozo::register_types<...>();

using OidMap = decltype(oidMap);

struct Query {
    virtual ozo::binary_query toBinaryQuery(const OidMap&, const std::allocator<char>&) const = 0;
    virtual ~Query() = 0;
};

} // namespace demo
```

Then the adaptation should look like this:

```c++
namespace ozo {
template <>
struct to_binary_query_impl<demo::Query> {
    template <typename OidMap, typename Alloc>
    static binary_query apply(const demo::Query& query, const demo::OidMap& oid_map, const std::allocator<char>& alloc) {
        return query.toBinaryQuery(oid_map, alloc);
    }
};
} // namespace ozo
```