### PR TITLE
Simplify typed_buffer to eliminate strange errors with GCC 9

### DIFF
--- a/include/ozo/detail/typed_buffer.h
+++ b/include/ozo/detail/typed_buffer.h
@@ -2,25 +2,14 @@
 
 #include <ozo/core/concept.h>
 
-namespace ozo {
-namespace detail {
+namespace ozo::detail {
 
 template <typename T>
 union typed_buffer {
-    constexpr static auto size = sizeof(T);
+    static_assert(std::is_fundamental_v<T>, "T should be fundamental type");
+
     T typed;
-    char raw[size];
+    char raw[sizeof(T)];
 };
 
-template <typename T>
-constexpr char* data(typed_buffer<T>& buf) noexcept { return buf.raw;}
-
-template <typename T>
-constexpr const char* data(const typed_buffer<T>& buf) noexcept { return buf.raw;}
-
-template <typename T>
-constexpr auto size(const typed_buffer<T>& buf) noexcept { return buf.size;}
-} // namespace detail
-
-} // namespace ozo
-
+} // namespace ozo::detail

--- a/include/ozo/io/istream.h
+++ b/include/ozo/io/istream.h
@@ -69,7 +69,7 @@ public:
     template <typename T>
     Require<Integral<T> && sizeof(T) != 1, istream&> read(T& out) noexcept {
         detail::typed_buffer<T> buf;
-        read(buf);
+        read(buf.raw);
         out = detail::convert_from_big_endian(buf.typed);
         return *this;
     }

--- a/include/ozo/io/ostream.h
+++ b/include/ozo/io/ostream.h
@@ -48,7 +48,7 @@ public:
     Require<Integral<T> && sizeof(T) != 1, ostream&> write(T in) {
         detail::typed_buffer<T> buf;
         buf.typed = detail::convert_to_big_endian(in);
-        return write(buf);
+        return write(buf.raw);
     }
 
     template <typename T>


### PR DESCRIPTION
Looks like GCC is very weird about `size` constant member and affects the SFINAE logic about compatibility with `size()` function. So this simplification resolves the problem. 