### PR TITLE
CMakeLists should not know anything about ccache

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,10 +1,3 @@
-find_program(CCACHE_FOUND ccache)
-
-if(CCACHE_FOUND)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-endif()
-
 add_executable(ozo_benchmark ozo_benchmark.cpp)
 target_link_libraries(ozo_benchmark ozo)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,10 +1,3 @@
-find_program(CCACHE_FOUND ccache)
-
-if(CCACHE_FOUND)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-endif()
-
 add_executable(ozo_request request.cpp)
 target_link_libraries(ozo_request ozo)
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -112,6 +112,8 @@ build() {
     mkdir -p ${BUILD_DIR}
     cd ${BUILD_DIR}
     cmake \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
         -DCMAKE_C_COMPILER="${CC_COMPILER}" \
         -DCMAKE_CXX_COMPILER="${CXX_COMPILER}" \
         -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS"\
@@ -148,6 +150,8 @@ build() {
         mkdir -p ${EXT_BUILD_DIR}
         cd ${EXT_BUILD_DIR}
         cmake \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_C_COMPILER="${CC_COMPILER}" \
             -DCMAKE_CXX_COMPILER="${CXX_COMPILER}" \
             -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_program(CCACHE_FOUND ccache)
-
 include(ExternalProject)
 ExternalProject_Add(
     GoogleTest
@@ -82,11 +80,6 @@ target_link_libraries(ozo_tests gtest)
 target_link_libraries(ozo_tests gmock)
 target_link_libraries(ozo_tests ozo)
 add_test(ozo_tests ozo_tests)
-
-if(CCACHE_FOUND)
-    set_target_properties(ozo_tests PROPERTIES RULE_LAUNCH_COMPILE ccache)
-    set_target_properties(ozo_tests PROPERTIES RULE_LAUNCH_LINK ccache)
-endif()
 
 # enable useful warnings and errors
 target_compile_options(ozo_tests PRIVATE -Wall -Wextra -pedantic -Werror)


### PR DESCRIPTION
Support for CMAKE_C_COMPILER_LAUNCHER was added in CMake 3.4