### PR TITLE
Add ltree support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -10,3 +10,4 @@ Martijn Otto <martijn@summitto.com>
 Mikhail Belyavsky <bmichail@yandex-team.ru>
 Yuriy Chernshov <thegeorg@yandex-team.ru>
 Timur Ziganshin <ortego@yandex-team.ru>
+Neo <neogenie@yandex.ru>

--- a/include/ozo/pg/types.h
+++ b/include/ozo/pg/types.h
@@ -21,3 +21,4 @@
 #include <ozo/pg/types/uuid.h>
 #include <ozo/pg/types/timestamp.h>
 #include <ozo/pg/types/interval.h>
+#include <ozo/pg/types/ltree.h>

--- a/include/ozo/pg/types/ltree.h
+++ b/include/ozo/pg/types/ltree.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <ozo/pg/definitions.h>
+#include <ozo/io/send.h>
+#include <ozo/io/recv.h>
+
+#include <string>
+
+namespace ozo::pg {
+
+class ltree {
+    friend send_impl<ltree>;
+    friend recv_impl<ltree>;
+    friend size_of_impl<ltree>;
+
+public:
+    ltree() = default;
+
+    ltree(std::string raw_string) noexcept
+        : value(std::move(raw_string)) {}
+
+    const std::string& raw_string() const & noexcept {
+        return value;
+    }
+
+    std::string raw_string() && noexcept {
+        return std::move(value);
+    }
+
+    friend bool operator ==(const ltree& lhs, const ltree& rhs) {
+        return lhs.value == rhs.value;
+    }
+
+private:
+    std::string value;
+};
+
+} // namespace ozo::pg
+
+namespace ozo {
+
+template <>
+struct size_of_impl<pg::ltree> {
+    static auto apply(const pg::ltree& v) noexcept {
+        return std::size(v.value) + 1;
+    }
+};
+
+template <>
+struct send_impl<pg::ltree> {
+    template <typename OidMap>
+    static ostream& apply(ostream& out, const OidMap&, const pg::ltree& in) {
+        const std::int8_t version = 1;
+        write(out, version);
+        return write(out, in.value);
+    }
+};
+
+template <>
+struct recv_impl<pg::ltree> {
+    template <typename OidMap>
+    static istream& apply(istream& in, size_type size, const OidMap&, pg::ltree& out) {
+        if (size < 1) {
+            throw std::range_error("data size " + std::to_string(size) + " is too small to read ltree");
+        }
+        std::int8_t version;
+        read(in, version);
+        out.value.resize(static_cast<std::size_t>(size - 1));
+        return read(in, out.value);
+    }
+};
+
+} // namespace ozo
+
+OZO_PG_DEFINE_CUSTOM_TYPE(ozo::pg::ltree, "ltree")


### PR DESCRIPTION
Since PostgreSQL 13 ltree supported in binary protocol: https://postgrespro.com/list/id/E1jJkxu-0005HI-SY@gemulon.postgresql.org. Details of implementation: https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=949a9f043eb70a4986041b47513579f9a13d6a33

Resolve #291