### PR TITLE
Decay OidMap type for connection_info's connection

### DIFF
--- a/include/ozo/connection_info.h
+++ b/include/ozo/connection_info.h
@@ -30,7 +30,7 @@ class connection_info {
     Statistics statistics;
 
 public:
-    using connection_type = std::shared_ptr<ozo::connection<OidMap, Statistics>>; //!< Type of connection which is produced by the source.
+    using connection_type = std::shared_ptr<ozo::connection<std::decay_t<OidMap>, Statistics>>; //!< Type of connection which is produced by the source.
 
     /**
      * @brief Construct a new connection information object


### PR DESCRIPTION
To do not confuse the user with error on this snippet

```c++
const auto oid_map = ozo::register_types<>();
ozo::connection_info<decltype(oid_map)> conn_info(...)
```

Here the connection_info uses the connection with const od oid map type,
that deletes move constructor of the underlying connection_rep type.