### PR TITLE
Support benchmark parameters as process args and different output formats

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -8,6 +8,8 @@ endif()
 add_executable(ozo_benchmark ozo_benchmark.cpp)
 target_link_libraries(ozo_benchmark ozo)
 
+find_package(Boost COMPONENTS coroutine context system thread atomic program_options REQUIRED)
+
 # enable a bunch of warnings and make them errors
 target_compile_options(ozo_benchmark PRIVATE -Wall -Wextra -Wsign-compare -pedantic -Werror)
 
@@ -18,6 +20,7 @@ endif()
 
 add_executable(ozo_benchmark_performance performance.cpp)
 target_link_libraries(ozo_benchmark_performance ozo)
+target_link_libraries(ozo_benchmark_performance Boost::program_options)
 
 # enable a bunch of warnings and make them errors
 target_compile_options(ozo_benchmark_performance PRIVATE -Wall -Wextra -Wsign-compare -pedantic -Werror)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -10,6 +10,19 @@ target_link_libraries(ozo_benchmark ozo)
 
 find_package(Boost COMPONENTS coroutine context system thread atomic program_options REQUIRED)
 
+include(ExternalProject)
+ExternalProject_Add(
+    NlohmannJson
+    GIT_REPOSITORY "https://github.com/nlohmann/json.git"
+    GIT_TAG v3.7.3
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR} -DBUILD_TESTING=OFF
+    UPDATE_COMMAND ""
+    LOG_DOWNLOAD ON
+    LOG_CONFIGURE ON
+    LOG_BUILD ON
+)
+include_directories(SYSTEM ${CMAKE_CURRENT_BINARY_DIR}/include)
+
 # enable a bunch of warnings and make them errors
 target_compile_options(ozo_benchmark PRIVATE -Wall -Wextra -Wsign-compare -pedantic -Werror)
 
@@ -19,6 +32,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 endif()
 
 add_executable(ozo_benchmark_performance performance.cpp)
+add_dependencies(ozo_benchmark_performance NlohmannJson)
 target_link_libraries(ozo_benchmark_performance ozo)
 target_link_libraries(ozo_benchmark_performance Boost::program_options)
 

--- a/benchmarks/benchmark.h
+++ b/benchmarks/benchmark.h
@@ -160,6 +160,10 @@ public:
         }
     }
 
+    void set_print_progress(bool value) {
+        print_progress = value;
+    }
+
     bool step(std::size_t rows_count, std::size_t token = 0) {
         if (finished) {
             return false;
@@ -217,6 +221,7 @@ private:
     std::chrono::steady_clock::time_point next_print = start + std::chrono::seconds(1);
     std::chrono::steady_clock::time_point step_start = start;
     std::vector<std::chrono::steady_clock::time_point> request_start;
+    bool print_progress = false;
 
     bool step_impl() {
         finish = std::chrono::steady_clock::now();
@@ -233,12 +238,14 @@ private:
             total_requests_count += step_count;
             total_rows_count += step_rows_count;
             const auto total_duration = finish - start;
-            std::cout << total_requests_count << " requests done in "
-                      << std::chrono::duration_cast<double_s>(total_duration).count() << " seconds, "
-                      << std::setprecision(4) << std::fixed << requests_per_second << " req/sec "
-                      << total_rows_count << " rows read "
-                      << std::setprecision(4) << std::fixed << rows_per_second << " row/sec"
-                      << std::endl;
+            if (print_progress) {
+                std::cout << total_requests_count << " requests done in "
+                          << std::chrono::duration_cast<double_s>(total_duration).count() << " seconds, "
+                          << std::setprecision(4) << std::fixed << requests_per_second << " req/sec "
+                          << total_rows_count << " rows read "
+                          << std::setprecision(4) << std::fixed << rows_per_second << " row/sec"
+                          << std::endl;
+            }
             if (total_duration > max_duration) {
                 finished = true;
                 return false;

--- a/benchmarks/benchmark.h
+++ b/benchmarks/benchmark.h
@@ -205,11 +205,11 @@ private:
     std::mutex step_mutex;
     std::chrono::steady_clock::duration max_duration;
     std::size_t total_requests_count = 0;
-    volatile std::size_t modulo = 1;
+    std::atomic<std::size_t> modulo {1};
     std::atomic<std::size_t> step_count {0};
     std::atomic<std::size_t> step_rows_count {0};
     std::size_t total_rows_count = 0;
-    volatile bool finished = false;
+    std::atomic<bool> finished {false};
     std::chrono::steady_clock::time_point finish;
     std::vector<step_t> steps;
     std::vector<std::chrono::steady_clock::duration> requests;

--- a/benchmarks/benchmark.h
+++ b/benchmarks/benchmark.h
@@ -77,6 +77,15 @@ std::ostream& operator <<(std::ostream& stream, std::chrono::steady_clock::durat
     return stream;
 }
 
+template <typename T>
+std::ostream& operator <<(std::ostream& stream, const OZO_STD_OPTIONAL<T>& value) {
+    if (value) {
+        return stream << *value;
+    } else {
+        return stream << "null";
+    }
+}
+
 class rows_count_limit_benchmark {
 public:
     rows_count_limit_benchmark(const std::size_t max_rows_count)
@@ -104,7 +113,7 @@ public:
     ~rows_count_limit_benchmark() {
         using double_s = std::chrono::duration<double, std::ratio<1>>;
         if (start_time && finish) {
-            std::cout << "read " << total_rows_count << " rows, "
+            std::cerr << "read " << total_rows_count << " rows, "
                       << std::setprecision(3) << std::fixed
                       << (total_rows_count / std::chrono::duration_cast<double_s>(*finish - *start_time).count())
                       << " row/sec" << std::endl;
@@ -118,46 +127,56 @@ private:
     std::size_t total_rows_count;
 };
 
+struct step {
+    std::chrono::steady_clock::duration duration;
+    std::size_t requests_count;
+    std::size_t rows_count;
+};
+
+struct output {
+    std::vector<std::chrono::steady_clock::duration> requests;
+    std::vector<step> steps;
+};
+
+struct stats {
+    OZO_STD_OPTIONAL<std::chrono::steady_clock::duration> mean_request_time;
+    OZO_STD_OPTIONAL<std::chrono::steady_clock::duration> median_request_time;
+    OZO_STD_OPTIONAL<std::chrono::steady_clock::duration> q90_request_time;
+    OZO_STD_OPTIONAL<std::chrono::steady_clock::duration> min_request_time;
+    OZO_STD_OPTIONAL<std::chrono::steady_clock::duration> max_request_time;
+    double mean_request_speed;
+    OZO_STD_OPTIONAL<double> median_request_speed;
+    OZO_STD_OPTIONAL<double> min_request_speed;
+    OZO_STD_OPTIONAL<double> max_request_speed;
+    double mean_read_rows_speed;
+    OZO_STD_OPTIONAL<double> median_read_rows_speed;
+    OZO_STD_OPTIONAL<double> min_read_rows_speed;
+    OZO_STD_OPTIONAL<double> max_read_rows_speed;
+};
+
+std::ostream& operator <<(std::ostream& stream, const stats& value) {
+    stream << "mean request time: " << value.mean_request_time << '\n';
+    stream << "median request time: " << value.median_request_time << '\n';
+    stream << "q90 request time: " << value.q90_request_time << '\n';
+    stream << "min request time: " << value.min_request_time << '\n';
+    stream << "max request time: " << value.max_request_time << '\n';
+    stream << "mean requests speed: " << value.mean_request_speed << " req/sec" << '\n';
+    stream << "median requests speed: " << value.median_request_speed << " req/sec" << '\n';
+    stream << "min requests speed: " << value.min_request_speed << " req/sec" << '\n';
+    stream << "max requests speed: " << value.max_request_speed << " req/sec" << '\n';
+    stream << "mean read rows speed: " << value.mean_read_rows_speed << " row/sec" << '\n';
+    stream << "median read rows speed: " << value.median_read_rows_speed << " row/sec" << '\n';
+    stream << "min read rows speed: " << value.min_read_rows_speed << " row/sec" << '\n';
+    stream << "max read rows speed: " << value.max_read_rows_speed << " row/sec" << '\n';
+    return stream;
+}
+
 class time_limit_benchmark {
 public:
     time_limit_benchmark(std::size_t coroutines, std::chrono::steady_clock::duration max_duration = std::chrono::seconds(31))
             : max_duration(max_duration), request_start(coroutines, start) {
-        steps.reserve(100);
+        steps.reserve(1000);
         requests.reserve(1000000);
-    }
-
-    ~time_limit_benchmark() {
-        using double_s = std::chrono::duration<double, std::ratio<1>>;
-        if (!requests.empty()) {
-            boost::sort(requests);
-            std::cout << "mean request time: " << boost::accumulate(requests, std::chrono::steady_clock::duration()) / requests.size() << std::endl;
-            std::cout << "median request time: " << requests[requests.size() / 2 + 1] << std::endl;
-            std::cout << "q90 request time: " << requests[requests.size() * 9 / 10] << std::endl;
-            std::cout << "min request time: " << requests.front() << std::endl;
-            std::cout << "max request time: " << requests.back() << std::endl;
-        }
-        std::cout << "mean requests speed: " << total_requests_count / std::chrono::duration_cast<double_s>(finish - start).count()
-                  << " req/sec" << std::endl;
-        std::vector<double> requests_speeds;
-        if (!steps.empty()) {
-            boost::transform(steps, std::back_inserter(requests_speeds),
-                [] (const auto& v) { return v.requests_count / std::chrono::duration_cast<double_s>(v.duration).count(); });
-            boost::sort(requests_speeds);
-            std::cout << "median requests speed: " << requests_speeds[requests_speeds.size() / 2 + 1] << " req/sec" << std::endl;
-            std::cout << "min requests speed: " << requests_speeds.front() << " req/sec" << std::endl;
-            std::cout << "max requests speed: " << requests_speeds.back() << " req/sec" << std::endl;
-        }
-        std::cout << "mean read rows speed: " << total_rows_count / std::chrono::duration_cast<double_s>(finish - start).count()
-                  << " row/sec" << std::endl;
-        std::vector<double> rows_speeds;
-        if (!steps.empty()) {
-            boost::transform(steps, std::back_inserter(rows_speeds),
-                [] (const auto& v) { return v.rows_count / std::chrono::duration_cast<double_s>(v.duration).count(); });
-            boost::sort(rows_speeds);
-            std::cout << "median read rows speed: " << rows_speeds[rows_speeds.size() / 2 + 1] << " row/sec" << std::endl;
-            std::cout << "min read rows speed: " << rows_speeds.front() << " row/sec" << std::endl;
-            std::cout << "max read rows speed: " << rows_speeds.back() << " row/sec" << std::endl;
-        }
     }
 
     void set_print_progress(bool value) {
@@ -198,13 +217,49 @@ public:
         return true;
     }
 
-private:
-    struct step_t {
-        std::chrono::steady_clock::duration duration;
-        std::size_t requests_count;
-        std::size_t rows_count;
-    };
+    output get_output() const {
+        output result;
+        result.requests = requests;
+        result.steps = steps;
+        return result;
+    }
 
+    stats get_stats() const {
+        using double_s = std::chrono::duration<double, std::ratio<1>>;
+        stats result;
+        if (!requests.empty()) {
+            auto requests = this->requests;
+            boost::sort(requests);
+            result.mean_request_time = boost::accumulate(requests, std::chrono::steady_clock::duration()) / requests.size();
+            result.median_request_time = requests[requests.size() / 2 + 1];
+            result.q90_request_time = requests[requests.size() * 9 / 10];
+            result.min_request_time = requests.front();
+            result.max_request_time = requests.back();
+        }
+        result.mean_request_speed = total_requests_count / std::chrono::duration_cast<double_s>(finish - start).count();
+        if (!steps.empty()) {
+            std::vector<double> requests_speeds;
+            boost::transform(steps, std::back_inserter(requests_speeds),
+                [] (const auto& v) { return v.requests_count / std::chrono::duration_cast<double_s>(v.duration).count(); });
+            boost::sort(requests_speeds);
+            result.median_request_speed = requests_speeds[requests_speeds.size() / 2 + 1];
+            result.min_request_speed = requests_speeds.front();
+            result.max_request_speed = requests_speeds.back();
+        }
+        result.mean_read_rows_speed = total_rows_count / std::chrono::duration_cast<double_s>(finish - start).count();
+        if (!steps.empty()) {
+            std::vector<double> rows_speeds;
+            boost::transform(steps, std::back_inserter(rows_speeds),
+                [] (const auto& v) { return v.rows_count / std::chrono::duration_cast<double_s>(v.duration).count(); });
+            boost::sort(rows_speeds);
+            result.median_read_rows_speed = rows_speeds[rows_speeds.size() / 2 + 1];
+            result.min_read_rows_speed = rows_speeds.front();
+            result.max_read_rows_speed = rows_speeds.back();
+        }
+        return result;
+    }
+
+private:
     std::mutex requests_mutex;
     std::mutex step_mutex;
     std::chrono::steady_clock::duration max_duration;
@@ -215,7 +270,7 @@ private:
     std::size_t total_rows_count = 0;
     std::atomic<bool> finished {false};
     std::chrono::steady_clock::time_point finish;
-    std::vector<step_t> steps;
+    std::vector<benchmark::step> steps;
     std::vector<std::chrono::steady_clock::duration> requests;
     const std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
     std::chrono::steady_clock::time_point next_print = start + std::chrono::seconds(1);
@@ -230,7 +285,7 @@ private:
             const auto duration = finish - step_start;
             const auto requests_per_second = step_count / std::chrono::duration_cast<double_s>(duration).count();
             const auto rows_per_second = step_rows_count / std::chrono::duration_cast<double_s>(duration).count();
-            steps.push_back(step_t {duration, step_count, step_rows_count});
+            steps.push_back(benchmark::step {duration, step_count, step_rows_count});
             modulo = std::max(
                 static_cast<std::size_t>(modulo),
                 static_cast<std::size_t>(std::round(requests_per_second * 0.05))

--- a/benchmarks/benchmark.h
+++ b/benchmarks/benchmark.h
@@ -118,14 +118,12 @@ private:
     std::size_t total_rows_count;
 };
 
-template <std::size_t coroutines>
 class time_limit_benchmark {
 public:
-    time_limit_benchmark(std::chrono::steady_clock::duration max_duration = std::chrono::seconds(31))
-            : max_duration(max_duration) {
+    time_limit_benchmark(std::size_t coroutines, std::chrono::steady_clock::duration max_duration = std::chrono::seconds(31))
+            : max_duration(max_duration), request_start(coroutines, start) {
         steps.reserve(100);
         requests.reserve(1000000);
-        std::fill(request_start.begin(), request_start.end(), start);
     }
 
     ~time_limit_benchmark() {
@@ -218,7 +216,7 @@ private:
     const std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
     std::chrono::steady_clock::time_point next_print = start + std::chrono::seconds(1);
     std::chrono::steady_clock::time_point step_start = start;
-    std::array<std::chrono::steady_clock::time_point, coroutines> request_start;
+    std::vector<std::chrono::steady_clock::time_point> request_start;
 
     bool step_impl() {
         finish = std::chrono::steady_clock::now();

--- a/benchmarks/benchmark.h
+++ b/benchmarks/benchmark.h
@@ -294,7 +294,7 @@ private:
             total_rows_count += step_rows_count;
             const auto total_duration = finish - start;
             if (print_progress) {
-                std::cout << total_requests_count << " requests done in "
+                std::cerr << total_requests_count << " requests done in "
                           << std::chrono::duration_cast<double_s>(total_duration).count() << " seconds, "
                           << std::setprecision(4) << std::fixed << requests_per_second << " req/sec "
                           << total_rows_count << " rows read "

--- a/benchmarks/benchmark.h
+++ b/benchmarks/benchmark.h
@@ -24,7 +24,7 @@ namespace ozo::benchmark {
 
 namespace hana = boost::hana;
 
-template <class Ratio>
+template <typename Ratio>
 struct duration_name {};
 
 template <>

--- a/benchmarks/performance.cpp
+++ b/benchmarks/performance.cpp
@@ -21,7 +21,7 @@ using benchmark_t = ozo::benchmark::time_limit_benchmark<coroutines>;
 constexpr const std::chrono::seconds connect_timeout(1);
 constexpr const std::chrono::seconds request_timeout(1);
 
-template <class T>
+template <typename T>
 void spawn(asio::io_context& io, std::size_t token, T&& coroutine) {
     asio::spawn(io, [token, coroutine = std::forward<T>(coroutine)] (asio::yield_context yield) {
         try {
@@ -34,7 +34,7 @@ void spawn(asio::io_context& io, std::size_t token, T&& coroutine) {
     });
 }
 
-template <class Query>
+template <typename Query>
 void reuse_connection_info(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
@@ -55,7 +55,7 @@ void reuse_connection_info(const std::string& conn_string, Query query) {
     io.run();
 }
 
-template <class Result, class Query>
+template <typename Result, typename Query>
 void reuse_connection_info_and_parse_result(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
@@ -76,7 +76,7 @@ void reuse_connection_info_and_parse_result(const std::string& conn_string, Quer
     io.run();
 }
 
-template <class Query>
+template <typename Query>
 void reuse_connection(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
@@ -98,7 +98,7 @@ void reuse_connection(const std::string& conn_string, Query query) {
     io.run();
 }
 
-template <class Result, class Query>
+template <typename Result, typename Query>
 void reuse_connection_and_parse_result(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
@@ -120,7 +120,7 @@ void reuse_connection_and_parse_result(const std::string& conn_string, Query que
     io.run();
 }
 
-template <class Query>
+template <typename Query>
 void use_connection_pool(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
@@ -145,7 +145,7 @@ void use_connection_pool(const std::string& conn_string, Query query) {
     io.run();
 }
 
-template <class Result, class Query>
+template <typename Result, typename Query>
 void use_connection_pool_and_parse_result(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
@@ -170,7 +170,7 @@ void use_connection_pool_and_parse_result(const std::string& conn_string, Query 
     io.run();
 }
 
-template <std::size_t coroutines, class Query>
+template <std::size_t coroutines, typename Query>
 void use_connection_pool_mult_connection(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << " coroutines=" << coroutines << std::endl;
 
@@ -197,7 +197,7 @@ void use_connection_pool_mult_connection(const std::string& conn_string, Query q
     io.run();
 }
 
-template <std::size_t coroutines, class Result, class Query>
+template <std::size_t coroutines, typename Result, typename Query>
 void use_connection_pool_and_parse_result_mult_connection(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << " coroutines=" << coroutines << std::endl;
 
@@ -232,7 +232,7 @@ struct context {
     context() = default;
 };
 
-template <std::size_t threads_number, std::size_t coroutines, class Query>
+template <std::size_t threads_number, std::size_t coroutines, typename Query>
 void use_connection_pool_mult_threads(const std::string& conn_string, Query query,
         std::size_t connections, std::size_t queue_capacity) {
     std::cout << '\n' << __func__

--- a/benchmarks/performance.cpp
+++ b/benchmarks/performance.cpp
@@ -116,7 +116,7 @@ void use_connection_pool_mult_connection(const std::string& conn_string, Query q
     ozo::connection_pool pool(connection_info, config);
 
     for (std::size_t token = 0; token < coroutines; ++token) {
-        spawn(io, 0, [&, token] (asio::yield_context yield) {
+        spawn(io, token, [&, token] (asio::yield_context yield) {
             while (true) {
                 std::conditional_t<std::is_same_v<Row, void>, ozo::result, std::vector<Row>> result;
                 ozo::request(pool[io], query, request_timeout, ozo::into(result), yield);

--- a/benchmarks/performance.cpp
+++ b/benchmarks/performance.cpp
@@ -71,6 +71,7 @@ struct benchmark_params {
     std::size_t queue_capacity = 0;
     std::size_t connections = 0;
     bool parse_result = false;
+    bool verbose = false;
 };
 
 template <typename Row, typename Query>
@@ -78,6 +79,8 @@ void reopen_connection(const benchmark_params& params, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
     benchmark_t benchmark(1);
+    benchmark.set_print_progress(params.verbose);
+
     asio::io_context io(1);
     ozo::connection_info connection_info(params.conn_string);
 
@@ -99,6 +102,8 @@ void reuse_connection(const benchmark_params& params, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
     benchmark_t benchmark(1);
+    benchmark.set_print_progress(params.verbose);
+
     asio::io_context io(1);
     ozo::connection_info connection_info(params.conn_string);
 
@@ -121,6 +126,8 @@ void use_connection_pool(const benchmark_params& params, Query query) {
     std::cout << '\n' << __func__ << " coroutines=" << params.coroutines << std::endl;
 
     benchmark_t benchmark(params.coroutines);
+    benchmark.set_print_progress(params.verbose);
+
     asio::io_context io(1);
     const ozo::connection_info connection_info(params.conn_string);
     ozo::connection_pool_config config;
@@ -160,6 +167,8 @@ void use_connection_pool_mult_threads(const benchmark_params& params, Query quer
         << " queue_capacity=" << params.queue_capacity << std::endl;
 
     benchmark_t benchmark(params.coroutines * params.threads_number);
+    benchmark.set_print_progress(params.verbose);
+
     const ozo::connection_info connection_info(params.conn_string);
     ozo::connection_pool_config config;
     config.capacity = params.connections;
@@ -298,6 +307,7 @@ int main(int argc, char **argv) {
             ("threads", po::value<std::size_t>()->default_value(1), "number of threads")
             ("connections", po::value<std::size_t>(), "number of parallel coroutines (default: equal to coroutines + 1)")
             ("parse,p", "parse query result")
+            ("verbose,v", "use verbose output")
         ;
 
         po::variables_map variables;
@@ -328,6 +338,7 @@ int main(int argc, char **argv) {
             params.connections = params.coroutines;
         }
         params.parse_result = variables.count("parse") > 0;
+        params.verbose = variables.count("verbose") > 0;
 
         run_benchmark(name, params);
 

--- a/benchmarks/performance.cpp
+++ b/benchmarks/performance.cpp
@@ -16,8 +16,7 @@ namespace {
 
 namespace asio = boost::asio;
 
-template <std::size_t coroutines>
-using benchmark_t = ozo::benchmark::time_limit_benchmark<coroutines>;
+using benchmark_t = ozo::benchmark::time_limit_benchmark;
 
 constexpr const std::chrono::seconds connect_timeout(1);
 constexpr const std::chrono::seconds request_timeout(1);
@@ -39,7 +38,7 @@ template <typename Row, typename Query>
 void reopen_connection(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
-    benchmark_t<1> benchmark;
+    benchmark_t benchmark(1);
     asio::io_context io(1);
     ozo::connection_info connection_info(conn_string);
 
@@ -60,7 +59,7 @@ template <typename Row, typename Query>
 void reuse_connection(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
-    benchmark_t<1> benchmark;
+    benchmark_t benchmark(1);
     asio::io_context io(1);
     ozo::connection_info connection_info(conn_string);
 
@@ -82,7 +81,7 @@ template <std::size_t coroutines, typename Row, typename Query>
 void use_connection_pool(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << " coroutines=" << coroutines << std::endl;
 
-    benchmark_t<coroutines> benchmark;
+    benchmark_t benchmark(coroutines);
     asio::io_context io(1);
     const ozo::connection_info connection_info(conn_string);
     ozo::connection_pool_config config;
@@ -122,7 +121,7 @@ void use_connection_pool_mult_threads(const std::string& conn_string, Query quer
         << " connections=" << connections
         << " queue_capacity=" << queue_capacity << std::endl;
 
-    benchmark_t<coroutines * threads_number> benchmark;
+    benchmark_t benchmark(coroutines * threads_number);
     const ozo::connection_info connection_info(conn_string);
     ozo::connection_pool_config config;
     config.capacity = connections;

--- a/benchmarks/performance.cpp
+++ b/benchmarks/performance.cpp
@@ -34,13 +34,21 @@ void spawn(asio::io_context& io, std::size_t token, T&& coroutine) {
     });
 }
 
+struct benchmark_params {
+    std::string conn_string;
+    std::size_t coroutines = 0;
+    std::size_t threads_number = 0;
+    std::size_t queue_capacity = 0;
+    std::size_t connections = 0;
+};
+
 template <typename Row, typename Query>
-void reopen_connection(const std::string& conn_string, Query query) {
+void reopen_connection(const benchmark_params& params, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
     benchmark_t benchmark(1);
     asio::io_context io(1);
-    ozo::connection_info connection_info(conn_string);
+    ozo::connection_info connection_info(params.conn_string);
 
     spawn(io, 0, [&] (asio::yield_context yield) {
         while (true) {
@@ -56,12 +64,12 @@ void reopen_connection(const std::string& conn_string, Query query) {
 }
 
 template <typename Row, typename Query>
-void reuse_connection(const std::string& conn_string, Query query) {
+void reuse_connection(const benchmark_params& params, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
     benchmark_t benchmark(1);
     asio::io_context io(1);
-    ozo::connection_info connection_info(conn_string);
+    ozo::connection_info connection_info(params.conn_string);
 
     spawn(io, 0, [&] (asio::yield_context yield) {
         auto connection = ozo::get_connection(connection_info[io], connect_timeout, yield);
@@ -77,19 +85,19 @@ void reuse_connection(const std::string& conn_string, Query query) {
     io.run();
 }
 
-template <std::size_t coroutines, typename Row, typename Query>
-void use_connection_pool(const std::string& conn_string, Query query) {
-    std::cout << '\n' << __func__ << " coroutines=" << coroutines << std::endl;
+template <typename Row, typename Query>
+void use_connection_pool(const benchmark_params& params, Query query) {
+    std::cout << '\n' << __func__ << " coroutines=" << params.coroutines << std::endl;
 
-    benchmark_t benchmark(coroutines);
+    benchmark_t benchmark(params.coroutines);
     asio::io_context io(1);
-    const ozo::connection_info connection_info(conn_string);
+    const ozo::connection_info connection_info(params.conn_string);
     ozo::connection_pool_config config;
-    config.capacity = coroutines + 1;
-    config.queue_capacity = 0;
+    config.capacity = params.coroutines + 1;
+    config.queue_capacity = params.queue_capacity;
     ozo::connection_pool pool(connection_info, config);
 
-    for (std::size_t token = 0; token < coroutines; ++token) {
+    for (std::size_t token = 0; token < params.coroutines; ++token) {
         spawn(io, token, [&, token] (asio::yield_context yield) {
             while (true) {
                 std::conditional_t<std::is_same_v<Row, void>, ozo::result, std::vector<Row>> result;
@@ -112,20 +120,19 @@ struct context {
     context() = default;
 };
 
-template <std::size_t threads_number, std::size_t coroutines, typename Row, typename Query>
-void use_connection_pool_mult_threads(const std::string& conn_string, Query query,
-        std::size_t connections, std::size_t queue_capacity) {
+template <typename Row, typename Query>
+void use_connection_pool_mult_threads(const benchmark_params& params, Query query) {
     std::cout << '\n' << __func__
-        << " threads_number=" << threads_number
-        << " coroutines_per_thread=" << coroutines
-        << " connections=" << connections
-        << " queue_capacity=" << queue_capacity << std::endl;
+        << " threads_number=" << params.threads_number
+        << " coroutines_per_thread=" << params.coroutines
+        << " connections=" << params.connections
+        << " queue_capacity=" << params.queue_capacity << std::endl;
 
-    benchmark_t benchmark(coroutines * threads_number);
-    const ozo::connection_info connection_info(conn_string);
+    benchmark_t benchmark(params.coroutines * params.threads_number);
+    const ozo::connection_info connection_info(params.conn_string);
     ozo::connection_pool_config config;
-    config.capacity = connections;
-    config.queue_capacity = queue_capacity;
+    config.capacity = params.connections;
+    config.queue_capacity = params.queue_capacity;
     std::vector<std::unique_ptr<context>> contexts;
     ozo::connection_pool pool(connection_info, config);
     std::atomic_size_t finished_coroutines {0};
@@ -133,11 +140,11 @@ void use_connection_pool_mult_threads(const std::string& conn_string, Query quer
     std::unique_lock<std::mutex> lock(mutex);
     std::condition_variable coroutine_finished;
 
-    for (std::size_t i = 0; i < threads_number; ++i) {
+    for (std::size_t i = 0; i < params.threads_number; ++i) {
         contexts.emplace_back(std::make_unique<context>());
         auto& io = contexts.back()->io;
-        for (std::size_t j = 0; j < coroutines; ++j) {
-            const auto token = coroutines * i + j;
+        for (std::size_t j = 0; j < params.coroutines; ++j) {
+            const auto token = params.coroutines * i + j;
             spawn(io, token, [&, token] (asio::yield_context yield) {
                 while (true) {
                     std::conditional_t<std::is_same_v<Row, void>, ozo::result, std::vector<Row>> result;
@@ -156,8 +163,10 @@ void use_connection_pool_mult_threads(const std::string& conn_string, Query quer
         }
     }
 
-    if (coroutines * threads_number > 0) {
-        coroutine_finished.wait(lock, [&] { return finished_coroutines >= coroutines * threads_number; });
+    if (params.coroutines * params.threads_number > 0) {
+        coroutine_finished.wait(lock, [&] {
+            return finished_coroutines >= params.coroutines * params.threads_number;
+        });
     }
 
     std::for_each(contexts.begin(), contexts.end(), [] (const auto& v) { v->guard.reset(); });
@@ -176,18 +185,31 @@ int main(int argc, char **argv) {
         return 1;
     }
 
-    const std::string conn_string(argv[1]);
-
     const auto simple_query = "SELECT 1"_SQL.build();
 
     std::cout << "\nquery: " << ozo::to_const_char(ozo::get_text(simple_query)) << std::endl;
-    reopen_connection<void>(conn_string, simple_query);
-    reuse_connection<void>(conn_string, simple_query);
-    use_connection_pool<1, void>(conn_string, simple_query);
-    use_connection_pool<2, void>(conn_string, simple_query);
-    use_connection_pool_mult_threads<2, 2, void>(conn_string, simple_query, 4, 0);
-    use_connection_pool_mult_threads<2, 2, void>(conn_string, simple_query, 2, 4);
-    use_connection_pool<1, std::tuple<std::int32_t>>(conn_string, simple_query);
+
+    benchmark_params params;
+    params.conn_string = argv[1];
+
+    reopen_connection<void>(params, simple_query);
+    reuse_connection<void>(params, simple_query);
+    params.coroutines = 1;
+    use_connection_pool<void>(params, simple_query);
+    params.coroutines = 2;
+    use_connection_pool<void>(params, simple_query);
+    params.threads_number = 2;
+    params.coroutines = 2;
+    params.connections = 4;
+    params.queue_capacity = 0;
+    use_connection_pool_mult_threads<void>(params, simple_query);
+    params.threads_number = 2;
+    params.coroutines = 2;
+    params.connections = 2;
+    params.queue_capacity = 4;
+    use_connection_pool_mult_threads<void>(params, simple_query);
+    params.coroutines = 1;
+    use_connection_pool<std::tuple<std::int32_t>>(params, simple_query);
 
     const auto complex_query = (
         "SELECT typname, typnamespace, typowner, typlen, typbyval, typcategory, "_SQL +
@@ -196,23 +218,58 @@ int main(int argc, char **argv) {
     ).build();
 
     std::cout << "\nquery: " << ozo::to_const_char(ozo::get_text(complex_query)) << std::endl;
-    use_connection_pool<1, void>(conn_string, complex_query);
-    use_connection_pool<1, pg_type>(conn_string, complex_query);
-    use_connection_pool<2, void>(conn_string, complex_query);
-    use_connection_pool<4, void>(conn_string, complex_query);
-    use_connection_pool<8, void>(conn_string, complex_query);
-    use_connection_pool<16, void>(conn_string, complex_query);
-    use_connection_pool<32, void>(conn_string, complex_query);
-    use_connection_pool<64, void>(conn_string, complex_query);
-    use_connection_pool<2, pg_type>(conn_string, complex_query);
-    use_connection_pool<4, pg_type>(conn_string, complex_query);
-    use_connection_pool<8, pg_type>(conn_string, complex_query);
-    use_connection_pool_mult_threads<2, 8, void>(conn_string, complex_query, 16, 0);
-    use_connection_pool_mult_threads<2, 8, void>(conn_string, complex_query, 8, 16);
-    use_connection_pool_mult_threads<4, 8, void>(conn_string, complex_query, 32, 0);
-    use_connection_pool_mult_threads<4, 8, void>(conn_string, complex_query, 16, 32);
-    use_connection_pool_mult_threads<8, 8, void>(conn_string, complex_query, 64, 0);
-    use_connection_pool_mult_threads<8, 8, void>(conn_string, complex_query, 32, 64);
+    params.coroutines = 1;
+    use_connection_pool<void>(params, complex_query);
+    params.coroutines = 1;
+    use_connection_pool<pg_type>(params, complex_query);
+    params.coroutines = 2;
+    use_connection_pool<void>(params, complex_query);
+    params.coroutines = 4;
+    use_connection_pool<void>(params, complex_query);
+    params.coroutines = 8;
+    use_connection_pool<void>(params, complex_query);
+    params.coroutines = 16;
+    use_connection_pool<void>(params, complex_query);
+    params.coroutines = 32;
+    use_connection_pool<void>(params, complex_query);
+    params.coroutines = 64;
+    use_connection_pool<void>(params, complex_query);
+    params.coroutines = 2;
+    use_connection_pool<pg_type>(params, complex_query);
+    params.coroutines = 4;
+    use_connection_pool<pg_type>(params, complex_query);
+    params.coroutines = 8;
+    use_connection_pool<pg_type>(params, complex_query);
+    params.threads_number = 2;
+    params.coroutines = 8;
+    params.connections = 16;
+    params.queue_capacity = 0;
+    use_connection_pool_mult_threads<void>(params, complex_query);
+    params.threads_number = 2;
+    params.coroutines = 8;
+    params.connections = 8;
+    params.queue_capacity = 16;
+    use_connection_pool_mult_threads<void>(params, complex_query);
+    params.threads_number = 4;
+    params.coroutines = 8;
+    params.connections = 32;
+    params.queue_capacity = 0;
+    use_connection_pool_mult_threads<void>(params, complex_query);
+    params.threads_number = 4;
+    params.coroutines = 8;
+    params.connections = 16;
+    params.queue_capacity = 32;
+    use_connection_pool_mult_threads<void>(params, complex_query);
+    params.threads_number = 8;
+    params.coroutines = 8;
+    params.connections = 64;
+    params.queue_capacity = 0;
+    use_connection_pool_mult_threads<void>(params, complex_query);
+    params.threads_number = 8;
+    params.coroutines = 8;
+    params.connections = 32;
+    params.queue_capacity = 64;
+    use_connection_pool_mult_threads<void>(params, complex_query);
 
     return 0;
 }

--- a/benchmarks/performance.cpp
+++ b/benchmarks/performance.cpp
@@ -4,6 +4,7 @@
 #include <ozo/connection_pool.h>
 #include <ozo/request.h>
 #include <ozo/query_builder.h>
+#include <ozo/shortcuts.h>
 
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/spawn.hpp>
@@ -34,7 +35,7 @@ void spawn(asio::io_context& io, std::size_t token, T&& coroutine) {
     });
 }
 
-template <typename Query>
+template <typename Row, typename Query>
 void reopen_connection(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
@@ -44,8 +45,8 @@ void reopen_connection(const std::string& conn_string, Query query) {
 
     spawn(io, 0, [&] (asio::yield_context yield) {
         while (true) {
-            ozo::result result;
-            ozo::request(connection_info[io], query, request_timeout, std::ref(result), yield);
+            std::conditional_t<std::is_same_v<Row, void>, ozo::result, std::vector<Row>> result;
+            ozo::request(connection_info[io], query, request_timeout, ozo::into(result), yield);
             if (!benchmark.step(result.size())) {
                 break;
             }
@@ -55,28 +56,7 @@ void reopen_connection(const std::string& conn_string, Query query) {
     io.run();
 }
 
-template <typename Result, typename Query>
-void reopen_connection_and_parse_result(const std::string& conn_string, Query query) {
-    std::cout << '\n' << __func__ << std::endl;
-
-    benchmark_t<1> benchmark;
-    asio::io_context io(1);
-    ozo::connection_info connection_info(conn_string);
-
-    spawn(io, 0, [&] (asio::yield_context yield) {
-        while (true) {
-            std::vector<Result> result;
-            ozo::request(connection_info[io], query, request_timeout, std::back_inserter(result), yield);
-            if (!benchmark.step(result.size())) {
-                break;
-            }
-        }
-    });
-
-    io.run();
-}
-
-template <typename Query>
+template <typename Row, typename Query>
 void reuse_connection(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
@@ -87,8 +67,8 @@ void reuse_connection(const std::string& conn_string, Query query) {
     spawn(io, 0, [&] (asio::yield_context yield) {
         auto connection = ozo::get_connection(connection_info[io], connect_timeout, yield);
         while (true) {
-            ozo::result result;
-            ozo::request(connection, query, request_timeout, std::ref(result), yield);
+            std::conditional_t<std::is_same_v<Row, void>, ozo::result, std::vector<Row>> result;
+            ozo::request(connection, query, request_timeout, ozo::into(result), yield);
             if (!benchmark.step(result.size())) {
                 break;
             }
@@ -98,29 +78,7 @@ void reuse_connection(const std::string& conn_string, Query query) {
     io.run();
 }
 
-template <typename Result, typename Query>
-void reuse_connection_and_parse_result(const std::string& conn_string, Query query) {
-    std::cout << '\n' << __func__ << std::endl;
-
-    benchmark_t<1> benchmark;
-    asio::io_context io(1);
-    ozo::connection_info connection_info(conn_string);
-
-    spawn(io, 0, [&] (asio::yield_context yield) {
-        auto connection = ozo::get_connection(connection_info[io], connect_timeout, yield);
-        while (true) {
-            std::vector<Result> result;
-            ozo::request(connection, query, request_timeout, std::back_inserter(result), yield);
-            if (!benchmark.step(result.size())) {
-                break;
-            }
-        }
-    });
-
-    io.run();
-}
-
-template <typename Query>
+template <typename Row, typename Query>
 void use_connection_pool(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
@@ -134,8 +92,8 @@ void use_connection_pool(const std::string& conn_string, Query query) {
 
     spawn(io, 0, [&] (asio::yield_context yield) {
         while (true) {
-            ozo::result result;
-            ozo::request(pool[io], query, request_timeout, std::ref(result), yield);
+            std::conditional_t<std::is_same_v<Row, void>, ozo::result, std::vector<Row>> result;
+            ozo::request(pool[io], query, request_timeout, ozo::into(result), yield);
             if (!benchmark.step(result.size())) {
                 break;
             }
@@ -145,32 +103,7 @@ void use_connection_pool(const std::string& conn_string, Query query) {
     io.run();
 }
 
-template <typename Result, typename Query>
-void use_connection_pool_and_parse_result(const std::string& conn_string, Query query) {
-    std::cout << '\n' << __func__ << std::endl;
-
-    benchmark_t<1> benchmark;
-    asio::io_context io(1);
-    const ozo::connection_info connection_info(conn_string);
-    ozo::connection_pool_config config;
-    config.capacity = 2;
-    config.queue_capacity = 0;
-    ozo::connection_pool pool(connection_info, config);
-
-    spawn(io, 0, [&] (asio::yield_context yield) {
-        while (true) {
-            std::vector<Result> result;
-            ozo::request(pool[io], query, request_timeout, std::back_inserter(result), yield);
-            if (!benchmark.step(result.size())) {
-                break;
-            }
-        }
-    });
-
-    io.run();
-}
-
-template <std::size_t coroutines, typename Query>
+template <std::size_t coroutines, typename Row, typename Query>
 void use_connection_pool_mult_connection(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << " coroutines=" << coroutines << std::endl;
 
@@ -185,35 +118,8 @@ void use_connection_pool_mult_connection(const std::string& conn_string, Query q
     for (std::size_t token = 0; token < coroutines; ++token) {
         spawn(io, 0, [&, token] (asio::yield_context yield) {
             while (true) {
-                ozo::result result;
-                ozo::request(pool[io], query, request_timeout, std::ref(result), yield);
-                if (!benchmark.step(result.size(), token)) {
-                    break;
-                }
-            }
-        });
-    }
-
-    io.run();
-}
-
-template <std::size_t coroutines, typename Result, typename Query>
-void use_connection_pool_and_parse_result_mult_connection(const std::string& conn_string, Query query) {
-    std::cout << '\n' << __func__ << " coroutines=" << coroutines << std::endl;
-
-    benchmark_t<coroutines> benchmark;
-    asio::io_context io(1);
-    const ozo::connection_info connection_info(conn_string);
-    ozo::connection_pool_config config;
-    config.capacity = coroutines + 1;
-    config.queue_capacity = 0;
-    ozo::connection_pool pool(connection_info, config);
-
-    for (std::size_t token = 0; token < coroutines; ++token) {
-        spawn(io, token, [&, token] (asio::yield_context yield) {
-            while (true) {
-                std::vector<Result> result;
-                ozo::request(pool[io], query, request_timeout, std::back_inserter(result), yield);
+                std::conditional_t<std::is_same_v<Row, void>, ozo::result, std::vector<Row>> result;
+                ozo::request(pool[io], query, request_timeout, ozo::into(result), yield);
                 if (!benchmark.step(result.size(), token)) {
                     break;
                 }
@@ -232,7 +138,7 @@ struct context {
     context() = default;
 };
 
-template <std::size_t threads_number, std::size_t coroutines, typename Query>
+template <std::size_t threads_number, std::size_t coroutines, typename Row, typename Query>
 void use_connection_pool_mult_threads(const std::string& conn_string, Query query,
         std::size_t connections, std::size_t queue_capacity) {
     std::cout << '\n' << __func__
@@ -260,9 +166,9 @@ void use_connection_pool_mult_threads(const std::string& conn_string, Query quer
             const auto token = coroutines * i + j;
             spawn(io, token, [&, token] (asio::yield_context yield) {
                 while (true) {
-                    ozo::result result;
+                    std::conditional_t<std::is_same_v<Row, void>, ozo::result, std::vector<Row>> result;
                     boost::system::error_code ec;
-                    ozo::request(pool[io], query, request_timeout, std::ref(result), yield[ec]);
+                    ozo::request(pool[io], query, request_timeout, ozo::into(result), yield[ec]);
                     if (!benchmark.thread_safe_step(result.size(), token)) {
                         break;
                     }
@@ -301,13 +207,13 @@ int main(int argc, char **argv) {
     const auto simple_query = "SELECT 1"_SQL.build();
 
     std::cout << "\nquery: " << ozo::to_const_char(ozo::get_text(simple_query)) << std::endl;
-    reopen_connection(conn_string, simple_query);
-    reuse_connection(conn_string, simple_query);
-    use_connection_pool(conn_string, simple_query);
-    use_connection_pool_mult_connection<2>(conn_string, simple_query);
-    use_connection_pool_mult_threads<2, 2>(conn_string, simple_query, 4, 0);
-    use_connection_pool_mult_threads<2, 2>(conn_string, simple_query, 2, 4);
-    use_connection_pool_and_parse_result<std::tuple<std::int32_t>>(conn_string, simple_query);
+    reopen_connection<void>(conn_string, simple_query);
+    reuse_connection<void>(conn_string, simple_query);
+    use_connection_pool<void>(conn_string, simple_query);
+    use_connection_pool_mult_connection<2, void>(conn_string, simple_query);
+    use_connection_pool_mult_threads<2, 2, void>(conn_string, simple_query, 4, 0);
+    use_connection_pool_mult_threads<2, 2, void>(conn_string, simple_query, 2, 4);
+    use_connection_pool<std::tuple<std::int32_t>>(conn_string, simple_query);
 
     const auto complex_query = (
         "SELECT typname, typnamespace, typowner, typlen, typbyval, typcategory, "_SQL +
@@ -316,23 +222,23 @@ int main(int argc, char **argv) {
     ).build();
 
     std::cout << "\nquery: " << ozo::to_const_char(ozo::get_text(complex_query)) << std::endl;
-    use_connection_pool(conn_string, complex_query);
-    use_connection_pool_and_parse_result<pg_type>(conn_string, complex_query);
-    use_connection_pool_mult_connection<2>(conn_string, complex_query);
-    use_connection_pool_mult_connection<4>(conn_string, complex_query);
-    use_connection_pool_mult_connection<8>(conn_string, complex_query);
-    use_connection_pool_mult_connection<16>(conn_string, complex_query);
-    use_connection_pool_mult_connection<32>(conn_string, complex_query);
-    use_connection_pool_mult_connection<64>(conn_string, complex_query);
-    use_connection_pool_and_parse_result_mult_connection<2, pg_type>(conn_string, complex_query);
-    use_connection_pool_and_parse_result_mult_connection<4, pg_type>(conn_string, complex_query);
-    use_connection_pool_and_parse_result_mult_connection<8, pg_type>(conn_string, complex_query);
-    use_connection_pool_mult_threads<2, 8>(conn_string, complex_query, 16, 0);
-    use_connection_pool_mult_threads<2, 8>(conn_string, complex_query, 8, 16);
-    use_connection_pool_mult_threads<4, 8>(conn_string, complex_query, 32, 0);
-    use_connection_pool_mult_threads<4, 8>(conn_string, complex_query, 16, 32);
-    use_connection_pool_mult_threads<8, 8>(conn_string, complex_query, 64, 0);
-    use_connection_pool_mult_threads<8, 8>(conn_string, complex_query, 32, 64);
+    use_connection_pool<void>(conn_string, complex_query);
+    use_connection_pool<pg_type>(conn_string, complex_query);
+    use_connection_pool_mult_connection<2, void>(conn_string, complex_query);
+    use_connection_pool_mult_connection<4, void>(conn_string, complex_query);
+    use_connection_pool_mult_connection<8, void>(conn_string, complex_query);
+    use_connection_pool_mult_connection<16, void>(conn_string, complex_query);
+    use_connection_pool_mult_connection<32, void>(conn_string, complex_query);
+    use_connection_pool_mult_connection<64, void>(conn_string, complex_query);
+    use_connection_pool_mult_connection<2, pg_type>(conn_string, complex_query);
+    use_connection_pool_mult_connection<4, pg_type>(conn_string, complex_query);
+    use_connection_pool_mult_connection<8, pg_type>(conn_string, complex_query);
+    use_connection_pool_mult_threads<2, 8, void>(conn_string, complex_query, 16, 0);
+    use_connection_pool_mult_threads<2, 8, void>(conn_string, complex_query, 8, 16);
+    use_connection_pool_mult_threads<4, 8, void>(conn_string, complex_query, 32, 0);
+    use_connection_pool_mult_threads<4, 8, void>(conn_string, complex_query, 16, 32);
+    use_connection_pool_mult_threads<8, 8, void>(conn_string, complex_query, 64, 0);
+    use_connection_pool_mult_threads<8, 8, void>(conn_string, complex_query, 32, 64);
 
     return 0;
 }

--- a/benchmarks/performance.cpp
+++ b/benchmarks/performance.cpp
@@ -230,7 +230,7 @@ benchmark_report use_connection_pool(const benchmark_params& params, Query query
     ozo::connection_pool_config config;
     config.capacity = params.coroutines + 1;
     config.queue_capacity = params.queue_capacity;
-    ozo::connection_pool pool(connection_info, config);
+    ozo::connection_pool pool(connection_info, config, !ozo::thread_safe);
 
     for (std::size_t token = 0; token < params.coroutines; ++token) {
         spawn(io, token, [&, token] (asio::yield_context yield) {

--- a/benchmarks/performance.cpp
+++ b/benchmarks/performance.cpp
@@ -35,7 +35,7 @@ void spawn(asio::io_context& io, std::size_t token, T&& coroutine) {
 }
 
 template <typename Query>
-void reuse_connection_info(const std::string& conn_string, Query query) {
+void reopen_connection(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
     benchmark_t<1> benchmark;
@@ -56,7 +56,7 @@ void reuse_connection_info(const std::string& conn_string, Query query) {
 }
 
 template <typename Result, typename Query>
-void reuse_connection_info_and_parse_result(const std::string& conn_string, Query query) {
+void reopen_connection_and_parse_result(const std::string& conn_string, Query query) {
     std::cout << '\n' << __func__ << std::endl;
 
     benchmark_t<1> benchmark;
@@ -301,7 +301,7 @@ int main(int argc, char **argv) {
     const auto simple_query = "SELECT 1"_SQL.build();
 
     std::cout << "\nquery: " << ozo::to_const_char(ozo::get_text(simple_query)) << std::endl;
-    reuse_connection_info(conn_string, simple_query);
+    reopen_connection(conn_string, simple_query);
     reuse_connection(conn_string, simple_query);
     use_connection_pool(conn_string, simple_query);
     use_connection_pool_mult_connection<2>(conn_string, simple_query);

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -37,7 +37,7 @@ RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-7 100 && \
 RUN wget -qO boost_1_66_0.tar.gz https://dl.bintray.com/boostorg/release/1.66.0/source/boost_1_66_0.tar.gz && \
     tar xzf boost_1_66_0.tar.gz && \
     cd boost_1_66_0 && \
-    ./bootstrap.sh --with-libraries=atomic,system,thread,chrono,date_time,context,coroutine && \
+    ./bootstrap.sh --with-libraries=atomic,system,thread,chrono,date_time,context,coroutine,program_options && \
     ./b2 \
         -j $(nproc) \
         --reconfigure \

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -4,41 +4,21 @@ docker-compose build asyncpg aiopg ozo_build_with_pg_tests
 
 scripts/build.sh pg docker clang release
 
-echo 'asyncpg benchmark'
+function run_benchmark {
+    docker-compose run \
+        --rm \
+        --user "$(id -u):$(id -g)" \
+        ${1:?} \
+        bash \
+        -exc "/code/scripts/wait_postgres.sh; ${2:?} ${3:?}"
+}
 
-docker-compose run \
-    --rm \
-    --user "$(id -u):$(id -g)" \
-    asyncpg \
-    bash \
-    -exc '/code/scripts/wait_postgres.sh; benchmarks/asyncpg_benchmark.py "postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}/${POSTGRES_DB}"'
-
-echo 'aiopg benchmark'
-
-docker-compose run \
-    --rm \
-    --user "$(id -u):$(id -g)" \
-    aiopg \
-    bash \
-    -exc '/code/scripts/wait_postgres.sh; benchmarks/aiopg_benchmark.py "host=${POSTGRES_HOST} user=${POSTGRES_USER} dbname=${POSTGRES_DB} password=${POSTGRES_PASSWORD}"'
-
-echo 'ozo benchmark'
-
-docker-compose run \
-    --rm \
-    --user "$(id -u):$(id -g)" \
-    ozo_build_with_pg_tests \
-    bash \
-    -exc '/code/scripts/wait_postgres.sh; ${BASE_BUILD_DIR}/clang_release/benchmarks/ozo_benchmark "host=${POSTGRES_HOST} user=${POSTGRES_USER} dbname=${POSTGRES_DB} password=${POSTGRES_PASSWORD}"'
-
-echo 'ozo performance benchmark'
-
-docker-compose run \
-    --rm \
-    --user "$(id -u):$(id -g)" \
-    ozo_build_with_pg_tests \
-    bash \
-    -exc '/code/scripts/wait_postgres.sh; ${BASE_BUILD_DIR}/clang_release/benchmarks/ozo_benchmark_performance "host=${POSTGRES_HOST} user=${POSTGRES_USER} dbname=${POSTGRES_DB} password=${POSTGRES_PASSWORD}"'
+run_benchmark asyncpg benchmarks/asyncpg_benchmark.py '"postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}/${POSTGRES_DB}"'
+run_benchmark aiopg benchmarks/aiopg_benchmark.py '"host=${POSTGRES_HOST} user=${POSTGRES_USER} dbname=${POSTGRES_DB} password=${POSTGRES_PASSWORD}"'
+run_benchmark ozo_build_with_pg_tests '${BASE_BUILD_DIR}/clang_release/benchmarks/ozo_benchmark' \
+    '"host=${POSTGRES_HOST} user=${POSTGRES_USER} dbname=${POSTGRES_DB} password=${POSTGRES_PASSWORD}"'
+run_benchmark ozo_build_with_pg_tests '${BASE_BUILD_DIR}/clang_release/benchmarks/ozo_benchmark_performance' \
+    '"host=${POSTGRES_HOST} user=${POSTGRES_USER} dbname=${POSTGRES_DB} password=${POSTGRES_PASSWORD}"'
 
 docker-compose stop ozo_postgres
 docker-compose rm -f ozo_postgres

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -17,8 +17,21 @@ run_benchmark asyncpg benchmarks/asyncpg_benchmark.py '"postgresql://${POSTGRES_
 run_benchmark aiopg benchmarks/aiopg_benchmark.py '"host=${POSTGRES_HOST} user=${POSTGRES_USER} dbname=${POSTGRES_DB} password=${POSTGRES_PASSWORD}"'
 run_benchmark ozo_build_with_pg_tests '${BASE_BUILD_DIR}/clang_release/benchmarks/ozo_benchmark' \
     '"host=${POSTGRES_HOST} user=${POSTGRES_USER} dbname=${POSTGRES_DB} password=${POSTGRES_PASSWORD}"'
-run_benchmark ozo_build_with_pg_tests '${BASE_BUILD_DIR}/clang_release/benchmarks/ozo_benchmark_performance' \
-    '"host=${POSTGRES_HOST} user=${POSTGRES_USER} dbname=${POSTGRES_DB} password=${POSTGRES_PASSWORD}"'
+
+function run_ozo_benchmark_performance {
+    run_benchmark ozo_build_with_pg_tests '${BASE_BUILD_DIR}/clang_release/benchmarks/ozo_benchmark_performance' \
+        "${1:?} --conninfo=\"host=\${POSTGRES_HOST} user=\${POSTGRES_USER} dbname=\${POSTGRES_DB} password=\${POSTGRES_PASSWORD}\""
+}
+
+run_ozo_benchmark_performance '--benchmark=reopen_connection --query=simple'
+run_ozo_benchmark_performance '--benchmark=reuse_connection --query=simple'
+run_ozo_benchmark_performance '--benchmark=use_connection_pool --query=simple --coroutines=1'
+run_ozo_benchmark_performance '--benchmark=use_connection_pool --query=simple --coroutines=2'
+run_ozo_benchmark_performance '--benchmark=use_connection_pool_mult_threads --query=simple --coroutines=2 --threads=2 --connections=5 --queue=0'
+run_ozo_benchmark_performance '--benchmark=use_connection_pool_mult_threads --query=simple --coroutines=2 --threads=2 --connections=2 --queue=4'
+run_ozo_benchmark_performance '--benchmark=use_connection_pool --query=simple --coroutines=1 --parse'
+run_ozo_benchmark_performance '--benchmark=use_connection_pool --query=complex --coroutines=1'
+run_ozo_benchmark_performance '--benchmark=use_connection_pool --query=complex --coroutines=1 --parse'
 
 docker-compose stop ozo_postgres
 docker-compose rm -f ozo_postgres


### PR DESCRIPTION
* General feature is ability to run specific benchmark using command line with output into JSON that can be used by other program (e.g. make a plot).
* New dependencies to nlohmann/json and Boost.Program_options are added.
* Single threaded benchmarks are using connection pool without synchronization.
