### PR TITLE
Add transaction test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ set(SOURCES
     failover/role_based.cpp
     detail/deadline.cpp
     impl/cancel.cpp
+    transaction.cpp
     main.cpp
 )
 

--- a/tests/transaction.cpp
+++ b/tests/transaction.cpp
@@ -1,0 +1,9 @@
+#include <ozo/transaction.h>
+
+namespace {
+
+// Test `constexpr`ness of transaction-related stuff here (so accidental breaking changes to the interface can be noticed)
+constexpr auto custom_opt = ozo::make_options(ozo::transaction_options::isolation_level = ozo::isolation_level::serializable);
+[[maybe_unused]] constexpr auto custom_begin = ozo::begin.with_transaction_options(custom_opt);
+
+}


### PR DESCRIPTION
- currently only to ensure constexprness of begin_op customization

As discussed in #207 