### PR TITLE
Add share ability for ozo::result

### DIFF
--- a/include/ozo/io/recv.h
+++ b/include/ozo/io/recv.h
@@ -351,8 +351,8 @@ basic_result<T>& recv_result(basic_result<T>& in, const OidMap&, basic_result<T>
     return out;
 }
 
-template <typename T, typename OidMap>
-basic_result<T>& recv_result(basic_result<T>& in, const OidMap& oid_map, std::reference_wrapper<basic_result<T>> out) {
+template <typename T, typename OidMap, typename Out>
+basic_result<T>& recv_result(basic_result<T>& in, const OidMap& oid_map, std::reference_wrapper<Out> out) {
     return recv_result(in, oid_map, out.get());
 }
 

--- a/include/ozo/pg/handle.h
+++ b/include/ozo/pg/handle.h
@@ -11,7 +11,7 @@ struct safe_handle;
 template<>
 struct safe_handle<::PGresult> {
     struct deleter {
-        void operator() (::PGresult *ptr) const { ::PQclear(ptr); }
+        void operator() (::PGresult *ptr) const noexcept { ::PQclear(ptr); }
     };
     using type = std::unique_ptr<::PGresult, deleter>;
 };
@@ -19,7 +19,7 @@ struct safe_handle<::PGresult> {
 template <>
 struct safe_handle<::PGconn> {
     struct deleter {
-        void operator() (::PGconn *ptr) const { ::PQfinish(ptr); }
+        void operator() (::PGconn *ptr) const noexcept { ::PQfinish(ptr); }
     };
     using type = std::unique_ptr<::PGconn, deleter>;
 };
@@ -28,7 +28,9 @@ template <typename T>
 using safe_handle_t = typename safe_handle<T>::type;
 
 template <typename T>
-safe_handle_t<T> make_safe(T* handle) { return safe_handle_t<T>{handle};}
+safe_handle_t<T> make_safe(T* handle) noexcept(noexcept(safe_handle_t<T>{handle})) {
+    return safe_handle_t<T>{handle};
+}
 
 using conn = safe_handle_t<::PGconn>;
 

--- a/include/ozo/pg/handle.h
+++ b/include/ozo/pg/handle.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <libpq-fe.h>
+#include <boost/hana/core/to.hpp>
 #include <memory>
 
 namespace ozo::pg {
@@ -36,4 +37,17 @@ using conn = safe_handle_t<::PGconn>;
 
 using result = pg::safe_handle_t<::PGresult>;
 
+using shared_result = std::shared_ptr<::PGresult>;
+
 } // namespace ozo::pg
+
+namespace boost::hana {
+
+template <>
+struct to_impl<ozo::pg::shared_result, ozo::pg::result> {
+    static ozo::pg::shared_result apply(ozo::pg::result x) {
+        return {x.release(), x.get_deleter()};
+    }
+};
+
+} // namespace boost::hana

--- a/include/ozo/result.h
+++ b/include/ozo/result.h
@@ -101,16 +101,6 @@ private:
     coordinates v_;
 };
 
-template <typename T, typename Result>
-inline const T* data(const value<Result>& v) noexcept {
-    return reinterpret_cast<const T*>(v.data());
-}
-
-template <typename T, typename Result>
-inline std::size_t size(const value<Result>& v) noexcept {
-    return v.size();
-}
-
 /**
  * @brief Database request result row proxy
  *

--- a/include/ozo/result.h
+++ b/include/ozo/result.h
@@ -30,7 +30,7 @@ public:
         int col;
     };
 
-    value(const coordinates& v) : v_(v) {}
+    value(const coordinates& v) noexcept : v_(v) {}
 
     /**
      * Get value type OID
@@ -144,7 +144,7 @@ public:
     > {
     public:
         const_iterator() = default;
-        const_iterator(const coordinates& v) : v_{v} {}
+        const_iterator(const coordinates& v) noexcept : v_{v} {}
 
     private:
         value dereference() const noexcept { return {v_}; }
@@ -169,7 +169,7 @@ public:
      */
     using iterator = const_iterator;
 
-    row(const coordinates& first) : first_(first) {}
+    row(const coordinates& first) noexcept : first_(first) {}
 
     /**
      * Iterator on the first of row values sequence.
@@ -221,7 +221,7 @@ public:
      * @return `true` --- no values in the row, `size() == 0`, `begin() == end()`.
      * @return `false` --- row is not empty, `size() > 0`, `begin() != end()`.
      */
-    bool empty() const noexcept { return size() == 0; }
+    [[nodiscard]] bool empty() const noexcept { return size() == 0; }
 
     /**
      * Get value by field index with range check
@@ -298,7 +298,7 @@ public:
     > {
     public:
         const_iterator() = default;
-        const_iterator(const coordinates& v) : v_{v} {}
+        const_iterator(const coordinates& v) noexcept : v_{v} {}
 
     private:
         row dereference() const noexcept { return {v_}; }
@@ -325,7 +325,8 @@ public:
     using iterator = const_iterator;
 
     basic_result() = default;
-    basic_result(handle_type res) : res_(std::move(res)) {}
+    basic_result(handle_type res) noexcept(noexcept(handle_type(std::move(res))))
+    : res_(std::move(res)) {}
 
     /**
      * Iterator on the first row of the result.
@@ -354,7 +355,7 @@ public:
      * @return `true` --- no ros in the result, `size() == 0`, `begin() == end()`.
      * @return `false` --- row is not empty, `size() > 0`, `begin() != end()`.
      */
-    bool empty() const noexcept { return size() == 0; }
+    [[nodiscard]] bool empty() const noexcept { return size() == 0; }
 
     /**
      * Get row by index.

--- a/tests/result.cpp
+++ b/tests/result.cpp
@@ -186,6 +186,15 @@ struct basic_result : Test {
     ozo::basic_result<pg_result_mock*> result{&mock};
 };
 
+TEST_F(basic_result, valid_should_return_true_for_constructed_with_handle) {
+    EXPECT_TRUE(result.valid());
+}
+
+TEST_F(basic_result, valid_should_return_false_for_constructed_with_null_handle) {
+    ozo::basic_result<pg_result_mock*> result{nullptr};
+    EXPECT_FALSE(result.valid());
+}
+
 TEST_F(basic_result, empty_should_return_true_if_pg_ntuples_returns_0) {
     EXPECT_CALL(mock, ntuples()).WillOnce(Return(0));
 


### PR DESCRIPTION
Initially `ozo::result` is not copyable object, but sometimes it is better to have copyable result object. This is solved via `ozo::shared_result` object which may be copyable. Shared result may be obtained via `ozo::result::share()` member function.