### PR TITLE
Use implicit deduction guides

### DIFF
--- a/benchmarks/ozo_benchmark.cpp
+++ b/benchmarks/ozo_benchmark.cpp
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
 
     rows_count_limit_benchmark benchmark(10000000);
     asio::io_context io(1);
-    ozo::connection_info<> connection_info(argv[1]);
+    ozo::connection_info connection_info(argv[1]);
     const auto query = ("SELECT typname, typnamespace, typowner, typlen, typbyval, typcategory, "_SQL +
                         "typispreferred, typisdefined, typdelim, typrelid, typelem, typarray "_SQL +
                         "FROM pg_type WHERE typtypmod = "_SQL +

--- a/benchmarks/performance.cpp
+++ b/benchmarks/performance.cpp
@@ -130,7 +130,7 @@ void use_connection_pool(const std::string& conn_string, Query query) {
     ozo::connection_pool_config config;
     config.capacity = 2;
     config.queue_capacity = 0;
-    auto pool = ozo::make_connection_pool(connection_info, config);
+    ozo::connection_pool pool(connection_info, config);
 
     spawn(io, 0, [&] (asio::yield_context yield) {
         while (true) {
@@ -155,7 +155,7 @@ void use_connection_pool_and_parse_result(const std::string& conn_string, Query 
     ozo::connection_pool_config config;
     config.capacity = 2;
     config.queue_capacity = 0;
-    auto pool = ozo::make_connection_pool(connection_info, config);
+    ozo::connection_pool pool(connection_info, config);
 
     spawn(io, 0, [&] (asio::yield_context yield) {
         while (true) {
@@ -180,7 +180,7 @@ void use_connection_pool_mult_connection(const std::string& conn_string, Query q
     ozo::connection_pool_config config;
     config.capacity = coroutines + 1;
     config.queue_capacity = 0;
-    auto pool = ozo::make_connection_pool(connection_info, config);
+    ozo::connection_pool pool(connection_info, config);
 
     for (std::size_t token = 0; token < coroutines; ++token) {
         spawn(io, 0, [&, token] (asio::yield_context yield) {
@@ -207,7 +207,7 @@ void use_connection_pool_and_parse_result_mult_connection(const std::string& con
     ozo::connection_pool_config config;
     config.capacity = coroutines + 1;
     config.queue_capacity = 0;
-    auto pool = ozo::make_connection_pool(connection_info, config);
+    ozo::connection_pool pool(connection_info, config);
 
     for (std::size_t token = 0; token < coroutines; ++token) {
         spawn(io, token, [&, token] (asio::yield_context yield) {
@@ -247,7 +247,7 @@ void use_connection_pool_mult_threads(const std::string& conn_string, Query quer
     config.capacity = connections;
     config.queue_capacity = queue_capacity;
     std::vector<std::unique_ptr<context>> contexts;
-    auto pool = ozo::make_connection_pool(connection_info, config);
+    ozo::connection_pool pool(connection_info, config);
     std::atomic_size_t finished_coroutines {0};
     std::mutex mutex;
     std::unique_lock<std::mutex> lock(mutex);

--- a/benchmarks/performance.cpp
+++ b/benchmarks/performance.cpp
@@ -40,7 +40,7 @@ void reuse_connection_info(const std::string& conn_string, Query query) {
 
     benchmark_t<1> benchmark;
     asio::io_context io(1);
-    ozo::connection_info<> connection_info(conn_string);
+    ozo::connection_info connection_info(conn_string);
 
     spawn(io, 0, [&] (asio::yield_context yield) {
         while (true) {
@@ -61,7 +61,7 @@ void reuse_connection_info_and_parse_result(const std::string& conn_string, Quer
 
     benchmark_t<1> benchmark;
     asio::io_context io(1);
-    ozo::connection_info<> connection_info(conn_string);
+    ozo::connection_info connection_info(conn_string);
 
     spawn(io, 0, [&] (asio::yield_context yield) {
         while (true) {
@@ -82,7 +82,7 @@ void reuse_connection(const std::string& conn_string, Query query) {
 
     benchmark_t<1> benchmark;
     asio::io_context io(1);
-    ozo::connection_info<> connection_info(conn_string);
+    ozo::connection_info connection_info(conn_string);
 
     spawn(io, 0, [&] (asio::yield_context yield) {
         auto connection = ozo::get_connection(connection_info[io], connect_timeout, yield);
@@ -104,7 +104,7 @@ void reuse_connection_and_parse_result(const std::string& conn_string, Query que
 
     benchmark_t<1> benchmark;
     asio::io_context io(1);
-    ozo::connection_info<> connection_info(conn_string);
+    ozo::connection_info connection_info(conn_string);
 
     spawn(io, 0, [&] (asio::yield_context yield) {
         auto connection = ozo::get_connection(connection_info[io], connect_timeout, yield);
@@ -126,7 +126,7 @@ void use_connection_pool(const std::string& conn_string, Query query) {
 
     benchmark_t<1> benchmark;
     asio::io_context io(1);
-    const ozo::connection_info<> connection_info(conn_string);
+    const ozo::connection_info connection_info(conn_string);
     ozo::connection_pool_config config;
     config.capacity = 2;
     config.queue_capacity = 0;
@@ -151,7 +151,7 @@ void use_connection_pool_and_parse_result(const std::string& conn_string, Query 
 
     benchmark_t<1> benchmark;
     asio::io_context io(1);
-    const ozo::connection_info<> connection_info(conn_string);
+    const ozo::connection_info connection_info(conn_string);
     ozo::connection_pool_config config;
     config.capacity = 2;
     config.queue_capacity = 0;
@@ -176,7 +176,7 @@ void use_connection_pool_mult_connection(const std::string& conn_string, Query q
 
     benchmark_t<coroutines> benchmark;
     asio::io_context io(1);
-    const ozo::connection_info<> connection_info(conn_string);
+    const ozo::connection_info connection_info(conn_string);
     ozo::connection_pool_config config;
     config.capacity = coroutines + 1;
     config.queue_capacity = 0;
@@ -203,7 +203,7 @@ void use_connection_pool_and_parse_result_mult_connection(const std::string& con
 
     benchmark_t<coroutines> benchmark;
     asio::io_context io(1);
-    const ozo::connection_info<> connection_info(conn_string);
+    const ozo::connection_info connection_info(conn_string);
     ozo::connection_pool_config config;
     config.capacity = coroutines + 1;
     config.queue_capacity = 0;
@@ -242,7 +242,7 @@ void use_connection_pool_mult_threads(const std::string& conn_string, Query quer
         << " queue_capacity=" << queue_capacity << std::endl;
 
     benchmark_t<coroutines * threads_number> benchmark;
-    const ozo::connection_info<> connection_info(conn_string);
+    const ozo::connection_info connection_info(conn_string);
     ozo::connection_pool_config config;
     config.capacity = connections;
     config.queue_capacity = queue_capacity;

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -39,7 +39,7 @@ int main() {
     ozo::rows_of<std::int64_t, std::optional<std::string>> rows;
 
     // Connection info with host and port to connect to
-    auto conn_info = ozo::make_connection_info("host=... port=...");
+    ozo::connection_info conn_info("host=... port=...");
 
     // For _SQL literal
     using namespace ozo::literals;
@@ -94,7 +94,7 @@ Note that in the example, the table is defined with the first (id) and third (am
 Note that it's acceptable to provide an `std::optional` for a _NOT NULL_ field, but it is not acceptable to omit the `std::optional` for a field that is not _NOT NULL_, unless you can gaurentee the retrieved data will not be _NULL_. Failure to properly use `std::optional` will lead to a run-time error in case of a _NULL_ value received from a database.
 
 ```cpp
-auto conn_info = ozo::make_connection_info("host=... port=...");
+ozo::connection_info conn_info("host=... port=...");
 ```
 
 Now we need to create a connection information for database to connect to. This is our connection source which can create a connection for us as it will be needed (you can learn more about ConnectionSource and ConnectionProvider concepts from the documentation). It's also acceptable to provide a connection URI string, instead of the comma seperated version.

--- a/examples/connection_pool.cpp
+++ b/examples/connection_pool.cpp
@@ -24,7 +24,7 @@ int main(int argc, char **argv) {
     //! [Creating Connection Pool]
 
     // To make a connection to a database we need to make a ConnectionSource.
-    auto connection_info = ozo::make_connection_info(argv[1]);
+    const ozo::connection_info connection_info(argv[1]);
 
     ozo::connection_pool_config connection_pool_config;
 

--- a/examples/connection_pool.cpp
+++ b/examples/connection_pool.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
     connection_pool_config.idle_timeout = std::chrono::seconds(60);
 
     // Creating connection pool from connection_info as the underlying ConnectionSource
-    auto connection_pool = ozo::make_connection_pool(connection_info, connection_pool_config);
+    ozo::connection_pool connection_pool(connection_info, connection_pool_config);
     //! [Creating Connection Pool]
 
     const auto coroutine = [&] (asio::yield_context yield) {

--- a/include/ozo/cancel.h
+++ b/include/ozo/cancel.h
@@ -106,7 +106,7 @@ ozo::io_context io;
 boost::asio::steady_timer timer(io);
 
 boost::asio::spawn(io, [&io, &timer](auto yield){
-    const auto conn_info = ozo::make_connection_info(OZO_PG_TEST_CONNINFO);
+    const ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
     ozo::error_code ec;
     auto conn = ozo::get_connection(conn_info[io], yield[ec]);
     assert(!ec);

--- a/include/ozo/connection_pool.h
+++ b/include/ozo/connection_pool.h
@@ -296,6 +296,8 @@ struct connection_traits<yamail::resource_pool::handle<Pool>> :
  */
 template <typename Source>
 class connection_pool {
+    static_assert(ConnectionSource<Source>, "should model ConnectionSource concept");
+
 public:
     using connection_rep_type = ozo::connection_rep<typename ozo::unwrap_type<ozo::connection_type<Source>>::oid_map_type>;
 
@@ -395,7 +397,6 @@ constexpr auto ConnectionPool = is_connection_pool<std::decay_t<T>>::value;
  */
 template <typename Source>
 auto make_connection_pool(Source&& source, const connection_pool_config& config) {
-    static_assert(ConnectionSource<Source>, "is not a ConnectionSource");
     return connection_pool<std::decay_t<Source>>{std::forward<Source>(source), config};
 }
 

--- a/include/ozo/type_traits.h
+++ b/include/ozo/type_traits.h
@@ -522,7 +522,7 @@ OZO_PG_DEFINE_CUSTOM_TYPE(custom_type, "code.custom_type")
 
 //...
 // Creating ConnectionSource for futher requests to a database
-const auto conn_source = ozo::make_connection_info("...", regiter_types<custom_type>());
+const ozo::connection_info conn_source("...", register_types<custom_type>());
  * @endcode
  *
  * @return `oid_map_t` object.

--- a/tests/connection_info.cpp
+++ b/tests/connection_info.cpp
@@ -7,7 +7,7 @@ namespace {
 
 TEST(connection_info, should_return_error_and_bad_connect_for_invalid_connection_info) {
     ozo::io_context io;
-    ozo::connection_info<> conn_info("invalid connection info");
+    ozo::connection_info conn_info("invalid connection info");
 
     ozo::get_connection(conn_info[io], [](ozo::error_code ec, auto conn){
         EXPECT_TRUE(ec);
@@ -16,6 +16,10 @@ TEST(connection_info, should_return_error_and_bad_connect_for_invalid_connection
     });
 
     io.run();
+}
+
+TEST(make_connection_info, should_not_throw) {
+    EXPECT_NO_THROW(ozo::make_connection_info("conn info string"));
 }
 
 } // namespace

--- a/tests/connection_pool.cpp
+++ b/tests/connection_pool.cpp
@@ -11,7 +11,7 @@ namespace {
 
 TEST(make_connection_pool, should_not_throw) {
     boost::asio::io_context io;
-    ozo::connection_info<> conn_info("conn info string");
+    ozo::connection_info conn_info("conn info string");
     const ozo::connection_pool_config config;
     EXPECT_NO_THROW(ozo::make_connection_pool(conn_info, config));
 }

--- a/tests/integration/cancel_integration.cpp
+++ b/tests/integration/cancel_integration.cpp
@@ -28,7 +28,7 @@ TEST(cancel, should_cancel_operation) {
     boost::asio::steady_timer timer(io);
 
     boost::asio::spawn(io, [&io, &timer](auto yield){
-        const auto conn_info = ozo::make_connection_info(OZO_PG_TEST_CONNINFO);
+        const ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
         ozo::error_code ec;
         auto conn = ozo::get_connection(conn_info[io], yield[ec]);
         EXPECT_FALSE(ec);
@@ -61,7 +61,7 @@ TEST(cancel, should_stop_cancel_operation_on_zero_timeout) {
     boost::asio::steady_timer timer(io);
 
     boost::asio::spawn(io, [&io, &timer, &dummy_io](auto yield){
-        const auto conn_info = ozo::make_connection_info(OZO_PG_TEST_CONNINFO);
+        const ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
         ozo::error_code ec;
         auto conn = ozo::get_connection(conn_info[io], yield[ec]);
         EXPECT_FALSE(ec);

--- a/tests/integration/execute_integration.cpp
+++ b/tests/integration/execute_integration.cpp
@@ -12,7 +12,7 @@ TEST(execute, should_perform_operation_without_result) {
     using namespace ozo::literals;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
 
     ozo::execute(conn_info[io], "BEGIN"_SQL,
         [&](ozo::error_code ec, auto conn) {

--- a/tests/integration/get_connection_integration.cpp
+++ b/tests/integration/get_connection_integration.cpp
@@ -7,7 +7,7 @@ namespace {
 
 TEST(get_connection, should_return_timeout_error_for_zero_connect_timeout) {
     ozo::io_context io;
-    const ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    const ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
     const std::chrono::seconds timeout(0);
 
     std::atomic_flag called {};
@@ -23,7 +23,7 @@ TEST(get_connection, should_return_timeout_error_for_zero_connect_timeout) {
 
 TEST(get_connection, should_return_connection_for_max_connect_timeout) {
     ozo::io_context io;
-    const ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    const ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
     const auto timeout = ozo::time_traits::duration::max();
 
     std::atomic_flag called {};

--- a/tests/integration/request_integration.cpp
+++ b/tests/integration/request_integration.cpp
@@ -97,7 +97,7 @@ TEST(request, should_return_error_and_bad_connect_for_invalid_connection_info) {
     using namespace hana::literals;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info("invalid connection info");
+    ozo::connection_info conn_info("invalid connection info");
 
     ozo::result res;
     ozo::request(conn_info[io], "SELECT 1"_SQL + " + 1"_SQL, std::ref(res),
@@ -114,7 +114,7 @@ TEST(request, should_return_selected_variable) {
     using namespace hana::literals;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
 
     ozo::result res;
     const std::string foo = "foo";
@@ -135,7 +135,7 @@ TEST(request, should_return_selected_string_array) {
     using namespace hana::literals;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
 
     const std::vector<std::string> foos = {"foo", "buzz", "bar"};
 
@@ -156,7 +156,7 @@ TEST(request, should_return_selected_int_array) {
     using namespace hana::literals;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
 
     const std::vector<int32_t> foos = {1, 22, 333};
 
@@ -178,7 +178,7 @@ TEST(request, should_fill_oid_map_when_oid_map_is_not_empty) {
 
     ozo::io_context io;
     constexpr const auto oid_map = ozo::register_types<custom_type>();
-    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
     ozo::connection_info<std::decay_t<decltype(oid_map)>> conn_info_with_oid_map(OZO_PG_TEST_CONNINFO);
 
     asio::spawn(io, [&] (asio::yield_context yield) {
@@ -200,7 +200,7 @@ TEST(request, should_request_with_connection_pool) {
     namespace asio = boost::asio;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
     const ozo::connection_pool_config config;
     ozo::connection_pool pool(conn_info, config);
     asio::spawn(io, [&] (asio::yield_context yield) {
@@ -218,7 +218,7 @@ TEST(request, should_call_handler_with_error_for_zero_timeout) {
     namespace asio = boost::asio;
 
     ozo::io_context io;
-    const ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    const ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
     const ozo::time_traits::duration timeout(0);
 
     ozo::result res;
@@ -238,7 +238,7 @@ TEST(request, should_return_result_for_max_timeout) {
     namespace asio = boost::asio;
 
     ozo::io_context io;
-    const ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    const ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
     const auto timeout = ozo::time_traits::duration::max();
 
     rows_of<std::int32_t> res;
@@ -262,7 +262,7 @@ TEST(request, should_return_custom_composite) {
 
     asio::spawn(io, [&] (asio::yield_context yield) {
         [&] {
-            const auto conn_info = ozo::make_connection_info(OZO_PG_TEST_CONNINFO);
+            const ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
             ozo::error_code ec{};
             auto conn = ozo::execute(conn_info[io],
                 "DROP TYPE IF EXISTS custom_type"_SQL, yield[ec]);
@@ -271,7 +271,7 @@ TEST(request, should_return_custom_composite) {
             ASSERT_REQUEST_OK(ec, conn);
         }();
 
-        const auto conn_info = ozo::make_connection_info(
+        const ozo::connection_info conn_info(
             OZO_PG_TEST_CONNINFO,
             ozo::register_types<custom_type>());
 
@@ -301,7 +301,7 @@ TEST(request, should_send_custom_composite) {
 
     asio::spawn(io, [&] (asio::yield_context yield) {
         [&] {
-            const auto conn_info = ozo::make_connection_info(OZO_PG_TEST_CONNINFO);
+            const ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
             ozo::error_code ec{};
             auto conn = ozo::execute(conn_info[io],
                 "DROP TYPE IF EXISTS custom_type"_SQL, yield[ec]);
@@ -310,7 +310,7 @@ TEST(request, should_send_custom_composite) {
             ASSERT_REQUEST_OK(ec, conn);
         }();
 
-        const auto conn_info = ozo::make_connection_info(
+        const ozo::connection_info conn_info(
             OZO_PG_TEST_CONNINFO,
             ozo::register_types<custom_type>());
 
@@ -338,7 +338,7 @@ TEST(result, should_send_bytea_properly) {
     using namespace boost::hana::literals;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
 
     std::vector<std::tuple<ozo::pg::bytea>> res;
     const std::string foo = "foo";
@@ -362,7 +362,7 @@ TEST(request, should_send_empty_optional) {
     namespace asio = boost::asio;
 
     ozo::io_context io;
-    const ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    const ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
     const auto timeout = ozo::time_traits::duration::max();
     OZO_STD_OPTIONAL<std::int32_t> value;
 
@@ -386,7 +386,7 @@ TEST(request, should_send_and_receive_empty_optional) {
     namespace asio = boost::asio;
 
     ozo::io_context io;
-    const ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    const ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
     const auto timeout = ozo::time_traits::duration::max();
     OZO_STD_OPTIONAL<std::int32_t> value;
 
@@ -409,7 +409,7 @@ TEST(request, should_send_and_receive_interval) {
     const auto interval = ozo::pg::interval(239278272013014LL);
 
     ozo::io_context io;
-    const ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    const ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
 
     ozo::rows_of<ozo::pg::interval> result;
     auto query = "SELECT '2769 days 10 hours 11 minutes 12 seconds 13014 microseconds'::interval + "_SQL + interval;
@@ -430,7 +430,7 @@ TEST(request, should_send_and_receive_composite_with_empty_optional) {
 
     asio::spawn(io, [&] (asio::yield_context yield) {
         [&] {
-            const auto conn_info = ozo::make_connection_info(OZO_PG_TEST_CONNINFO);
+            const ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
             ozo::error_code ec;
             auto conn = ozo::execute(conn_info[io],
                 "DROP TYPE IF EXISTS with_optional"_SQL, yield[ec]);
@@ -439,7 +439,7 @@ TEST(request, should_send_and_receive_composite_with_empty_optional) {
             ASSERT_REQUEST_OK(ec, conn);
         } ();
 
-        const auto conn_info = ozo::make_connection_info(
+        const ozo::connection_info conn_info(
             OZO_PG_TEST_CONNINFO,
             ozo::register_types<with_optional>()
         );
@@ -465,7 +465,7 @@ TEST(request, should_send_and_receive_jsonb) {
     namespace asio = boost::asio;
 
     ozo::io_context io;
-    const ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    const ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
     const auto timeout = ozo::time_traits::duration::max();
     std::string value = R"({"foo": "bar"})";
 
@@ -492,7 +492,7 @@ TEST(request, should_send_and_receive_composite_with_jsonb_field) {
 
     asio::spawn(io, [&] (asio::yield_context yield) {
         [&] {
-            const auto conn_info = ozo::make_connection_info(OZO_PG_TEST_CONNINFO);
+            const ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
             ozo::error_code ec;
             auto conn = ozo::execute(conn_info[io],
                 "DROP TYPE IF EXISTS with_jsonb"_SQL, yield[ec]);
@@ -501,7 +501,7 @@ TEST(request, should_send_and_receive_composite_with_jsonb_field) {
             ASSERT_REQUEST_OK(ec, conn);
         } ();
 
-        const auto conn_info = ozo::make_connection_info(
+        const ozo::connection_info conn_info(
             OZO_PG_TEST_CONNINFO,
             ozo::register_types<with_jsonb>()
         );

--- a/tests/integration/request_integration.cpp
+++ b/tests/integration/request_integration.cpp
@@ -202,7 +202,7 @@ TEST(request, should_request_with_connection_pool) {
     ozo::io_context io;
     ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
     const ozo::connection_pool_config config;
-    auto pool = ozo::make_connection_pool(conn_info, config);
+    ozo::connection_pool pool(conn_info, config);
     asio::spawn(io, [&] (asio::yield_context yield) {
         ozo::result result;
         ozo::error_code ec{};

--- a/tests/integration/transaction_integration.cpp
+++ b/tests/integration/transaction_integration.cpp
@@ -19,7 +19,7 @@ TEST(transaction, create_schema_in_transaction_and_commit_then_table_should_exis
     using namespace ozo::literals;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
 
     asio::spawn(io, [&] (asio::yield_context yield) {
         auto transaction = ozo::begin(conn_info[io], yield);
@@ -38,7 +38,7 @@ TEST(transaction, create_schema_in_transaction_and_rollback_then_table_should_no
     using namespace ozo::literals;
 
     ozo::io_context io;
-    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
 
     asio::spawn(io, [&] (asio::yield_context yield) {
         auto transaction = ozo::begin(conn_info[io], yield);
@@ -56,7 +56,7 @@ TEST(transaction, create_schema_in_transaction_and_rollback_then_table_should_no
 
 TEST(transaction, transaction_level_options_should_not_cause_sql_syntax_errors) {
     ozo::io_context io;
-    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
 
     asio::spawn(io, [&] (asio::yield_context yield) {
         auto level = ozo::isolation_level::serializable;
@@ -123,7 +123,7 @@ TEST(transaction, transaction_level_options_should_not_cause_sql_syntax_errors) 
 
 TEST(transaction, transaction_mode_options_should_not_cause_sql_syntax_errors) {
     ozo::io_context io;
-    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
 
     asio::spawn(io, [&] (asio::yield_context yield) {
         auto mode = ozo::transaction_mode::read_write;
@@ -161,7 +161,7 @@ TEST(transaction, transaction_mode_options_should_not_cause_sql_syntax_errors) {
 TEST(transaction, transaction_deferrability_options_should_not_generate_syntax_errors) {
     using ozo::transaction_options;
     ozo::io_context io;
-    ozo::connection_info<> conn_info(OZO_PG_TEST_CONNINFO);
+    ozo::connection_info conn_info(OZO_PG_TEST_CONNINFO);
 
     asio::spawn(io, [&] (asio::yield_context yield) {
         auto defer = ozo::deferrable;


### PR DESCRIPTION
Avoid using unnecessary functions like `make_*` that are only required for type deduction. C++17 provides the same feature for constructors.