### PR TITLE
Add github actions as a second continuous integration platform

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,37 @@
+name: Linux
+
+on:
+  pull_request:
+  push:
+  release:
+    types: published
+
+jobs:
+  linux:
+    runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        pattern:
+          - 'pg docker gcc debug'
+          - 'pg docker gcc release'
+          - 'pg docker gcc test_external_project'
+          - 'pg docker clang debug'
+          - 'pg docker clang release'
+          - 'pg docker clang asan'
+          - 'pg docker clang ubsan'
+          - 'pg docker clang tsan'
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Install dependencies
+      run: |
+        sudo sed -i 's/azure\.//' /etc/apt/sources.list
+        sudo apt update
+        sudo apt install -y python3-setuptools
+        pip3 install --user docker-compose
+
+    - name: Build OZO
+      shell: bash
+      run: |
+        scripts/build.sh ${{ matrix.pattern }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,27 @@
+name: Mac OS X
+
+on:
+  pull_request:
+  push:
+  release:
+    types: published
+
+jobs:
+  macos:
+    runs-on: [macos-latest]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Install dependencies
+      run: |
+        sudo chown -R $(whoami) $(brew --prefix)/*
+        brew unlink libpq
+        brew install --force boost postgresql || brew link --overwrite postgresql
+
+    - name: Build OZO
+      env:
+        BOOSTROOT: /usr
+      shell: bash
+      run: |
+        scripts/build.sh clang debug

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,10 +1,3 @@
-find_program(CCACHE_FOUND ccache)
-
-if(CCACHE_FOUND)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-endif()
-
 add_executable(ozo_benchmark ozo_benchmark.cpp)
 target_link_libraries(ozo_benchmark ozo)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,10 +1,3 @@
-find_program(CCACHE_FOUND ccache)
-
-if(CCACHE_FOUND)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-endif()
-
 add_executable(ozo_request request.cpp)
 target_link_libraries(ozo_request ozo)
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -112,8 +112,6 @@ build() {
     mkdir -p ${BUILD_DIR}
     cd ${BUILD_DIR}
     cmake \
-        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
         -DCMAKE_C_COMPILER="${CC_COMPILER}" \
         -DCMAKE_CXX_COMPILER="${CXX_COMPILER}" \
         -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS"\
@@ -150,8 +148,6 @@ build() {
         mkdir -p ${EXT_BUILD_DIR}
         cd ${EXT_BUILD_DIR}
         cmake \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_C_COMPILER="${CC_COMPILER}" \
             -DCMAKE_CXX_COMPILER="${CXX_COMPILER}" \
             -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -112,6 +112,8 @@ build() {
     mkdir -p ${BUILD_DIR}
     cd ${BUILD_DIR}
     cmake \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
         -DCMAKE_C_COMPILER="${CC_COMPILER}" \
         -DCMAKE_CXX_COMPILER="${CXX_COMPILER}" \
         -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS"\
@@ -148,6 +150,8 @@ build() {
         mkdir -p ${EXT_BUILD_DIR}
         cd ${EXT_BUILD_DIR}
         cmake \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DCMAKE_C_COMPILER="${CC_COMPILER}" \
             -DCMAKE_CXX_COMPILER="${CXX_COMPILER}" \
             -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-find_program(CCACHE_FOUND ccache)
-
 include(ExternalProject)
 ExternalProject_Add(
     GoogleTest
@@ -82,11 +80,6 @@ target_link_libraries(ozo_tests gtest)
 target_link_libraries(ozo_tests gmock)
 target_link_libraries(ozo_tests ozo)
 add_test(ozo_tests ozo_tests)
-
-if(CCACHE_FOUND)
-    set_target_properties(ozo_tests PROPERTIES RULE_LAUNCH_COMPILE ccache)
-    set_target_properties(ozo_tests PROPERTIES RULE_LAUNCH_LINK ccache)
-endif()
 
 # enable useful warnings and errors
 target_compile_options(ozo_tests PRIVATE -Wall -Wextra -pedantic -Werror)


### PR DESCRIPTION
The reason why this is beneficial to people is because github actions are included in all github accounts, where configuring a continuous integration service like travis CI is not super trivial to do. It's obviously not impossible, since I did it once upon a time, but it's kind of a pain in the rear nevertheless.

So people working on a fork of OZO on github, even if they don't have travis CI, will automatically have their work run through continuous integration, even before they create a pull request for the main OZO repository.

Further, github actions allow up to 20 parallel jobs (5 for macos), which can allow the OZO continuous integration to complete significantly faster.

And lastly, in my experience, on a job per job basis, it's been my experience that github actions are quite a bit faster than travis ci.

Note: This PR includes https://github.com/yandex/ozo/pull/249, and then removes ccache usage entirely. This is because the github CI is quite a bit faster than travis, while also having a different security model than travis, making the existing ccaching code more complicated to use. I'd be happy to leave that in if someone can point out how to adjust the github actions environment to be happy with it.