### PR TITLE
Make begin_op::with_transaction_options constexpr

### DIFF
--- a/include/ozo/transaction.h
+++ b/include/ozo/transaction.h
@@ -35,7 +35,7 @@ struct begin_op : base_async_operation <begin_op<Initiator, Options>, Initiator>
     }
 
     template <typename OtherOptions>
-    auto with_transaction_options(const OtherOptions& options) const {
+    constexpr auto with_transaction_options(const OtherOptions& options) const {
         return begin_op<Initiator, OtherOptions>{get_operation_initiator(*this), options};
     }
 


### PR DESCRIPTION
When implementing transaction options, I forgot to make `with_transaction_options` `constexpr`. Given that both `begin_op`'s constructor and `get_operation_initiator` are in fact `constexpr`, there is no reason it should not be; sorry for that oversight.

As a side question, is there a specific place for 'compile time tests' or something? It would make sense to have something stop compile, should the interface ever change to lose its `constexpr`ness for some reason, but there is no test for `begin_op` specifically (and creating a new file for just one test felt strange); the transaction integration test on the other hand is only an 'opt-in test' and therefore not really the place to test compile time stuff.