### PR TITLE
Make connection_pool.cpp compile under C++20

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Jonas Stoehr <jonass@jsje.de>
 Evgeny Nikulin <evnikulin@yandex-team.ru>
 Martijn Otto <martijn@summitto.com>
 Mikhail Belyavsky <bmichail@yandex-team.ru>
+Yuriy Chernshov <thegeorg@yandex-team.ru>

--- a/tests/connection_pool.cpp
+++ b/tests/connection_pool.cpp
@@ -59,13 +59,18 @@ struct pool_handle_mock {
 
 struct connection_pool {
     struct handle {
-        pool_handle_mock* mock_;
+        pool_handle_mock* mock_ = nullptr;
         using value_type = pool_handle_mock::value_type;
         using native_handle_type = value_type::native_handle_type;
         using oid_map_type = value_type::oid_map_type;
         using error_context_type = value_type::error_context_type;
         using statistics_type = value_type::statistics_type;
 
+        handle(pool_handle_mock* mock)
+            : mock_(mock)
+        {
+        }
+        handle() = default;
         handle(const handle&) = delete;
         handle(handle&&) = default;
         handle& operator = (const handle& ) = delete;


### PR DESCRIPTION
C++20 disables aggregate initialization in case of user-defined / defaulted / deleted ctors presence.