### PR TITLE
Fix build

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,10 +1,16 @@
-FROM ubuntu:18.10
+FROM ubuntu:18.04
+
+RUN apt-get update && \
+    apt-get install -y apt-transport-https ca-certificates gnupg software-properties-common wget
+
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -
+
+RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
 
 RUN apt-get update && \
     apt-get install -y \
         ccache \
         clang-7 \
-        cmake \
         curl \
         g++-8 \
         git \
@@ -16,7 +22,7 @@ RUN apt-get update && \
         python-openssl \
         python-pip \
         python-yaml \
-        wget \
+        cmake \
         doxygen \
         && \
     rm -rf /var/lib/apt/lists/*

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,6 +77,7 @@ endif()
 
 add_executable(ozo_tests ${SOURCES})
 add_dependencies(ozo_tests GoogleTest)
+target_link_libraries(ozo_tests gtest)
 target_link_libraries(ozo_tests gmock)
 target_link_libraries(ozo_tests ozo)
 add_test(ozo_tests ozo_tests)


### PR DESCRIPTION
Downgrade image to Ubuntu 18.04 LTS
Add missing dependency to gtest (which is really missing with newer versions of gtest)