### PR TITLE
Use Boost.Hana as a primary mechanism for structures adaptation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ These things are needed:
 * **GCC** or **Clang** C++ compiler with C++17 support (tested with GCC 7.0, Clang 5.0 and Apple LLVM version 9.0.0)
 * **Boost** >= 1.66 with `BOOST_HANA_CONFIG_ENABLE_STRING_UDL` defined.
 * **libpq** >= 9.3
+* Ozo uses the [resource_pool](https://github.com/elsid/resource_pool) library as a git submodule, so in case of using a package version, this dependency should be satisfied too.
 
 If you want to run integration tests and/or build inside Docker container:
 * **Docker** >= 1.13.0

--- a/benchmarks/benchmark.h
+++ b/benchmarks/benchmark.h
@@ -271,6 +271,6 @@ struct pg_type {
 
 } // namespace ozo::benchmark
 
-BOOST_FUSION_ADAPT_STRUCT(ozo::benchmark::pg_type,
+BOOST_HANA_ADAPT_STRUCT(ozo::benchmark::pg_type,
     typname, typnamespace, typowner, typlen, typbyval, typcategory,
-    typispreferred, typisdefined, typdelim, typrelid, typelem, typarray)
+    typispreferred, typisdefined, typdelim, typrelid, typelem, typarray);

--- a/docs/howto.md
+++ b/docs/howto.md
@@ -3,12 +3,12 @@
 Here are some examples of how to use OZO API.
 
 <!-- TOC -->
-- [How to](#How-to)
-  - [How To Make A Very Simple Request](#How-To-Make-A-Very-Simple-Request)
-  - [How To Handle Error Properly](#How-To-Handle-Error-Properly)
-  - [How To Map Column Names to Column Numbers At Compile Time](#How-To-Map-Column-Names-to-Column-Numbers-At-Compile-Time)
-  - [How To Determine Which Type Do I Need To Use For The PostgreSQL Type](#How-To-Determine-Which-Type-Do-I-Need-To-Use-For-The-PostgreSQL-Type)
-  - [How To Bind One More PostgreSQL Type For C++ Type With Existing Binding](#How-To-Bind-One-More-PostgreSQL-Type-For-C-Type-With-Existing-Binding)
+- [How to](#how-to)
+  - [How To Make A Very Simple Request](#how-to-make-a-very-simple-request)
+  - [How To Handle Error Properly](#how-to-handle-error-properly)
+  - [How To Map Column Names to Column Numbers At Compile Time](#how-to-map-column-names-to-column-numbers-at-compile-time)
+  - [How To Determine Which Type Do I Need To Use For The PostgreSQL Type](#how-to-determine-which-type-do-i-need-to-use-for-the-postgresql-type)
+  - [How To Bind One More PostgreSQL Type For C++ Type With Existing Binding](#how-to-bind-one-more-postgresql-type-for-c-type-with-existing-binding)
 
 ## How To Make A Very Simple Request
 
@@ -173,10 +173,12 @@ const auto query = "SELECT id, name FROM users_info WHERE amount>="_SQL + std::i
 If we interchange `id` and `name` in the query text we will get a run-time error. To be more robust to changes in the ordering of columns returned from the database, we can use Boost.Fusion to map column names to positions.
 
 ```cpp
-BOOST_FUSION_DEFINE_STRUCT((), my_row,
-    (std::int64_t, id)
-    (std::optional<std::string>, name)
-)
+struct my_row {
+    std::int64_t id;
+    std::optional<std::string> name;
+};
+
+BOOST_HANA_ADAPT_STRUCT(my_row, id, name);
 
 int main() {
 
@@ -197,6 +199,8 @@ int main() {
 ```
 
 In this example, you can change the order of the fields in either `my_row` or your database query freely, as the fields are identified based on their name, and not based on their index in the tuple.
+
+ > **Note:** you may use `BOOST_FUSION_ADAPT_STRUCT` and all of the `Boost.Fusion` adaptation mechanisms for structures, but it is recommended to use `Boost.Hana` for a faster and more modern approach.
 
 ---
 

--- a/tests/integration/request_integration.cpp
+++ b/tests/integration/request_integration.cpp
@@ -68,9 +68,9 @@ static std::ostream& operator <<(std::ostream& s, const with_jsonb& v) {
 
 } // namespace ozo::tests
 
-BOOST_FUSION_ADAPT_STRUCT(ozo::tests::custom_type, number, text)
-BOOST_FUSION_ADAPT_STRUCT(ozo::tests::with_optional, value)
-BOOST_FUSION_ADAPT_STRUCT(ozo::tests::with_jsonb, value)
+BOOST_HANA_ADAPT_STRUCT(ozo::tests::custom_type, number, text);
+BOOST_HANA_ADAPT_STRUCT(ozo::tests::with_optional, value);
+BOOST_HANA_ADAPT_STRUCT(ozo::tests::with_jsonb, value);
 
 OZO_PG_DEFINE_CUSTOM_TYPE(ozo::tests::custom_type, "custom_type")
 OZO_PG_DEFINE_CUSTOM_TYPE(ozo::tests::with_optional, "with_optional")


### PR DESCRIPTION
#203 - replacing `BOOST_FUSION_ADAPT_STRUCT` with `BOOST_HANA_ADAPT_STRUCT`.
#215 - add resource_pool to the dependency list in README.md