### PR TITLE
Fix Travis build for macos by unlinking python@2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ matrix:
     osx_image: xcode10
     install:
     - brew update
+    - brew unlink python@2
     - brew upgrade boost
     #- brew upgrade postgresql
     - brew upgrade cmake


### PR DESCRIPTION
```
==> Pouring python-3.7.6_1.high_sierra.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink Frameworks/Python.framework/Headers
Target /usr/local/Frameworks/Python.framework/Headers
is a symlink belonging to python@2. You can unlink it:
  brew unlink python@2

To force the link and overwrite all conflicting files:
  brew link --overwrite python

To list all files that would be deleted:
  brew link --overwrite --dry-run python
```