### PR TITLE
Remove deprecated std::allocator<void>

### DIFF
--- a/tests/test_asio.h
+++ b/tests/test_asio.h
@@ -119,20 +119,20 @@ struct execution_context : asio::execution_context {
 
         void on_work_finished() const {}
 
-        template <typename Function>
-        void dispatch(Function&& f, std::allocator<void>) const {
+        template <typename Function, typename Allocator>
+        void dispatch(Function&& f, Allocator&&) const {
             assert_has_impl();
             return impl_->dispatch(wrap_shared(std::forward<Function>(f)));
         }
 
-        template <typename Function>
-        void post(Function&& f, std::allocator<void>) const {
+        template <typename Function, typename Allocator>
+        void post(Function&& f, Allocator&&) const {
             assert_has_impl();
             return impl_->post(wrap_shared(std::forward<Function>(f)));
         }
 
-        template <typename Function>
-        void defer(Function&& f, std::allocator<void>) const {
+        template <typename Function, typename Allocator>
+        void defer(Function&& f, Allocator&&) const {
             assert_has_impl();
             return impl_->defer(wrap_shared(std::forward<Function>(f)));
         }


### PR DESCRIPTION
Clang claims about std::allocator<void> is deprecated in C++17

```
Apple clang version 12.0.5 (clang-1205.0.22.9)
Target: arm64-apple-darwin20.5.0
```