### PR TITLE
Set BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT flag to build with Boost 1.74

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,13 +63,13 @@ matrix:
     env: BUILD_ARGS='pg docker clang tsan'
 
   - os: osx
-    osx_image: xcode10
+    osx_image: xcode11
     install:
-    - brew update
-    - brew unlink python@2
-    - brew upgrade boost
-    #- brew upgrade postgresql
-    - brew upgrade cmake
+    # - brew update
+    # - brew unlink python@2
+    # - brew upgrade boost
+    # - brew upgrade postgresql
+    # - brew upgrade cmake
     - brew install ccache
     env: BUILD_ARGS='clang debug'
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ target_include_directories(ozo INTERFACE
 
 target_compile_definitions(ozo INTERFACE -DBOOST_COROUTINES_NO_DEPRECATION_WARNING)
 target_compile_definitions(ozo INTERFACE -DBOOST_HANA_CONFIG_ENABLE_STRING_UDL)
+# For the time OZO may not support Executor TS
+# See https://github.com/yandex/ozo/issues/266
+target_compile_definitions(ozo INTERFACE -DBOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
 
 target_link_libraries(ozo INTERFACE Boost::coroutine)
 target_link_libraries(ozo INTERFACE PostgreSQL::PostgreSQL)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Since the project is on early state of development it lacks of documentation. We
 * learn more about main use-cases from [unit tests](tests/integration/request_integration.cpp),
 * See our [C++Now'18 talk about OZO](https://youtu.be/-1zbaxuUsMA) with [presentation](https://github.com/boostcon/cppnow_presentations_2018/blob/master/05-09-2018_wednesday/design_and_implementation_of_dbms_asynchronous_client_library__roman_siromakha__cppnow_05092018.pdf).
 
+## Compatibilities
+
+For the time OZO is not compatible with new executors models that are used by default since Boost 1.74. The `BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT` macro needs to be defined. See Boost 1.74 [changelog](https://www.boost.org/doc/libs/1_74_0/doc/html/boost_asio/history.html#boost_asio.history.asio_1_18_0___boost_1_74) for the details.
 ## Dependencies
 
 These things are needed:


### PR DESCRIPTION
For now this is the shortest way to build OZO for MacOS and brew installed Boost.
This does not solve problem itself. So the new executors should be suppurted in a
proper way.