### PR TITLE
Add std::pair external adaptation as 'record' of two fields

### DIFF
--- a/include/ozo/ext/std.h
+++ b/include/ozo/ext/std.h
@@ -15,6 +15,7 @@
 #include <ozo/ext/std/shared_ptr.h>
 #include <ozo/ext/std/string.h>
 #include <ozo/ext/std/tuple.h>
+#include <ozo/ext/std/pair.h>
 #include <ozo/ext/std/unique_ptr.h>
 #include <ozo/ext/std/vector.h>
 #include <ozo/ext/std/weak_ptr.h>

--- a/include/ozo/ext/std/pair.h
+++ b/include/ozo/ext/std/pair.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <ozo/pg/definitions.h>
+#include <utility>
+#include <boost/hana/ext/std/pair.hpp>
+
+/**
+ * @defgroup group-ext-std-pair std::pair
+ * @ingroup group-ext-std
+ * @brief [std::pair](https://en.cppreference.com/w/cpp/utility/pair) support
+ *
+ *@code
+#include <ozo/ext/std/pair.h>
+ *@endcode
+ *
+ * `std::pair<T1, T2>` is defined as a generic composite type of two elements
+ * and mapped as PostgreSQL `Record` type and its array.
+ */
+namespace ozo::definitions {
+
+template <typename ...Ts>
+struct type<std::pair<Ts...>> : pg::type_definition<decltype("record"_s)>{};
+
+template <typename ...Ts>
+struct array<std::pair<Ts...>> : pg::array_definition<decltype("record"_s)>{};
+
+} // namespace ozo::definitions
+
+namespace ozo {
+
+template <typename ...Ts>
+struct is_composite<std::pair<Ts...>> : std::true_type {};
+
+} // namespace ozo

--- a/tests/integration/result_integration.cpp
+++ b/tests/integration/result_integration.cpp
@@ -150,4 +150,19 @@ TEST(result, should_convert_in_rows_of_tuple_rows_of_records) {
     ));
 }
 
+TEST(result, should_convert_rows_of_records_in_rows_of_std_pairs) {
+    auto result = execute_query("SELECT * FROM (VALUES ((1, 'one'::text)), ((2, 'two'::text)), ((3, 'three'::text))) AS t (tuple);");
+    auto oid_map = ozo::empty_oid_map();
+
+    ozo::rows_of<std::pair<int, std::string>> out;
+
+    ozo::recv_result(result, oid_map, ozo::into(out));
+
+    EXPECT_THAT(out, ElementsAre(
+        std::make_tuple(std::make_pair(int(1), "one")),
+        std::make_tuple(std::make_pair(int(2), "two")),
+        std::make_tuple(std::make_pair(int(3), "three"))
+    ));
+}
+
 } // namespace


### PR DESCRIPTION
The `std::pair` type is adapted as a `RECORD` of two fields.